### PR TITLE
ARCPOC-1236 patch wording from GET on update ALE

### DIFF
--- a/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
+++ b/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
@@ -1,337 +1,322 @@
 Feature: Applications List Entry Create
 
-    @PJ
-    Scenario Outline: Create Application List Entry With Complete Details
-        Given User Is On The Portal Page
-        When User Signs In With Microsoft SSO As "<User>"
-        When User Searches Application List With:
-            | Date         | Time   | List description | CourtSearch   | Court   | Select list status | Other location description | Criminal justice area | CJASearch |
-            | <SearchDate> | <Time> | <Description>    | <CourtSearch> | <Court> | <Status>           |                            |                       |           |
-        When User Clicks "Select" Then "Open" From Menu In Row Of Table "Lists" With:
-            | Date          | Time   | Location | Description   | Entries   | Status   |
-            | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
-        Then User See "Applications List" On The Page
-        Then User Clicks On The Link "Create application"
+  @PJ
+  Scenario Outline: Create Application List Entry With Complete Details
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
+    When User Searches Application List With:
+      | Date         | Time   | List description | CourtSearch   | Court   | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> | <Time> | <Description>    | <CourtSearch> | <Court> | <Status>           |                            |                       |           |
+    When User Clicks "Select" Then "Open" From Menu In Row Of Table "Lists" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    Then User See "Applications List" On The Page
+    Then User Clicks On The Link "Create application"
+    When User Fills In The Applicant Details
+      | Select applicant type | Organisation                       |
+      | Organisation name     | Test Sample Applicant Organisation |
+      | Address line 1        |                    123 High Street |
+      | Address line 2        | Apartment 4B                       |
+      | Town or city          | Leeds                              |
+      | County or region      | West Yorkshire                     |
+      | Post town             | Leeds                              |
+      | Postcode              | LS10 1PJ                           |
+      | Phone number          |                      020 7946 0000 |
+      | Mobile number         |                       07123 456789 |
+      | Email address         | john.smith@example.com             |
+    When User Fills In The Respondent Details
+      | Select type      | Organisation                 |
+      | name             | Test Sample Res Organisation |
+      | Address line 1   |              123 High Street |
+      | Address line 2   | Apartment 4B                 |
+      | Town or city     | Leeds                        |
+      | County or region | West Yorkshire               |
+      | Post town        | Leeds                        |
+      | Postcode         | LS10 1PJ                     |
+      | Phone number     |                020 7946 0000 |
+      | Mobile number    |                 07123 456789 |
+      | Email address    | john.smith@example.com       |
+    Then User Enters "MX99009" Into The Accordion "Codes" Textbox "Application code"
+    Then User Enters "20/03/2026" Into The Accordion "Codes" Date Field "Lodgement date"
+    Then User Enters "Test wording content" Into The Accordion "Wording" Textbox "Wording"
+    Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
+    Then User Enters "15/05/2025" Into The Accordion "Civil fee" Date Field "Status date"
+    Then User Enters "PAY-2025-12345" Into The Accordion "Civil fee" Textbox "Payment reference"
+    When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
+    Then User Enters "CR-2025-00123" Into The Accordion "Notes" Textbox "Case reference"
+    Then User Enters "AC-987654" Into The Accordion "Notes" Textbox "Account reference"
+    Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
 
-        When User Fills In The Applicant Details
-            | Select applicant type | Organisation                       |
-            | Organisation name     | Test Sample Applicant Organisation |
-            | Address line 1        | 123 High Street                    |
-            | Address line 2        | Apartment 4B                       |
-            | Town or city          | Leeds                              |
-            | County or region      | West Yorkshire                     |
-            | Post town             | Leeds                              |
-            | Postcode              | LS10 1PJ                           |
-            | Phone number          | 020 7946 0000                      |
-            | Mobile number         | 07123 456789                       |
-            | Email address         | john.smith@example.com             |
+    Examples:
+      | User  | SearchDate | DisplayDate | Time  | CourtSearch | Court                             | Description                         | Entries | Status |
+      | user1 | 20/03/2026 | 20 Mar 2026 | 10:20 | LCCC065     | Leeds Combined Court Centre Set 7 | Applications to review at Test_2614 |       0 | OPEN   |
 
-        When User Fills In The Respondent Details
-            | Select type      | Organisation                 |
-            | name             | Test Sample Res Organisation |
-            | Address line 1   | 123 High Street              |
-            | Address line 2   | Apartment 4B                 |
-            | Town or city     | Leeds                        |
-            | County or region | West Yorkshire               |
-            | Post town        | Leeds                        |
-            | Postcode         | LS10 1PJ                     |
-            | Phone number     | 020 7946 0000                |
-            | Mobile number    | 07123 456789                 |
-            | Email address    | john.smith@example.com       |
+  @PJ1
+  Scenario Outline: test
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
+    When User Searches Application List With:
+      | Date         | Time   | List description | CourtSearch   | Court   | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> | <Time> | <Description>    | <CourtSearch> | <Court> | <Status>           |                            |                       |           |
+    When User Clicks "Select" Then "Open" From Menu In Row Of Table "Lists" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    Then User See "Applications List" On The Page
+    Then User Clicks On The Link "Create application"
+    Then User Selects "Person" From The Accordion "Applicant" Dropdown "Select applicant type"
+    Then User Selects "Dr" From The Accordion "Applicant" Dropdown "Select title"
+    Then User Enters "Appl" Into The Accordion "Applicant" Textbox "First name"
+    Then User Enters "Resp" Into The Accordion "Respondent" Textbox "First name"
+    Then User Selects "Person" From The Accordion "Respondent" Dropdown "Select type"
+    Then User Enters "20/03/2026" Into The Accordion "Civil fee" Date Field "Status date"
 
-        Then User Enters "MX99009" Into The Accordion "Codes" Textbox "Application code"
-        Then User Enters "20/03/2026" Into The Accordion "Codes" Date Field "Lodgement date"
+    Examples:
+      | User  | TableName | SearchDate | DisplayDate | Time  | CourtSearch | Court                             | Description                         | Entries | Status |
+      | user1 | Lists     | 20/03/2026 | 20 Mar 2026 | 10:20 | LCCC065     | Leeds Combined Court Centre Set 7 | Applications to review at Test_2614 |       0 | OPEN   |
 
-        Then User Enters "Test wording content" Into The Accordion "Wording" Textbox "Wording"
-
-        Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
-        Then User Enters "15/05/2025" Into The Accordion "Civil fee" Date Field "Status date"
-        Then User Enters "PAY-2025-12345" Into The Accordion "Civil fee" Textbox "Payment reference"
-        When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
-
-        Then User Enters "CR-2025-00123" Into The Accordion "Notes" Textbox "Case reference"
-        Then User Enters "AC-987654" Into The Accordion "Notes" Textbox "Account reference"
-        Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
-
-        Examples:
-            | User  | SearchDate | DisplayDate | Time  | CourtSearch | Court                             | Description                         | Entries | Status |
-            | user1 | 20/03/2026 | 20 Mar 2026 | 10:20 | LCCC065     | Leeds Combined Court Centre Set 7 | Applications to review at Test_2614 | 0       | OPEN   |
-
-    @PJ1
-    Scenario Outline: test
-        Given User Is On The Portal Page
-        When User Signs In With Microsoft SSO As "<User>"
-        When User Searches Application List With:
-            | Date         | Time   | List description | CourtSearch   | Court   | Select list status | Other location description | Criminal justice area | CJASearch |
-            | <SearchDate> | <Time> | <Description>    | <CourtSearch> | <Court> | <Status>           |                            |                       |           |
-        When User Clicks "Select" Then "Open" From Menu In Row Of Table "Lists" With:
-            | Date          | Time   | Location | Description   | Entries   | Status   |
-            | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
-        Then User See "Applications List" On The Page
-        Then User Clicks On The Link "Create application"
-        Then User Selects "Person" From The Accordion "Applicant" Dropdown "Select applicant type"
-        Then User Selects "Dr" From The Accordion "Applicant" Dropdown "Select title"
-        Then User Enters "Appl" Into The Accordion "Applicant" Textbox "First name"
-
-        Then User Enters "Resp" Into The Accordion "Respondent" Textbox "First name"
-        Then User Selects "Person" From The Accordion "Respondent" Dropdown "Select type"
-
-        Then User Enters "20/03/2026" Into The Accordion "Civil fee" Date Field "Status date"
-
-
-        Examples:
-            | User  | TableName | SearchDate | DisplayDate | Time  | CourtSearch | Court                             | Description                         | Entries | Status |
-            | user1 | Lists     | 20/03/2026 | 20 Mar 2026 | 10:20 | LCCC065     | Leeds Combined Court Centre Set 7 | Applications to review at Test_2614 | 0       | OPEN   |
-
-    @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC1
-    Scenario Outline: Create an ALE where Applicant = Person and Respondent = Person, using an Application Code with Fee Required = Y and Respondent Required = Y
-        Given User Authenticates Via API As "<User>"
+  @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC1
+  Scenario Outline: Create an ALE where Applicant = Person and Respondent = Person, using an Application Code with Fee Required = Y and Respondent Required = Y
+    Given User Authenticates Via API As "<User>"
         # Create Application List
-        When User Makes POST API Request To "/application-lists" With Body:
-            | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
-            | todayiso | <Time> | <Status> | <Description> | 2             | 22              | LCCC065           |
-        Then User Verify Response Status Code Should Be "201"
-        Then User Stores Response Body Property "id" As "listId"
-        Given User Is On The Portal Page
-        When User Signs In With Microsoft SSO As "<User>"
+    When User Makes POST API Request To "/application-lists" With Body:
+      | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
+      | todayiso | <Time> | <Status> | <Description> |             2 |              22 | LCCC065           |
+    Then User Verify Response Status Code Should Be "201"
+    Then User Stores Response Body Property "id" As "listId"
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
         # Search Created Application List
-        When User Searches Application List With:
-            | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
-            | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
-        When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
-            | Date          | Time   | Location | Description   | Entries   | Status   |
-            | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    When User Searches Application List With:
+      | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
+    When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
         ## Create Application under Application List
-        Then User Clicks On The Link "Create application"
-        When User Clicks On The "Show all sections" Button
-        Then User Should See The Button "Hide all sections"
+    Then User Clicks On The Link "Create application"
+    When User Clicks On The "Show all sections" Button
+    Then User Should See The Button "Hide all sections"
         # Applicant Details
-        When User Fills In The Applicant Details
-            | Select applicant type | Person                 |
-            | Select title          | Mr                     |
-            | First name            | John                   |
-            | Middle name(s)        | Michael                |
-            | Surname               | Smith                  |
-            | Address line 1        | 123 High Street        |
-            | Address line 2        | Apartment 4B           |
-            | Town or city          | Leeds                  |
-            | County or region      | West Yorkshire         |
-            | Post town             | Leeds                  |
-            | Postcode              | LS10 1PJ               |
-            | Phone number          | 020 7946 0000          |
-            | Mobile number         | 07123 456789           |
-            | Email address         | john.smith@example.com |
+    When User Fills In The Applicant Details
+      | Select applicant type | Person                 |
+      | Select title          | Mr                     |
+      | First name            | John                   |
+      | Middle name(s)        | Michael                |
+      | Surname               | Smith                  |
+      | Address line 1        |        123 High Street |
+      | Address line 2        | Apartment 4B           |
+      | Town or city          | Leeds                  |
+      | County or region      | West Yorkshire         |
+      | Post town             | Leeds                  |
+      | Postcode              | LS10 1PJ               |
+      | Phone number          |          020 7946 0000 |
+      | Mobile number         |           07123 456789 |
+      | Email address         | john.smith@example.com |
         # Application Codes
-        Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
-        When User Clicks On The "Search" Button In The Accordion "Codes"
-        Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
-        Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
-            | Code              | Title              | Bulk | Fee req |
-            | <ApplicationCode> | <ApplicationTitle> | No   | CO8.1   |
-        Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
-        Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
+    Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
+    When User Clicks On The "Search" Button In The Accordion "Codes"
+    Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
+    Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
+      | Code              | Title              | Bulk | Fee req |
+      | <ApplicationCode> | <ApplicationTitle> | No   | CO8.1   |
+    Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
+    Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
         # Wording Details
-        Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
-        Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
+    Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
+    Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
         # (Bug raised ARCPOC-1230/ARCPOC-1205/AARCPOC-1253 for below statement)
-        When User Clicks On The "Save Wording" Button In The Accordion "Wording"
-        Then User Sees Success Alert "Successfully saved wording"
-
+    When User Clicks On The "Apply wording" Button In The Accordion "Wording"
+    Then User Sees Success Alert "Wording saved to the form. Save the entry to submit these changes."
         # Respondent Details
-        When User Fills In The Respondent Details
-            | Select type      | Person               |
-            | Select title     | Mrs                  |
-            | First name       | Jane                 |
-            | Middle name(s)   | Elizabeth            |
-            | Surname          | Doe                  |
-            | Address line 1   | 456 Park Road        |
-            | Address line 2   | Building C           |
-            | Town or city     | Leeds                |
-            | County or region | West Yorkshire       |
-            | Post town        | Leeds                |
-            | Postcode         | LS10 1PJ             |
-            | Phone number     | 020 7946 1111        |
-            | Mobile number    | 07987 654321         |
-            | Email address    | jane.doe@example.com |
-
+    When User Fills In The Respondent Details
+      | Select type      | Person               |
+      | Select title     | Mrs                  |
+      | First name       | Jane                 |
+      | Middle name(s)   | Elizabeth            |
+      | Surname          | Doe                  |
+      | Address line 1   |        456 Park Road |
+      | Address line 2   | Building C           |
+      | Town or city     | Leeds                |
+      | County or region | West Yorkshire       |
+      | Post town        | Leeds                |
+      | Postcode         | LS10 1PJ             |
+      | Phone number     |        020 7946 1111 |
+      | Mobile number    |         07987 654321 |
+      | Email address    | jane.doe@example.com |
         # Civil Fee Details
-        When User Verifies The Checkbox With Label "Off site fee applies" In The Accordion "Civil fee" Is Enabled
-        Then User Should See The Text "<OffsiteFeeString>" In The Accordion "Civil fee"
-        Then User Should See The Text "<FeeReference>" In The Accordion "Civil fee"
-        Then User Should See The Text "<FeeAmount>" In The Accordion "Civil fee"
-        Then User Verifies The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee" Is Unchecked
-        Then User Checks The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee"
+    When User Verifies The Checkbox With Label "Off site fee applies" In The Accordion "Civil fee" Is Enabled
+    Then User Should See The Text "<OffsiteFeeString>" In The Accordion "Civil fee"
+    Then User Should See The Text "<FeeReference>" In The Accordion "Civil fee"
+    Then User Should See The Text "<FeeAmount>" In The Accordion "Civil fee"
+    Then User Verifies The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee" Is Unchecked
+    Then User Checks The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee"
         # Bug ARCPOC-1241 is raised
         # Then User Should See The Text "<OffisiteFeeCode>" In The Accordion "Civil fee"
         # Then User Should See The Text "<OffsiteFeeValue>" In The Accordion "Civil fee"
         # Then User Should See The Text "<TotalFeeAmount>" In The Accordion "Civil fee"
-        Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
-        Then User Enters "<SearchDate>" Into The Accordion "Civil fee" Date Field "Status date"
-        Then User Enters "<PaymentReference>" Into The Accordion "Civil fee" Textbox "Payment reference"
-        When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
+    Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
+    Then User Enters "<SearchDate>" Into The Accordion "Civil fee" Date Field "Status date"
+    Then User Enters "<PaymentReference>" Into The Accordion "Civil fee" Textbox "Payment reference"
+    When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
         # Notes Details
-        Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
-        Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
-        Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
+    Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
+    Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
+    Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
         # Submit Application
-        When User Clicks On The "Create entry" Button
-        Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
+    When User Clicks On The "Create entry" Button
+    Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
 
-        Examples:
-            | User  | TableName | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle           | WordingText                                      | placeholder                  | WordingValue        | PaymentReference | CaseReference | AccountReference | OffsiteFeeString                                                                                         | OffsiteFeeCode | OffsiteFeeValue             | TotalFeeAmount            | FeeReference         | FeeAmount       |
-            | user1 | Lists     | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} | 0       | OPEN   | Select           | Open       | MX99006         | Condemnation of Unfit Food | Application for the condemnation of food, namely | Enter a Describe Seized Food | Test Sample Wording | PAY-12345        | case12345     | account12345     | Selecting this will automatically apply the off site fee to the entry. This change is saved immediately. | CO1.1          | Off Site Fee Amount: £30.00 | Total Fee Amount: £284.00 | Fee Reference: CO8.1 | Amount: £284.00 |
+    Examples:
+      | User  | TableName | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle           | WordingText                                      | placeholder                  | WordingValue        | PaymentReference | CaseReference | AccountReference | OffsiteFeeString                                                                                         | OffsiteFeeCode | OffsiteFeeValue             | TotalFeeAmount            | FeeReference         | FeeAmount       |
+      | user1 | Lists     | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} |       0 | OPEN   | Select           | Open       | MX99006         | Condemnation of Unfit Food | Application for the condemnation of food, namely | Enter a Describe Seized Food | Test Sample Wording | PAY-12345        | case12345     | account12345     | Selecting this will automatically apply the off site fee to the entry. This change is saved immediately. | CO1.1          | Off Site Fee Amount: £30.00 | Total Fee Amount: £284.00 | Fee Reference: CO8.1 | Amount: £284.00 |
 
-    @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC2
-    Scenario Outline: Create an ALE where Applicant = Organisation and Respondent = Organisation, using an Application Code with Fee Required = N and Respondent Required = Y
-        Given User Authenticates Via API As "<User>"
+  @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC2
+  Scenario Outline: Create an ALE where Applicant = Organisation and Respondent = Organisation, using an Application Code with Fee Required = N and Respondent Required = Y
+    Given User Authenticates Via API As "<User>"
         # Create Application List
-        When User Makes POST API Request To "/application-lists" With Body:
-            | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
-            | todayiso | <Time> | <Status> | <Description> | 2             | 22              | LCCC065           |
-        Then User Verify Response Status Code Should Be "201"
-        Then User Stores Response Body Property "id" As "listId"
-        Given User Is On The Portal Page
-        When User Signs In With Microsoft SSO As "<User>"
+    When User Makes POST API Request To "/application-lists" With Body:
+      | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
+      | todayiso | <Time> | <Status> | <Description> |             2 |              22 | LCCC065           |
+    Then User Verify Response Status Code Should Be "201"
+    Then User Stores Response Body Property "id" As "listId"
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
         # Search Created Application List
-        When User Searches Application List With:
-            | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
-            | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
-        When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
-            | Date          | Time   | Location | Description   | Entries   | Status   |
-            | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    When User Searches Application List With:
+      | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
+    When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
         ## Create Application under Application List
-        Then User Clicks On The Link "Create application"
-        When User Clicks On The "Show all sections" Button
-        Then User Should See The Button "Hide all sections"
+    Then User Clicks On The Link "Create application"
+    When User Clicks On The "Show all sections" Button
+    Then User Should See The Button "Hide all sections"
         # Applicant Details
-        When User Fills In The Applicant Details
-            | Select applicant type | Organisation                       |
-            | Organisation name     | Test Sample Applicant Organisation |
-            | Address line 1        | 123 High Street                    |
-            | Address line 2        | Apartment 4B                       |
-            | Town or city          | Leeds                              |
-            | County or region      | West Yorkshire                     |
-            | Post town             | Leeds                              |
-            | Postcode              | LS10 1PJ                           |
-            | Phone number          | 020 7946 0000                      |
-            | Mobile number         | 07123 456789                       |
-            | Email address         | john.smith@example.com             |
+    When User Fills In The Applicant Details
+      | Select applicant type | Organisation                       |
+      | Organisation name     | Test Sample Applicant Organisation |
+      | Address line 1        |                    123 High Street |
+      | Address line 2        | Apartment 4B                       |
+      | Town or city          | Leeds                              |
+      | County or region      | West Yorkshire                     |
+      | Post town             | Leeds                              |
+      | Postcode              | LS10 1PJ                           |
+      | Phone number          |                      020 7946 0000 |
+      | Mobile number         |                       07123 456789 |
+      | Email address         | john.smith@example.com             |
         # Application Codes
-        Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
-        When User Clicks On The "Search" Button In The Accordion "Codes"
-        Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
-        Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
-            | Code              | Title              | Bulk | Fee req |
-            | <ApplicationCode> | <ApplicationTitle> | No   | CO8.1   |
-        Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
-        Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
+    Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
+    When User Clicks On The "Search" Button In The Accordion "Codes"
+    Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
+    Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
+      | Code              | Title              | Bulk | Fee req |
+      | <ApplicationCode> | <ApplicationTitle> | No   | CO8.1   |
+    Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
+    Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
         # Wording Details
-        Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
-        Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
+    Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
+    Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
         # (Bug raised ARCPOC-1230/ARCPOC-1205/AARCPOC-1253 for below statement)
-        When User Clicks On The "Save Wording" Button In The Accordion "Wording"
+    When User Clicks On The "Apply wording" Button In The Accordion "Wording"
         # Respondent Details
-        When User Fills In The Respondent Details
-            | Select type       | Organisation                 |
-            | Organisation name | Test Sample Res Organisation |
-            | Address line 1    | 123 High Street              |
-            | Address line 2    | Apartment 4B                 |
-            | Town or city      | Leeds                        |
-            | County or region  | West Yorkshire               |
-            | Post town         | Leeds                        |
-            | Postcode          | LS10 1PJ                     |
-            | Phone number      | 020 7946 0000                |
-            | Mobile number     | 07123 456789                 |
-            | Email address     | john.smith@example.com       |
+    When User Fills In The Respondent Details
+      | Select type       | Organisation                 |
+      | Organisation name | Test Sample Res Organisation |
+      | Address line 1    |              123 High Street |
+      | Address line 2    | Apartment 4B                 |
+      | Town or city      | Leeds                        |
+      | County or region  | West Yorkshire               |
+      | Post town         | Leeds                        |
+      | Postcode          | LS10 1PJ                     |
+      | Phone number      |                020 7946 0000 |
+      | Mobile number     |                 07123 456789 |
+      | Email address     | john.smith@example.com       |
         # Civil Fee Details
-        Then User Should See The Text "No fee required" In The Accordion "Civil fee"
-        Then User Verifies Dropdown "Fee status" Is Disabled In The Accordion "Civil fee"
-        Then User Verifies Date Field "Status date" Is Disabled In The Accordion "Civil fee"
-        Then User Verifies The Textbox "Payment reference" Is Disabled In The Accordion "Civil fee"
-        Then User Verifies The Button "Add fee details" Is Disabled In The Accordion "Civil fee"
+    Then User Should See The Text "No fee required" In The Accordion "Civil fee"
+    Then User Verifies Dropdown "Fee status" Is Disabled In The Accordion "Civil fee"
+    Then User Verifies Date Field "Status date" Is Disabled In The Accordion "Civil fee"
+    Then User Verifies The Textbox "Payment reference" Is Disabled In The Accordion "Civil fee"
+    Then User Verifies The Button "Add fee details" Is Disabled In The Accordion "Civil fee"
         # Notes Details
-        Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
-        Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
-        Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
+    Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
+    Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
+    Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
         # Submit Application
-        When User Clicks On The "Create entry" Button
-        Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
+    When User Clicks On The "Create entry" Button
+    Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
 
-        Examples:
-            | User  | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle                               | WordingText                                                                                                                                                        | placeholder       | WordingValue | TableName | CaseReference | AccountReference |
-            | user1 | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} | 0       | OPEN   | Select           | Open       | CT99002         | Issue of liability order summons - council tax | Attends to swear a complaint for the issue of a summons for the debtor to answer an application for a liability order in relation to unpaid council tax (reference | Enter a Reference | TestRef-001  | Lists     | case12345     | account12345     |
+    Examples:
+      | User  | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle                               | WordingText                                                                                                                                                        | placeholder       | WordingValue | TableName | CaseReference | AccountReference |
+      | user1 | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} |       0 | OPEN   | Select           | Open       | CT99002         | Issue of liability order summons - council tax | Attends to swear a complaint for the issue of a summons for the debtor to answer an application for a liability order in relation to unpaid council tax (reference | Enter a Reference | TestRef-001  | Lists     | case12345     | account12345     |
 
-    @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC3
-    Scenario Outline: Create an ALE where Applicant = Standard Applicant, using an Application Code with Fee Required = Y and Respondent Required = N
-        Given User Authenticates Via API As "<User>"
+  @ignore @ARCPOC-222 @ARCPOC-427 @ARCPOC-1238 @ARCPOC-1239 @ARCPOC-1241 @SC3
+  Scenario Outline: Create an ALE where Applicant = Standard Applicant, using an Application Code with Fee Required = Y and Respondent Required = N
+    Given User Authenticates Via API As "<User>"
         # Create Application List
-        When User Makes POST API Request To "/application-lists" With Body:
-            | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
-            | todayiso | <Time> | <Status> | <Description> | 2             | 22              | LCCC065           |
-        Then User Verify Response Status Code Should Be "201"
-        Then User Stores Response Body Property "id" As "listId"
-        Given User Is On The Portal Page
-        When User Signs In With Microsoft SSO As "<User>"
+    When User Makes POST API Request To "/application-lists" With Body:
+      | date     | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
+      | todayiso | <Time> | <Status> | <Description> |             2 |              22 | LCCC065           |
+    Then User Verify Response Status Code Should Be "201"
+    Then User Stores Response Body Property "id" As "listId"
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
         # Search Created Application List
-        When User Searches Application List With:
-            | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
-            | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
-        When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
-            | Date          | Time   | Location | Description   | Entries   | Status   |
-            | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    When User Searches Application List With:
+      | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
+    When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
         ## Create Application under Application List
-        Then User Clicks On The Link "Create application"
-        When User Clicks On The "Show all sections" Button
-        Then User Should See The Button "Hide all sections"
+    Then User Clicks On The Link "Create application"
+    When User Clicks On The "Show all sections" Button
+    Then User Should See The Button "Hide all sections"
         # Applicant Details - Standard Applicant
-        When User Fills In The Applicant Details
-            | Select applicant type | Standard Applicant |
-        When User Checks The Checkbox In Row Of Table In The Accordion "Applicant" With:
-            | Code         | Name         | Address         | Use from     | Use to |
-            | <StdAppCode> | <StdAppName> | <StdAppAddress> | <StdAppFrom> | —      |
+    When User Fills In The Applicant Details
+      | Select applicant type | Standard Applicant |
+    When User Checks The Checkbox In Row Of Table In The Accordion "Applicant" With:
+      | Code         | Name         | Address         | Use from     | Use to |
+      | <StdAppCode> | <StdAppName> | <StdAppAddress> | <StdAppFrom> | —      |
         # Application Codes
-        Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
-        When User Clicks On The "Search" Button In The Accordion "Codes"
-        Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
-        Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
-            | Code              | Title              | Bulk | Fee req |
-            | <ApplicationCode> | <ApplicationTitle> | No   | CO3.1   |
-        Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
-        Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
+    Then User Enters "<ApplicationCode>" Into The Accordion "Codes" Textbox "Application code"
+    When User Clicks On The "Search" Button In The Accordion "Codes"
+    Then User Verifies Table "Codes" In The Accordion "Codes" Has Sortable Headers "Code, Title, Bulk, Fee req"
+    Then User Clicks "Add code" Button In Row Of Table "Codes" With In The Accordion "Codes":
+      | Code              | Title              | Bulk | Fee req |
+      | <ApplicationCode> | <ApplicationTitle> | No   | CO3.1   |
+    Then User Verifies The "Application Title" Textbox Has Value "<ApplicationTitle>"
+    Then User Verifies The Date field "Lodgement date" Has Value "<SearchDate>"
         # Wording Details
-        Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
-        Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
+    Then User Verifies The "Wording" Accordion Has Value "<WordingText>"
+    Then User Verifies The "Wording" Accordion Has textbox with placeholder "<placeholder>" and Enters "<WordingValue>"
         # (Bug raised ARCPOC-1230/ARCPOC-1205/AARCPOC-1253 for below statement)
-        When User Clicks On The "Save Wording" Button In The Accordion "Wording"
-        Then User Sees Success Alert "Successfully saved wording"
+    When User Clicks On The "Apply wording" Button In The Accordion "Wording"
+    Then User Sees Success Alert "Wording saved to the form. Save the entry to submit these changes."
         # Respondent Details Not provided as Respondent Required = N for the Application Code
         # Civil Fee Details
-        When User Verifies The Checkbox With Label "Off site fee applies" In The Accordion "Civil fee" Is Enabled
-        Then User Should See The Text "<OffsiteFeeString>" In The Accordion "Civil fee"
-        Then User Should See The Text "<FeeReference>" In The Accordion "Civil fee"
-        Then User Should See The Text "<FeeAmount>" In The Accordion "Civil fee"
-        Then User Verifies The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee" Is Unchecked
-        Then User Checks The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee"
+    When User Verifies The Checkbox With Label "Off site fee applies" In The Accordion "Civil fee" Is Enabled
+    Then User Should See The Text "<OffsiteFeeString>" In The Accordion "Civil fee"
+    Then User Should See The Text "<FeeReference>" In The Accordion "Civil fee"
+    Then User Should See The Text "<FeeAmount>" In The Accordion "Civil fee"
+    Then User Verifies The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee" Is Unchecked
+    Then User Checks The Checkbox With Label " Off site fee applies " In The Accordion "Civil fee"
         # Bug ARCPOC-1241 is raised
         # Then User Should See The Text "<OffisiteFeeCode>" In The Accordion "Civil fee"
         # Then User Should See The Text "<OffsiteFeeValue>" In The Accordion "Civil fee"
         # Then User Should See The Text "<TotalFeeAmount>" In The Accordion "Civil fee"
-        Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
-        Then User Enters "<SearchDate>" Into The Accordion "Civil fee" Date Field "Status date"
-        Then User Enters "<PaymentReference>" Into The Accordion "Civil fee" Textbox "Payment reference"
-        When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
+    Then User Selects "Paid" From The Accordion "Civil fee" Dropdown "Fee status"
+    Then User Enters "<SearchDate>" Into The Accordion "Civil fee" Date Field "Status date"
+    Then User Enters "<PaymentReference>" Into The Accordion "Civil fee" Textbox "Payment reference"
+    When User Clicks On The "Add fee details" Button In The Accordion "Civil fee"
         # Notes Details
-        Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
-        Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
-        Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
+    Then User Enters "<CaseReference>" Into The Accordion "Notes" Textbox "Case reference"
+    Then User Enters "<AccountReference>" Into The Accordion "Notes" Textbox "Account reference"
+    Then User Enters "This is a test application with special requirements" Into The Accordion "Notes" Textbox "Application details"
         # Submit Application
-        When User Clicks On The "Create entry" Button
-        Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
+    When User Clicks On The "Create entry" Button
+    Then User Sees Success Banner "Success Application list entry created The application list entry has been created successfully."
 
-        Examples:
-            | User  | TableName | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle                                           | WordingText                                                                                                                     | placeholder  | WordingValue | PaymentReference | CaseReference | AccountReference | OffsiteFeeString                                         | OffsiteFeeCode | OffsiteFeeValue             | TotalFeeAmount            | FeeReference         | FeeAmount       | StdAppCode | StdAppName       | StdAppAddress  | StdAppFrom |
-            | user1 | Lists     | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} | 0       | OPEN   | Select           | Open       | AP99004         | Request for Certificate of Refusal to State a Case (Civil) | Request for a certificate of refusal to state a case for the opinion of the High Court in respect of civil proceedings heard on | Enter a Date | today        | PAY-12345        | case12345     | account12345     | Selecting this will apply the off site fee to the entry. | CO1.1          | Off Site Fee Amount: £30.00 | Total Fee Amount: £135.00 | Fee Reference: CO3.1 | Amount: £105.00 | APP025     | Miss Ava Johnson | 258 Cedar Lane | 06/11/2025 |
-
-
-
-
+    Examples:
+      | User  | TableName | SearchDate | DisplayDate  | Time  | Court                             | Description                             | Entries | Status | SelectButtonText | ButtonName | ApplicationCode | ApplicationTitle                                           | WordingText                                                                                                                     | placeholder  | WordingValue | PaymentReference | CaseReference | AccountReference | OffsiteFeeString                                         | OffsiteFeeCode | OffsiteFeeValue             | TotalFeeAmount            | FeeReference         | FeeAmount       | StdAppCode | StdAppName       | StdAppAddress  | StdAppFrom |
+      | user1 | Lists     | today      | todaydisplay | 10:20 | Leeds Combined Court Centre Set 7 | Applications to review at Test_{RANDOM} |       0 | OPEN   | Select           | Open       | AP99004         | Request for Certificate of Refusal to State a Case (Civil) | Request for a certificate of refusal to state a case for the opinion of the High Court in respect of civil proceedings heard on | Enter a Date | today        | PAY-12345        | case12345     | account12345     | Selecting this will apply the off site fee to the entry. | CO1.1          | Off Site Fee Amount: £30.00 | Total Fee Amount: £135.00 | Fee Reference: CO3.1 | Amount: £105.00 | APP025     | Miss Ava Johnson | 258 Cedar Lane | 06/11/2025 |

--- a/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.ts
+++ b/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.ts
@@ -30,7 +30,7 @@ import { SuccessBannerComponent } from '@components/success-banner/success-banne
 import {
   ApplicationListEntriesApi,
   BulkUploadApplicationListEntriesRequestParams,
-  JobStatus,
+  JobStatus2 as JobStatus,
 } from '@openapi';
 import { getProblemText } from '@util/http-error-to-text';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';

--- a/src/app/pages/applications-list-entry-create/util/helpers.ts
+++ b/src/app/pages/applications-list-entry-create/util/helpers.ts
@@ -67,7 +67,7 @@ export function hasRequiredOrg(o: {
 export function pruneNullish<T extends object>(o: T): T {
   const rec = o as Record<string, unknown>;
   for (const [k, v] of Object.entries(rec)) {
-    if (v === null) {
+    if (v === null || v === undefined) {
       delete rec[k];
     }
   }

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -371,6 +371,14 @@ export class ApplicationsListEntryDetail implements OnInit {
       return;
     }
 
+    if (this.runWordingValidationForPartialSave()) {
+      this.form.controls.feeStatuses.setValue(previousFeeStatuses, {
+        emitEvent: false,
+      });
+      this.form.controls.feeStatuses.markAsPristine();
+      return;
+    }
+
     const entryUpdateDto = buildEntryUpdateDtoForFeeChange(
       this.entryDetail,
       this.form.getRawValue(),
@@ -654,6 +662,16 @@ export class ApplicationsListEntryDetail implements OnInit {
     return this.appListEntryDetailState().errorFound;
   }
 
+  private runWordingValidationForPartialSave(): boolean {
+    this.childErrors.wording =
+      this.wordingSection?.validateForSubmit({
+        enforceSavedWording: false,
+      }) ?? [];
+
+    this.updateAllErrors();
+    return this.childErrors.wording.length > 0;
+  }
+
   onUpdateApplicant(): void {
     this.resetErrors();
     this.resetSuccessBanner();
@@ -734,6 +752,14 @@ export class ApplicationsListEntryDetail implements OnInit {
     const entryId = getEntryId(this.route);
 
     if (!entryId || !this.entryDetail) {
+      return;
+    }
+
+    if (this.runWordingValidationForPartialSave()) {
+      this.form.controls.hasOffsiteFee.setValue(prevValue, {
+        emitEvent: false,
+      });
+      this.form.controls.hasOffsiteFee.markAsPristine();
       return;
     }
 

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -516,10 +516,15 @@ export function buildEntryUpdateDtoForFeeChange<K extends keyof EntryUpdateDto>(
   value: EntryUpdateDto[K],
 ): EntryUpdateDto {
   const dto = buildEntryUpdateDtoWithChange(detail, key, value);
+  const stagedWordingFields = formValue.wordingFields;
 
   const applicationCode = toOptionalTrimmed(formValue.applicationCode);
   if (applicationCode) {
     dto.applicationCode = applicationCode;
+  }
+
+  if (stagedWordingFields?.length) {
+    dto.wordingFields = stagedWordingFields;
   }
 
   return dto;

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -48,7 +48,7 @@ import {
   trimToUndefined,
 } from '@util/string-helpers';
 import {
-  WordingFieldLike,
+  getEntryWordingFields,
   toTemplateSubstitutions,
 } from '@util/template-substitution-utils';
 import {
@@ -267,18 +267,8 @@ export function buildOrganisationForm(
   }) as OrganisationForm;
 }
 
-// Wording fields moved from string[] to TemplateSubstitution[]; preserve stable fallback keys for legacy responses.
+// Preserve stable fallback keys for wording values that may arrive without keys.
 const LEGACY_WORDING_KEYS = ['courtName', 'organisationName'] as const;
-
-type EntryDetailWithLegacyWordingFields = EntryGetDetailDto & {
-  wordingFields?: WordingFieldLike[];
-};
-
-function getEntryWordingFields(
-  detail: EntryGetDetailDto,
-): WordingFieldLike[] | undefined {
-  return (detail as EntryDetailWithLegacyWordingFields).wordingFields;
-}
 
 export function buildEntryUpdateDtoFromForm(
   detail: EntryGetDetailDto,

--- a/src/app/shared/components/wording-parser/wording-parser.component.html
+++ b/src/app/shared/components/wording-parser/wording-parser.component.html
@@ -26,7 +26,7 @@
       data-module="govuk-button"
       (click)="submitWordingFields()"
     >
-      Save Wording
+      Apply wording
     </button>
   }
 </form>

--- a/src/app/shared/components/wording-parser/wording-parser.component.ts
+++ b/src/app/shared/components/wording-parser/wording-parser.component.ts
@@ -26,6 +26,10 @@ export type Token =
   | { type: 'text'; value: string }
   | { type: 'input'; key: string };
 
+export type WordingValidationOptions = {
+  enforceSavedWording?: boolean;
+};
+
 @Component({
   selector: 'app-wording-parser',
   imports: [ReactiveFormsModule, NgClass],
@@ -203,7 +207,7 @@ export class WordingParserComponent {
     }
   }
 
-  validateForSubmit(opts: { enforceSavedWording?: boolean } = {}): ErrorItem[] {
+  validateForSubmit(opts: WordingValidationOptions = {}): ErrorItem[] {
     this.submitted.set(true);
 
     const enforceSavedWording = opts.enforceSavedWording ?? true;

--- a/src/app/shared/components/wording-parser/wording-parser.component.ts
+++ b/src/app/shared/components/wording-parser/wording-parser.component.ts
@@ -220,7 +220,7 @@ export class WordingParserComponent {
     if (enforceSavedWording && this.showSaveButton() && this.form.dirty) {
       const errors: ErrorItem[] = [
         {
-          text: `Save wording changes in the ${this.section()} section before submitting`,
+          text: `Apply wording changes in the ${this.section()} section before submitting`,
           href: '#save-wording-button',
         },
       ];

--- a/src/app/shared/components/wording-section/wording-section.component.html
+++ b/src/app/shared/components/wording-section/wording-section.component.html
@@ -1,7 +1,7 @@
 @if (saveSuccessful()) {
   <app-alert
     alertType="success"
-    message="Successfully saved wording"
+    message="Wording applied to this entry. Save the entry to keep these changes."
     [allowDismiss]="true"
   />
 }

--- a/src/app/shared/components/wording-section/wording-section.component.ts
+++ b/src/app/shared/components/wording-section/wording-section.component.ts
@@ -2,7 +2,10 @@ import { Component, ViewChild, input, output, signal } from '@angular/core';
 
 import { AlertComponent } from '@components/alert/alert.component';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
-import { WordingParserComponent } from '@components/wording-parser/wording-parser.component';
+import {
+  WordingParserComponent,
+  WordingValidationOptions,
+} from '@components/wording-parser/wording-parser.component';
 import { TemplateDetail, TemplateSubstitution } from '@openapi';
 
 @Component({
@@ -33,7 +36,7 @@ export class WordingSectionComponent {
     this.saveSuccessful.set(false);
   }
 
-  validateForSubmit(): ErrorItem[] {
-    return this.wordingParser?.validateForSubmit() ?? [];
+  validateForSubmit(opts?: WordingValidationOptions): ErrorItem[] {
+    return this.wordingParser?.validateForSubmit(opts) ?? [];
   }
 }

--- a/src/app/shared/services/applications-list-entry/application-list-entry-form.service.ts
+++ b/src/app/shared/services/applications-list-entry/application-list-entry-form.service.ts
@@ -32,6 +32,7 @@ import {
   createEmptyPerson,
 } from '@util/applicant-helpers';
 import { markFormGroupClean } from '@util/form-helpers';
+import { getEntryWordingFields } from '@util/template-substitution-utils';
 
 type HydrateOptions = {
   /** Default false: avoid triggering applicantType valueChanges etc. */
@@ -92,8 +93,7 @@ export class ApplicationListEntryFormService {
         applicationCode: dto.applicationCode ?? null,
         respondent: dto.respondent ?? null,
         numberOfRespondents: dto.numberOfRespondents ?? null,
-        // TODO: Revisit when ticket ARCPOC-1058 is done
-        // wordingFields: dto.wordingFields ?? null,
+        wordingFields: getEntryWordingFields(dto) ?? null,
         feeStatuses: dto.feeStatuses ?? null,
         hasOffsiteFee: dto.hasOffsiteFee ?? null,
         applicationNotes: {

--- a/src/app/shared/util/child-submit-validation.ts
+++ b/src/app/shared/util/child-submit-validation.ts
@@ -1,7 +1,8 @@
 import { ErrorItem } from '@components/error-summary/error-summary.component';
+import { WordingValidationOptions } from '@components/wording-parser/wording-parser.component';
 
 export interface SubmitValidatableSection {
-  validateForSubmit(): ErrorItem[];
+  validateForSubmit(opts?: WordingValidationOptions): ErrorItem[];
 }
 
 export type SubmitValidationTarget<T extends string> = {

--- a/src/app/shared/util/template-substitution-utils.ts
+++ b/src/app/shared/util/template-substitution-utils.ts
@@ -1,4 +1,8 @@
-import { TemplateSubstitution } from '@openapi';
+import {
+  EntryGetDetailDto,
+  TemplateKeyWithConstraint,
+  TemplateSubstitution,
+} from '@openapi';
 
 export type WordingFieldLike = string | TemplateSubstitution;
 
@@ -49,4 +53,17 @@ export function wordingFromFields(
 ): string {
   const resolved = toWordingValues(values);
   return resolved.length > 0 ? resolved.join(', ') : '-';
+}
+
+export function getEntryWordingFields(
+  detail: EntryGetDetailDto | null | undefined,
+): TemplateSubstitution[] | undefined {
+  return detail?.wording?.['substitution-key-constraints']
+    ?.filter(
+      (
+        item,
+      ): item is TemplateKeyWithConstraint & { key: string; value: string } =>
+        typeof item.key === 'string' && typeof item.value === 'string',
+    )
+    .map(({ key, value }) => ({ key, value }));
 }

--- a/test/unit/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.spec.ts
+++ b/test/unit/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.spec.ts
@@ -9,7 +9,7 @@ import { ApplicationsListBulkUploadState } from '@components/applications-list-b
 import {
   ApplicationListEntriesApi,
   JobAcknowledgement,
-  JobStatus,
+  JobStatus2 as JobStatus,
   JobType,
 } from '@openapi';
 

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -346,6 +346,47 @@ describe('applications-list entry form builders', () => {
       expect(dto.applicant?.person?.name?.firstForename).toBe('John');
       expect('standardApplicantCode' in dto).toBe(false);
     });
+
+    it('preserves wording fields from detail.wording when the form has not changed them', () => {
+      const dto = buildEntryUpdateDtoFromForm(
+        {
+          ...baseDetail,
+          wording: {
+            template: 'At {{Court}} for {{Date}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+              { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+            ],
+          },
+        } as EntryGetDetailDto,
+        {
+          applicantType: 'person',
+          standardApplicantCode: null,
+          applicationCode: 'APP-100',
+          respondentEntryType: 'person',
+          wordingFields: null,
+          applicationNotes: {
+            notes: null,
+            caseReference: null,
+            accountReference: null,
+          },
+        } as never,
+        {
+          ...blankPerson,
+          firstName: 'John',
+          surname: 'Smith',
+          addressLine1: '1 Street',
+        } as never,
+        blankOrg as never,
+        blankPerson as never,
+        blankOrg as never,
+      );
+
+      expect(dto.wordingFields).toEqual([
+        { key: 'Court', value: 'Court A' },
+        { key: 'Date', value: '2026-04-13' },
+      ]);
+    });
   });
 
   describe('buildEntryUpdateDtoWithChange', () => {

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -464,5 +464,40 @@ describe('applications-list entry form builders', () => {
       expect(dto.notes).toBe('persisted note');
       expect(dto.applicant?.person?.name?.firstForename).toBe('Jane');
     });
+
+    it('prefers staged wordingFields from the form when building a fee-only update', () => {
+      const stagedWordingFields = [
+        { key: 'Court', value: 'New Court' },
+        { key: 'Date', value: '2026-04-14' },
+      ];
+
+      const dto = buildEntryUpdateDtoForFeeChange(
+        {
+          applicationCode: 'APP-100',
+          lodgementDate: '2025-01-01',
+          wording: {
+            template: 'At {{Court}} for {{Date}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Old Court', constraint: { length: 20 } },
+              { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+            ],
+          },
+        } as unknown as EntryGetDetailDto,
+        {
+          applicationCode: 'APP-100',
+          lodgementDate: '2025-01-01',
+          wordingFields: stagedWordingFields,
+          applicationNotes: {
+            notes: null,
+            caseReference: null,
+            accountReference: null,
+          },
+        } as never,
+        'feeStatuses',
+        [],
+      );
+
+      expect(dto.wordingFields).toEqual(stagedWordingFields);
+    });
   });
 });

--- a/test/unit/app/pages/applications-list-entry-create/util/helpers.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/util/helpers.spec.ts
@@ -98,7 +98,7 @@ describe('helpers', () => {
   });
 
   describe('pruneNullish', () => {
-    it('deletes keys with null values but keeps undefined', () => {
+    it('deletes keys with null and undefined values', () => {
       const o: {
         a?: string | null;
         b?: string | undefined;
@@ -113,9 +113,8 @@ describe('helpers', () => {
 
       expect(out).toBe(o); // mutates + returns same object
       expect('a' in out).toBe(false);
+      expect('b' in out).toBe(false);
       expect('c' in out).toBe(false);
-      expect('b' in out).toBe(true);
-      expect(out.b).toBeUndefined();
     });
 
     it('does not delete falsy non-null values', () => {

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -69,7 +69,7 @@ type PaymentRefApplier = {
   applyPaymentRefReturn: (updatedRowId: string, newRef: string) => void;
 };
 
-type EntryDetailWithLegacyWordingFields = EntryGetDetailDto & {
+type EntryDetailWithWordingSnapshot = EntryGetDetailDto & {
   wordingFields?: string[];
 };
 
@@ -124,6 +124,21 @@ describe('ApplicationsListEntryDetail', () => {
         lodgementDate: '2025-11-01',
         applicationCode: 'APP-100',
         standardApplicantCode: null,
+        wording: {
+          template: 'At {{Court}} for {{Date}}',
+          'substitution-key-constraints': [
+            {
+              key: 'Court',
+              value: 'Court A',
+              constraint: { length: 20 },
+            },
+            {
+              key: 'Date',
+              value: '2026-04-13',
+              constraint: { length: 10 },
+            },
+          ],
+        },
       } as unknown as EntryGetDetailDto),
     );
 
@@ -230,6 +245,13 @@ describe('ApplicationsListEntryDetail', () => {
       false,
       expect.objectContaining({ transferCache: true }),
     );
+  });
+
+  it('hydrates wordingFields from entry wording on init', () => {
+    expect(component['form'].controls.wordingFields.value).toEqual([
+      { key: 'Court', value: 'Court A' },
+      { key: 'Date', value: '2026-04-13' },
+    ]);
   });
 
   it('isUpdateDisabled true when entryDetail is not set', () => {
@@ -933,7 +955,7 @@ describe('ApplicationsListEntryDetail', () => {
       lodgementDate: '2025-11-01',
       wordingFields: ['Old wording'],
       feeStatuses: [],
-    } as unknown as EntryDetailWithLegacyWordingFields;
+    } as unknown as EntryDetailWithWordingSnapshot;
 
     const entryUpdateDto = {
       applicationCode: 'APP-200',
@@ -957,7 +979,7 @@ describe('ApplicationsListEntryDetail', () => {
 
     expect(component['entryDetail']?.applicationCode).toBe('APP-300');
     expect(
-      (component['entryDetail'] as EntryDetailWithLegacyWordingFields)
+      (component['entryDetail'] as EntryDetailWithWordingSnapshot)
         ?.wordingFields,
     ).toEqual(['Court A']);
     expect(component['entryDetail']?.respondent).toEqual(res.respondent);
@@ -968,7 +990,7 @@ describe('ApplicationsListEntryDetail', () => {
       applicationCode: 'APP-100',
       wordingFields: ['Old wording'],
       feeStatuses: [],
-    } as unknown as EntryDetailWithLegacyWordingFields;
+    } as unknown as EntryDetailWithWordingSnapshot;
 
     const entryUpdateDto = {
       applicationCode: 'APP-200',
@@ -987,7 +1009,7 @@ describe('ApplicationsListEntryDetail', () => {
 
     expect(component['entryDetail']?.applicationCode).toBe('APP-200');
     expect(
-      (component['entryDetail'] as EntryDetailWithLegacyWordingFields)
+      (component['entryDetail'] as EntryDetailWithWordingSnapshot)
         ?.wordingFields,
     ).toEqual(['Court A']);
   });

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -618,6 +618,41 @@ describe('ApplicationsListEntryDetail', () => {
     ).toBeTruthy();
   });
 
+  it('persistHasOffsiteFee blocks the partial save when wording is invalid', () => {
+    component['entryDetail'] = {
+      id: 'EN-1',
+      listId: 'AL-1',
+      applicationCode: 'APP-100',
+      numberOfRespondents: 0,
+      lodgementDate: '2025-11-01',
+    };
+    component['appListEntryDetailPatch']({ appListId: 'AL-1' });
+    component['form'].controls.hasOffsiteFee.setValue(true, {
+      emitEvent: false,
+    });
+
+    (component as never)['wordingSection'] = {
+      validateForSubmit: () => [
+        { text: 'Enter a Court in the wording section', href: '#Court' },
+      ],
+    } as never;
+
+    mockUpdateApplicationListEntry.mockClear();
+
+    component['persistHasOffsiteFee'](false, true);
+
+    expect(mockUpdateApplicationListEntry).not.toHaveBeenCalled();
+    expect(component['form'].controls.hasOffsiteFee.value).toBe(true);
+    expect(component['form'].controls.hasOffsiteFee.pristine).toBe(true);
+    expect(component['appListEntryDetailState']().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Enter a Court in the wording section',
+        }),
+      ]),
+    );
+  });
+
   it('shows list-created success banner when listCreated=true query param is present', () => {
     (
       routeStub.snapshot as unknown as {

--- a/test/unit/app/shared/components/wording-parser/wording-parser.component.spec.ts
+++ b/test/unit/app/shared/components/wording-parser/wording-parser.component.spec.ts
@@ -409,7 +409,7 @@ describe('WordingParserComponent', () => {
 
       expect(errors).toEqual([
         {
-          text: 'Save wording changes in the wording section before submitting',
+          text: 'Apply wording changes in the wording section before submitting',
           href: '#save-wording-button',
         },
       ]);
@@ -531,7 +531,7 @@ describe('WordingParserComponent', () => {
 
       expect(errorsSpy).toHaveBeenCalledWith([
         {
-          text: 'Save wording changes in the wording section before submitting',
+          text: 'Apply wording changes in the wording section before submitting',
           href: '#save-wording-button',
         },
       ]);

--- a/test/unit/app/shared/util/template-substitution-utils.spec.ts
+++ b/test/unit/app/shared/util/template-substitution-utils.spec.ts
@@ -1,5 +1,6 @@
-import { TemplateSubstitution } from '@openapi';
+import { EntryGetDetailDto, TemplateSubstitution } from '@openapi';
 import {
+  getEntryWordingFields,
   isTemplateSubstitution,
   toTemplateSubstitutions,
   toWordingValues,
@@ -74,6 +75,46 @@ describe('template-substitution-utils', () => {
       ).toBe('2026-03-02, London');
       expect(wordingFromFields([])).toBe('-');
       expect(wordingFromFields(undefined)).toBe('-');
+    });
+  });
+
+  describe('getEntryWordingFields', () => {
+    it('maps entry wording constraints to template substitutions', () => {
+      const entry = {
+        wording: {
+          template: 'At {{Court}} for {{Date}}',
+          'substitution-key-constraints': [
+            { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+            { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+          ],
+        },
+      } as EntryGetDetailDto;
+
+      expect(getEntryWordingFields(entry)).toEqual([
+        { key: 'Court', value: 'Court A' },
+        { key: 'Date', value: '2026-04-13' },
+      ]);
+    });
+
+    it('ignores entries without both key and value', () => {
+      const entry = {
+        wording: {
+          template: 'At {{Court}} for {{Date}}',
+          'substitution-key-constraints': [
+            { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+            { key: 'Date', value: undefined, constraint: { length: 10 } },
+            { key: undefined, value: '2026-04-13', constraint: { length: 10 } },
+          ],
+        },
+      } as unknown as EntryGetDetailDto;
+
+      expect(getEntryWordingFields(entry)).toEqual([
+        { key: 'Court', value: 'Court A' },
+      ]);
+    });
+
+    it('returns undefined when entry has no wording', () => {
+      expect(getEntryWordingFields({} as EntryGetDetailDto)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
- Added a shared `getEntryWordingFields()` helper to map persisted entry wording from the GET DTO shape (`wording.substitution-key-constraints`) into `TemplateSubstitution[]`.

- Updated entry detail update DTO construction to use the real generated `EntryGetDetailDto.wording` shape instead of relying on a legacy/non-generated `wordingFields` property.

- Hydrated the parent update form’s `wordingFields` on page load so “Save complete application” includes the current persisted wording even before “Apply wording” is clicked.

- Preserved the existing wording validation behavior so if a user edits wording but does not click “Apply wording,” the full submit is still blocked with the validation message.

- Fixed patch-merging behavior in create/update helpers so `undefined` values are removed before merging, preventing persisted fields like wording from being accidentally overwritten.

- Updated save wording to apply wording and relevant success message for wording section

- Updated unit tests to reflect the generated DTO contract and added coverage for wording hydration/mapping behavior.

Wording/ fee conflict changes;
- Preserved staged wording during fee and off-site partial updates by preferring the current form `wordingFields` over stale `entryDetail` wording when building the full PUT payload.
- Added lightweight wording validation to fee/off-site saves so invalid wording blocks the partial update, while unapplied-but-valid wording no longer does.

