### PR TITLE
ARCPOC-1188

### DIFF
--- a/src/app/core/components/sortable-table/sortable-table.component.html
+++ b/src/app/core/components/sortable-table/sortable-table.component.html
@@ -1,184 +1,199 @@
-<table
-  #mojTable
-  class="govuk-table"
-  [attr.data-module]="
-    clientOrServerSort() === 'client' ? 'moj-sortable-table' : null
-  "
-  [attr.aria-describedby]="caption() ? 'sortable-' + captionId() : null"
->
-  <ng-content select="caption"></ng-content>
+@if (data() && data().length) {
+  <table
+    #mojTable
+    class="govuk-table"
+    [attr.data-module]="
+      clientOrServerSort() === 'client' ? 'moj-sortable-table' : null
+    "
+    [attr.aria-describedby]="caption() ? 'sortable-' + captionId() : null"
+  >
+    <ng-content select="caption"></ng-content>
 
-  @if (caption()) {
-    <caption
-      [class.govuk-visually-hidden]="hiddenCaption()"
-      class="govuk-table__caption govuk-table__caption--{{ captionSize() }}"
-      [id]="'sortable-' + captionId()"
-    >
-      {{
-        caption()
-      }}
-    </caption>
-  }
-
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      @if (selectable()) {
-        @if (!singleSelect()) {
-          <th
-            class="govuk-table__header moj-multi-select__select-all"
-            scope="col"
-            aria-label="Select rows"
-          >
-            <span class="govuk-visually-hidden">Select rows</span>
-
-            <div class="govuk-checkboxes govuk-checkboxes--small">
-              <div class="govuk-checkboxes__item moj-multi-select__checkbox">
-                <input
-                  #selectAll
-                  type="checkbox"
-                  class="govuk-checkboxes__input"
-                  [id]="idPrefix() + 'select-all'"
-                  [checked]="allVisibleSelected"
-                  [indeterminate]="someVisibleSelected && !allVisibleSelected"
-                  (change)="toggleSelectAllVisible(selectAll.checked)"
-                />
-                <label
-                  class="govuk-label govuk-checkboxes__label"
-                  [for]="idPrefix() + 'select-all'"
-                >
-                  <span class="govuk-visually-hidden">Select all</span>
-                </label>
-              </div>
-            </div>
-          </th>
-        } @else {
-          <th class="govuk-table__header" scope="col" aria-label="Select row">
-            <span class="govuk-visually-hidden">Select row</span>
-          </th>
-        }
-      }
-
-      @for (col of columns(); track col.field) {
-        <th
-          scope="col"
-          class="govuk-table__header"
-          [class.govuk-table__header--numeric]="col.numeric"
-          [class.app-sortable-table__cell--wrap]="!col.numeric"
-          [class.app-sortable-table__cell--nowrap]="col.field === 'actions'"
-          [attr.aria-sort]="
-            col.sortable === false
-              ? null
-              : clientOrServerSort() === 'server'
-                ? ariaSortFor(col.field)
-                : (col.defaultSort ?? 'none')
-          "
-        >
-          @if (clientOrServerSort() === 'server' && col.sortable !== false) {
-            <button
-              type="button"
-              class="app-sortable-table__header-button"
-              (click)="onHeaderClick($event, col)"
-            >
-              <span class="app-sortable-table__header-label">
-                {{ col.header }}
-              </span>
-              <span
-                class="app-sortable-table__sort-indicator"
-                aria-hidden="true"
-              ></span>
-            </button>
-          } @else {
-            {{ col.header }}
-          }
-        </th>
-      }
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    @for (row of data(); track trackRow($index, row)) {
-      <tr
-        class="govuk-table__row"
-        [class.govuk-table__row--selected]="selectable() && isSelected(row)"
+    @if (caption()) {
+      <caption
+        [class.govuk-visually-hidden]="hiddenCaption()"
+        class="govuk-table__caption govuk-table__caption--{{ captionSize() }}"
+        [id]="'sortable-' + captionId()"
       >
-        @if (selectable()) {
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes govuk-checkboxes--small">
-              <div class="govuk-checkboxes__item moj-multi-select__checkbox">
-                <input
-                  #cb
-                  type="checkbox"
-                  class="govuk-checkboxes__input"
-                  name="rows[]"
-                  [id]="idPrefix() + getRowId(row)"
-                  [checked]="isSelected(row)"
-                  (change)="toggleOne(row, cb.checked)"
-                />
-                <label
-                  class="govuk-label govuk-checkboxes__label"
-                  [for]="idPrefix() + getRowId(row)"
-                >
-                  <span class="govuk-visually-hidden">
-                    Select {{ row[firstColField] }}
-                  </span>
-                </label>
-              </div>
-            </div>
-          </td>
-        }
+        {{
+          caption()
+        }}
+      </caption>
+    }
 
-        @for (col of columns(); track col.field; let ci = $index) {
-          @if (ci === 0) {
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        @if (selectable()) {
+          @if (!singleSelect()) {
             <th
-              scope="row"
-              class="govuk-table__header"
-              [class.govuk-table__cell--numeric]="col.numeric"
-              [class.app-sortable-table__cell--wrap]="!col.numeric"
-              [class.app-sortable-table__cell--nowrap]="col.field === 'actions'"
-              [attr.data-sort-value]="
-                clientOrServerSort() === 'client' && col.sortable !== false
-                  ? getSortValue(row, col)
-                  : null
-              "
+              class="govuk-table__header moj-multi-select__select-all"
+              scope="col"
+              aria-label="Select rows"
             >
-              @if (col.field === dateFieldIdentifier() && dateTpl()) {
-                <ng-container
-                  *ngTemplateOutlet="dateTpl(); context: { $implicit: row }"
-                ></ng-container>
-              } @else {
-                {{ row[col.field] }}
-              }
+              <span class="govuk-visually-hidden">Select rows</span>
+
+              <div class="govuk-checkboxes govuk-checkboxes--small">
+                <div class="govuk-checkboxes__item moj-multi-select__checkbox">
+                  <input
+                    #selectAll
+                    type="checkbox"
+                    class="govuk-checkboxes__input"
+                    [id]="idPrefix() + 'select-all'"
+                    [checked]="allVisibleSelected"
+                    [indeterminate]="someVisibleSelected && !allVisibleSelected"
+                    (change)="toggleSelectAllVisible(selectAll.checked)"
+                  />
+                  <label
+                    class="govuk-label govuk-checkboxes__label"
+                    [for]="idPrefix() + 'select-all'"
+                  >
+                    <span class="govuk-visually-hidden">Select all</span>
+                  </label>
+                </div>
+              </div>
             </th>
           } @else {
-            <td
-              class="govuk-table__cell"
-              [class.govuk-table__cell--numeric]="col.numeric"
-              [class.app-sortable-table__cell--wrap]="!col.numeric"
-              [class.app-sortable-table__cell--nowrap]="col.field === 'actions'"
-              [attr.data-sort-value]="
-                clientOrServerSort() === 'client' && col.sortable !== false
-                  ? getSortValue(row, col)
-                  : null
-              "
-            >
-              @if (col.field === 'actions') {
-                <ng-container
-                  *ngTemplateOutlet="
-                    actionsTpl ?? null;
-                    context: { $implicit: row }
-                  "
-                ></ng-container>
-              } @else if (col.field === dateFieldIdentifier() && dateTpl()) {
-                <ng-container
-                  *ngTemplateOutlet="dateTpl(); context: { $implicit: row }"
-                ></ng-container>
-              } @else {
-                {{ row[col.field] }}
-              }
-            </td>
+            <th class="govuk-table__header" scope="col" aria-label="Select row">
+              <span class="govuk-visually-hidden">Select row</span>
+            </th>
           }
         }
+
+        @for (col of columns(); track col.field) {
+          <th
+            scope="col"
+            class="govuk-table__header"
+            [class.govuk-table__header--numeric]="col.numeric"
+            [class.app-sortable-table__cell--wrap]="!col.numeric"
+            [class.app-sortable-table__cell--nowrap]="col.field === 'actions'"
+            [attr.aria-sort]="
+              col.sortable === false
+                ? null
+                : clientOrServerSort() === 'server'
+                  ? ariaSortFor(col.field)
+                  : (col.defaultSort ?? 'none')
+            "
+          >
+            @if (clientOrServerSort() === 'server' && col.sortable !== false) {
+              <button
+                type="button"
+                class="app-sortable-table__header-button"
+                (click)="onHeaderClick($event, col)"
+              >
+                <span class="app-sortable-table__header-label">
+                  {{ col.header }}
+                </span>
+                <span
+                  class="app-sortable-table__sort-indicator"
+                  aria-hidden="true"
+                ></span>
+              </button>
+            } @else {
+              {{ col.header }}
+            }
+          </th>
+        }
       </tr>
-    }
-  </tbody>
-</table>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      @for (row of data(); track trackRow($index, row)) {
+        <tr
+          class="govuk-table__row"
+          [class.govuk-table__row--selected]="selectable() && isSelected(row)"
+        >
+          @if (selectable()) {
+            <td class="govuk-table__cell">
+              <div class="govuk-checkboxes govuk-checkboxes--small">
+                <div class="govuk-checkboxes__item moj-multi-select__checkbox">
+                  <input
+                    #cb
+                    type="checkbox"
+                    class="govuk-checkboxes__input"
+                    name="rows[]"
+                    [id]="idPrefix() + getRowId(row)"
+                    [checked]="isSelected(row)"
+                    (change)="toggleOne(row, cb.checked)"
+                  />
+                  <label
+                    class="govuk-label govuk-checkboxes__label"
+                    [for]="idPrefix() + getRowId(row)"
+                  >
+                    <span class="govuk-visually-hidden">
+                      Select {{ row[firstColField] }}
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </td>
+          }
+
+          @for (col of columns(); track col.field; let ci = $index) {
+            @if (ci === 0) {
+              <th
+                scope="row"
+                class="govuk-table__header"
+                [class.govuk-table__cell--numeric]="col.numeric"
+                [class.app-sortable-table__cell--wrap]="!col.numeric"
+                [class.app-sortable-table__cell--nowrap]="
+                  col.field === 'actions'
+                "
+                [attr.data-sort-value]="
+                  clientOrServerSort() === 'client' && col.sortable !== false
+                    ? getSortValue(row, col)
+                    : null
+                "
+              >
+                @if (col.field === dateFieldIdentifier() && dateTpl()) {
+                  <ng-container
+                    *ngTemplateOutlet="dateTpl(); context: { $implicit: row }"
+                  ></ng-container>
+                } @else {
+                  {{ row[col.field] }}
+                }
+              </th>
+            } @else {
+              <td
+                class="govuk-table__cell"
+                [class.govuk-table__cell--numeric]="col.numeric"
+                [class.app-sortable-table__cell--wrap]="!col.numeric"
+                [class.app-sortable-table__cell--nowrap]="
+                  col.field === 'actions'
+                "
+                [attr.data-sort-value]="
+                  clientOrServerSort() === 'client' && col.sortable !== false
+                    ? getSortValue(row, col)
+                    : null
+                "
+              >
+                @if (col.field === 'actions') {
+                  <ng-container
+                    *ngTemplateOutlet="
+                      actionsTpl ?? null;
+                      context: { $implicit: row }
+                    "
+                  ></ng-container>
+                } @else if (col.field === dateFieldIdentifier() && dateTpl()) {
+                  <ng-container
+                    *ngTemplateOutlet="dateTpl(); context: { $implicit: row }"
+                  ></ng-container>
+                } @else {
+                  {{ row[col.field] }}
+                }
+              </td>
+            }
+          }
+        </tr>
+      }
+    </tbody>
+  </table>
+} @else {
+  <p
+    id="no-data-message"
+    [attr.aria-label]="noDataMessage()"
+    class="govuk-body"
+    tabindex="0"
+  >
+    {{ noDataMessage() }}
+  </p>
+}

--- a/src/app/core/components/sortable-table/sortable-table.component.ts
+++ b/src/app/core/components/sortable-table/sortable-table.component.ts
@@ -7,6 +7,7 @@
 
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import {
+  AfterViewChecked,
   AfterViewInit,
   ChangeDetectorRef,
   Component,
@@ -51,7 +52,9 @@ export type TableColumn = {
   templateUrl: './sortable-table.component.html',
   styleUrl: './sortable-table.component.scss',
 })
-export class SortableTableComponent implements AfterViewInit, OnDestroy {
+export class SortableTableComponent
+  implements AfterViewInit, AfterViewChecked, OnDestroy
+{
   @ContentChild('actionsTemplate', { read: TemplateRef })
   actionsTpl?: TemplateRef<unknown>;
 
@@ -108,10 +111,11 @@ export class SortableTableComponent implements AfterViewInit, OnDestroy {
   idPrefix = input('apps-');
   singleSelect = input(false);
 
-  @ViewChild('mojTable', { static: true })
-  tableRef!: ElementRef<HTMLTableElement>;
+  @ViewChild('mojTable')
+  tableRef?: ElementRef<HTMLTableElement>;
 
   private sortableInstance?: { init?: () => void; destroy?: () => void };
+  private isInitialisingSortable = false;
 
   private readonly platformId = inject(PLATFORM_ID);
   private readonly cdr = inject(ChangeDetectorRef);
@@ -243,12 +247,31 @@ export class SortableTableComponent implements AfterViewInit, OnDestroy {
    * the latest backend payload.
    */
   ngAfterViewInit(): void {
-    if (
-      !isPlatformBrowser(this.platformId) ||
-      this.clientOrServerSort() === 'server'
-    ) {
+    this.tryInitSortableTable();
+  }
+
+  ngAfterViewChecked(): void {
+    this.tryInitSortableTable();
+  }
+
+  private tryInitSortableTable(): void {
+    if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+
+    if (this.clientOrServerSort() === 'server') {
+      return;
+    }
+
+    if (!this.tableRef?.nativeElement) {
+      return;
+    }
+
+    if (this.sortableInstance || this.isInitialisingSortable) {
+      return;
+    }
+
+    this.isInitialisingSortable = true;
 
     void import('@ministryofjustice/frontend')
       .then((mod) => {
@@ -269,12 +292,15 @@ export class SortableTableComponent implements AfterViewInit, OnDestroy {
           return;
         }
 
-        const instance = new SortableCtor(this.tableRef.nativeElement);
+        const instance = new SortableCtor(this.tableRef!.nativeElement);
         instance.init?.();
         this.sortableInstance = instance;
       })
       .catch(() => {
         // no-op for non-browser/test environments
+      })
+      .finally(() => {
+        this.isInitialisingSortable = false;
       });
   }
 

--- a/src/app/core/components/sortable-table/sortable-table.component.ts
+++ b/src/app/core/components/sortable-table/sortable-table.component.ts
@@ -81,6 +81,7 @@ export class SortableTableComponent implements AfterViewInit, OnDestroy {
   hiddenCaption = input(false);
   columns = input<TableColumn[]>([]);
   data = input<Row[]>([]);
+  noDataMessage = input('No results found.');
 
   dateFieldIdentifier = input<string>('date');
 

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -128,7 +128,7 @@
             class="govuk-table__caption govuk-table__caption--m"
             id="sortable-Lists"
           >
-            <span class="table-caption__text"> Lists </span>
+            <span class="table-caption__text"> Entries </span>
 
             <span
               class="table-caption__actions"

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
@@ -12,7 +12,7 @@ export const CODES_COLUMNS: TableColumn[] = [
   { header: 'Code', field: 'code' },
   { header: 'Title', field: 'title' },
   { header: 'Bulk', field: 'bulk' },
-  { header: 'Fee req', field: 'fee' },
+  { header: 'Fee required', field: 'isFeeDue' },
   { header: 'Actions', field: 'actions', sortable: false },
 ];
 

--- a/src/app/pages/applications-list/applications-list.component.html
+++ b/src/app/pages/applications-list/applications-list.component.html
@@ -83,7 +83,10 @@
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
 
-@if (storedRecordsVm().submitted && !vm().isLoading) {
+@if (
+  storedRecordsVm().rows.length ||
+  (storedRecordsVm().submitted && !vm().isLoading)
+) {
   <!-- Sortable table component -->
   <app-sortable-table
     id="sortable-table"

--- a/src/app/pages/applications-list/applications-list.component.html
+++ b/src/app/pages/applications-list/applications-list.component.html
@@ -1,15 +1,3 @@
-<app-page-header
-  title="Applications List"
-  [actions]="[
-    {
-      label: 'Create new list',
-      routerLink: ['create'],
-      startIcon: true,
-      variant: 'primary',
-    },
-  ]"
-/>
-
 @if (storedRecordsVm().submitted && vm().searchErrors.length) {
   <app-error-summary
     [title]="'There is a problem'"
@@ -50,6 +38,18 @@
   />
 }
 
+<app-page-header
+  title="Applications List"
+  [actions]="[
+    {
+      label: 'Create new list',
+      routerLink: ['create'],
+      startIcon: true,
+      variant: 'primary',
+    },
+  ]"
+/>
+
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
@@ -83,7 +83,7 @@
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
 
-@if (storedRecordsVm().rows.length) {
+@if (storedRecordsVm().submitted && !vm().isLoading) {
   <!-- Sortable table component -->
   <app-sortable-table
     id="sortable-table"
@@ -130,7 +130,7 @@
             </button>
 
             <!-- Print continuous button (always shown)
-             Print cont with false bool param to change PDF title -->
+               Print cont with false bool param to change PDF title -->
             <button
               type="button"
               class="govuk-button moj-button-menu__item govuk-button--secondary"
@@ -166,7 +166,7 @@
             </button>
 
             <!-- Print continuous button (always shown)
-             Print cont with true bool param to change PDF title -->
+               Print cont with true bool param to change PDF title -->
             <button
               type="button"
               class="govuk-button moj-button-menu__item govuk-button--secondary"

--- a/src/app/pages/applications-list/applications-list.component.ts
+++ b/src/app/pages/applications-list/applications-list.component.ts
@@ -367,7 +367,6 @@ export class ApplicationsList extends PlaceFieldsBase implements OnInit {
     // Reset flag
     this.appListSignalState.patch(clearNotificationsPatch());
     this.appListSignalState.patch({ isSearch: true });
-    this.storedRecordsState.patch({ rows: [] });
 
     this.form.markAllAsTouched();
     this.form.updateValueAndValidity({ emitEvent: false });

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -1,4 +1,15 @@
-<h1 class="govuk-heading-xl">Standard applications</h1>
+@if (vm().searchErrors.length) {
+  <app-error-summary [items]="vm().searchErrors" title="There is a problem" />
+} @else {
+  @if (vm().hasSearched && !vm().isLoading && !vm().rows.length) {
+    <app-notification-banner
+      heading="No standard applicants found"
+      body="Try different filters"
+    />
+  }
+}
+
+<h1 class="govuk-heading-xl">Standard applicants</h1>
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
@@ -9,25 +20,23 @@
     <app-text-input
       formControlName="code"
       label="Code"
-      hint="Application code"
       idPrefix="code"
-    >
-    </app-text-input>
+      containerWidthClass="govuk-grid-column-one-half"
+    />
+  </div>
 
+  <div class="govuk-grid-row">
     <app-text-input
       formControlName="name"
-      label="Applicant"
-      hint="Standard applicant name"
+      label="Standard applicant name"
       idPrefix="name"
-    >
-    </app-text-input>
+      widthClass="govuk-input--width-20"
+      containerWidthClass="govuk-grid-column-one-half"
+    />
   </div>
 
   <div class="govuk-button-group">
     <button type="submit" class="govuk-button" value="search">Search</button>
-    <button type="button" class="govuk-button govuk-button--secondary">
-      Export
-    </button>
   </div>
 </form>
 
@@ -35,27 +44,70 @@
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
 
-<!-- Sortable table component -->
-<app-sortable-table caption="Lists" [columns]="columns">
-  <!-- actions slot -->
-  <ng-template #actionsTemplate let-row>
-    <div class="govuk-button-group">
-      <a
-        [routerLink]="['/standard-applicants', row.id]"
-        class="govuk-button govuk-button--secondary"
-      >
-        View
-      </a>
-      <button type="button" class="govuk-button govuk-button--warning">
-        Download
-      </button>
-    </div>
-  </ng-template>
-</app-sortable-table>
+@if (vm().hasSearched && !vm().isLoading) {
+  <!-- Sortable table component -->
+  <app-sortable-table
+    id="sa-sortable-table"
+    [columns]="columns"
+    [data]="vm().rows"
+    [clientOrServerSort]="'server'"
+    [sortKey]="vm().sortField.key"
+    [sortDirection]="vm().sortField.direction"
+    (sortChange)="onSortChange($event)"
+    appMojButtonMenu
+  >
+    <caption
+      class="govuk-table__caption govuk-table__caption--m"
+      id="sa-sortable-table-caption"
+    >
+      <span class="table-caption__text"> Standard applicants </span>
 
-<!-- Pager -->
-<app-pagination
-  [currentPage]="currentPage"
-  [totalPages]="totalPages"
-  (pageChange)="onPageChange($event)"
-/>
+      <span
+        class="table-caption__actions"
+        role="group"
+        aria-label="Table export action"
+      >
+        <div
+          class="moj-button-menu"
+          data-module="moj-button-menu"
+          data-button-text="Actions"
+          data-align-menu="right"
+          data-button-classes="govuk-button govuk-button--small govuk-button--primary table-caption__action-button"
+        >
+          <button
+            type="button"
+            class="govuk-button moj-button-menu__item govuk-button--secondary"
+          >
+            Export
+          </button>
+
+          <button
+            type="button"
+            class="govuk-button moj-button-menu__item govuk-button--secondary"
+          >
+            Print
+          </button>
+        </div>
+      </span>
+    </caption>
+
+    <!-- actions slot -->
+    <ng-template #actionsTemplate let-row>
+      <div class="govuk-button-group">
+        <button
+          type="button"
+          class="govuk-button moj-button-menu__item govuk-button"
+        >
+          Open
+        </button>
+      </div>
+    </ng-template>
+  </app-sortable-table>
+
+  <!-- Pager -->
+  <app-pagination
+    [currentPage]="vm().currentPage"
+    [totalPages]="vm().totalPages"
+    (pageChange)="onPageChange($event)"
+  />
+}

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -44,7 +44,7 @@
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
 
-@if (vm().hasSearched && !vm().isLoading) {
+@if (vm().hasSearched && !vm().isLoading && !vm().searchErrors.length) {
   <!-- Sortable table component -->
   <app-sortable-table
     id="sa-sortable-table"

--- a/src/app/pages/standard-applicants/standard-applicants.component.scss
+++ b/src/app/pages/standard-applicants/standard-applicants.component.scss
@@ -1,0 +1,7 @@
+.table-caption__actions {
+  float: right;
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -1,57 +1,170 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import {
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import { RouterLink } from '@angular/router';
+  Component,
+  EnvironmentInjector,
+  OnInit,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
+import {
+  ErrorItem,
+  ErrorSummaryComponent,
+} from '@components/error-summary/error-summary.component';
+import { NotificationBannerComponent } from '@components/notification-banner/notification-banner.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
-import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
+import {
+  SortableTableComponent,
+  TableColumn,
+} from '@components/sortable-table/sortable-table.component';
+import {
+  mapSaToRow,
+  standardAppColumns,
+} from '@components/standard-applicant-select/util/standard-applicant-select-row-helpers';
 import { TextInputComponent } from '@components/text-input/text-input.component';
+import {
+  GetStandardApplicantsRequestParams,
+  StandardApplicantsApi,
+} from '@openapi';
+import { getProblemText } from '@util/http-error-to-text';
+import { MojButtonMenuDirective } from '@util/moj-button-menu';
+import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
+import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
+import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
+
+type StandardApplicantsState = {
+  hasSearched: boolean;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+  sortField: { key: string; direction: 'desc' | 'asc' };
+  rows: StandardApplicantRow[];
+  isLoading: boolean;
+  searchErrors: ErrorItem[];
+};
+
+const initialStandardApplicantsState: StandardApplicantsState = {
+  hasSearched: false,
+  currentPage: 0,
+  totalPages: 0,
+  pageSize: 10,
+  sortField: { key: 'code', direction: 'asc' },
+  rows: [],
+  isLoading: false,
+  searchErrors: [],
+};
 
 @Component({
   selector: 'app-standard-applicants',
   standalone: true,
   imports: [
-    FormsModule,
-    RouterLink,
+    CommonModule,
     ReactiveFormsModule,
     TextInputComponent,
     PaginationComponent,
     SortableTableComponent,
+    ErrorSummaryComponent,
+    MojButtonMenuDirective,
+    NotificationBannerComponent,
   ],
   templateUrl: './standard-applicants.component.html',
+  styleUrl: './standard-applicants.component.scss',
 })
-export class StandardApplicants {
-  currentPage = 1;
-  totalPages = 5;
+export class StandardApplicants implements OnInit {
+  private readonly envInjector = inject(EnvironmentInjector);
+  private readonly saApi = inject(StandardApplicantsApi);
+
+  private readonly signalState = createSignalState<StandardApplicantsState>(
+    initialStandardApplicantsState,
+  );
+  readonly vm = this.signalState.vm;
+
+  private readonly loadRequest =
+    signal<GetStandardApplicantsRequestParams | null>(null);
 
   form = new FormGroup({
-    code: new FormControl<string>(''),
-    name: new FormControl<string>(''),
+    code: new FormControl<string>('', { nonNullable: true }),
+    name: new FormControl<string>('', { nonNullable: true }),
   });
 
-  columns = [
-    { header: 'Code', field: 'code', numeric: true },
-    { header: 'Name', field: 'name' },
-    { header: 'Address line 1', field: 'address' },
-    { header: 'Use from', field: 'useFrom' },
-    { header: 'Use to', field: 'useTo' },
+  columns: TableColumn[] = [
+    ...standardAppColumns,
     { header: 'Actions', field: 'actions', sortable: false },
   ];
 
-  onSubmit(event: SubmitEvent): void {
-    event.preventDefault();
+  ngOnInit(): void {
+    this.setupEffects();
   }
 
-  loadStandardApplicants(): void {
-    // TODO: fetch lists
+  onSubmit(event: SubmitEvent): void {
+    event.preventDefault();
+    this.signalState.patch({ hasSearched: true });
+    this.loadStandardApplicants(0);
+  }
+
+  onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
+    this.signalState.patch({ sortField: sort });
+    this.loadStandardApplicants(0);
   }
 
   onPageChange(page: number): void {
-    this.currentPage = page;
-    this.loadStandardApplicants(); // fetch page `page`
+    this.loadStandardApplicants(page);
+  }
+
+  private setupEffects(): void {
+    setupLoadEffect(
+      {
+        request: this.loadRequest,
+        load: (params) =>
+          this.saApi.getStandardApplicants(params, 'body', false, {
+            transferCache: true,
+          }),
+        onSuccess: (page) => {
+          this.signalState.patch({
+            rows: (page.content ?? []).map((sa) => mapSaToRow(sa)),
+            totalPages: page.totalPages ?? 0,
+            isLoading: false,
+            searchErrors: [],
+          });
+          this.loadRequest.set(null);
+        },
+        onError: (err) => {
+          this.signalState.patch({
+            rows: [],
+            totalPages: 0,
+            isLoading: false,
+            searchErrors: [{ id: 'search', text: getProblemText(err) }],
+          });
+          this.loadRequest.set(null);
+        },
+      },
+      this.envInjector,
+    );
+  }
+
+  private loadStandardApplicants(page: number): void {
+    if (this.vm().isLoading) {
+      return;
+    }
+
+    const code = this.form.controls.code.value.trim();
+    const name = this.form.controls.name.value.trim();
+    const sort = this.vm().sortField;
+    const apiSortKey = toStandardApplicantSortKey(sort.key);
+
+    this.signalState.patch({
+      currentPage: page,
+      isLoading: true,
+      searchErrors: [],
+    });
+
+    this.loadRequest.set({
+      code: code || undefined,
+      name: name || undefined,
+      pageNumber: page,
+      pageSize: this.vm().pageSize,
+      sort: [`${apiSortKey},${sort.direction}`],
+    });
   }
 }

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
@@ -1,20 +1,51 @@
 <div id="standard-applicant">
-  <app-sortable-table
-    id="standard-applicant-table"
-    caption="Standard applicants"
-    [columns]="columns"
-    [data]="rows"
-    [selectable]="true"
-    idField="code"
-    [singleSelect]="true"
-    [selectedIds]="selectedIds"
-    (selectedIdsChange)="onSelectedIdsChange($event)"
-    appMojButtonMenu
-  />
+  <form [formGroup]="form" (ngSubmit)="onSubmit($event)">
+    <div class="govuk-grid-row">
+      <app-text-input
+        formControlName="code"
+        label="Code"
+        idPrefix="standard-applicant-code"
+        containerWidthClass="govuk-grid-column-one-half"
+      />
+    </div>
 
-  <app-pagination
-    [currentPage]="vm().pageIndex"
-    [totalPages]="vm().totalPages"
-    (pageChange)="onPageChange($event)"
-  />
+    <div class="govuk-grid-row">
+      <app-text-input
+        formControlName="name"
+        label="Standard applicant name"
+        idPrefix="standard-applicant-name"
+        widthClass="govuk-input--width-20"
+        containerWidthClass="govuk-grid-column-one-half"
+      />
+    </div>
+
+    <div class="govuk-button-group">
+      <button type="submit" class="govuk-button">Search</button>
+    </div>
+  </form>
+
+  @if (vm().hasSearched && !vm().loading) {
+    <app-sortable-table
+      id="standard-applicant-table"
+      caption="Standard applicants"
+      [columns]="columns"
+      [data]="rows"
+      [clientOrServerSort]="'server'"
+      [sortKey]="vm().sortField.key"
+      [sortDirection]="vm().sortField.direction"
+      (sortChange)="onSortChange($event)"
+      [selectable]="true"
+      idField="code"
+      [singleSelect]="true"
+      [selectedIds]="selectedIds"
+      (selectedIdsChange)="onSelectedIdsChange($event)"
+      appMojButtonMenu
+    />
+
+    <app-pagination
+      [currentPage]="vm().pageIndex"
+      [totalPages]="vm().totalPages"
+      (pageChange)="onPageChange($event)"
+    />
+  }
 </div>

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -14,6 +14,7 @@ import {
   output,
   signal,
 } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import {
   mapSaToRow,
@@ -29,14 +30,22 @@ import {
   SortableTableComponent,
   TableColumn,
 } from '@components/sortable-table/sortable-table.component';
+import { TextInputComponent } from '@components/text-input/text-input.component';
 import { StandardApplicantsApi } from '@openapi';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
+import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
 
 @Component({
   selector: 'app-standard-applicant-select',
   standalone: true,
-  imports: [CommonModule, SortableTableComponent, PaginationComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TextInputComponent,
+    SortableTableComponent,
+    PaginationComponent,
+  ],
   templateUrl: './standard-applicant-select.component.html',
 })
 export class StandardApplicantSelectComponent implements OnInit, OnChanges {
@@ -59,9 +68,17 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
   readonly vm = this.saSignalState.vm;
 
   private readonly loadRequest = signal<{
+    code?: string;
+    name?: string;
     pageNumber: number;
     pageSize: number;
+    sort: string[];
   } | null>(null);
+
+  form = new FormGroup({
+    code: new FormControl<string>('', { nonNullable: true }),
+    name: new FormControl<string>('', { nonNullable: true }),
+  });
 
   // Selection for the table
   selectedIds: Set<string> = new Set<string>();
@@ -69,6 +86,7 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.syncSelectedIdsFromCode();
     this.setupEffects();
+    this.saSignalState.patch({ hasSearched: true });
     this.loadPage(0);
   }
 
@@ -90,7 +108,24 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
   }
 
   onPageChange(page: number): void {
+    if (!this.saState().hasSearched) {
+      return;
+    }
     this.loadPage(page);
+  }
+
+  onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
+    if (!this.saState().hasSearched) {
+      return;
+    }
+    this.saSignalState.patch({ sortField: sort });
+    this.loadPage(0);
+  }
+
+  onSubmit(event: SubmitEvent): void {
+    event.preventDefault();
+    this.saSignalState.patch({ hasSearched: true });
+    this.loadPage(0);
   }
 
   private setupEffects(): void {
@@ -133,8 +168,18 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     this.saSignalState.patch({ loading: true, pageIndex: page });
 
     const pageSize = this.saState().pageSize;
+    const sort = this.saState().sortField;
+    const apiSortKey = toStandardApplicantSortKey(sort.key);
+    const code = this.form.controls.code.value.trim();
+    const name = this.form.controls.name.value.trim();
 
-    this.loadRequest.set({ pageNumber: this.saState().pageIndex, pageSize });
+    this.loadRequest.set({
+      code: code || undefined,
+      name: name || undefined,
+      pageNumber: this.saState().pageIndex,
+      pageSize,
+      sort: [`${apiSortKey},${sort.direction}`],
+    });
   }
 
   private syncSelectedIdsFromCode(): void {

--- a/src/app/shared/components/standard-applicant-select/util/standard-applicant-select.state.ts
+++ b/src/app/shared/components/standard-applicant-select/util/standard-applicant-select.state.ts
@@ -1,14 +1,18 @@
 export interface StandardApplicantSelectPagingState {
+  hasSearched: boolean;
   pageIndex: number;
   totalPages: number;
   pageSize: number;
+  sortField: { key: string; direction: 'desc' | 'asc' };
   loading: boolean;
 }
 
 export const initialStandardApplicantSelectPagingState: StandardApplicantSelectPagingState =
   {
+    hasSearched: false,
     pageIndex: 0,
     totalPages: 0,
     pageSize: 10,
+    sortField: { key: 'code', direction: 'asc' },
     loading: false,
   };

--- a/src/app/shared/util/application-code-helpers.ts
+++ b/src/app/shared/util/application-code-helpers.ts
@@ -52,6 +52,7 @@ export type CodeRow = {
   title: string;
   bulk: string;
   fee: string;
+  isFeeDue: string;
 };
 
 export type CodeRowsResult = {
@@ -66,6 +67,7 @@ export function mapCodeRows(page: ApplicationCodePage): CodeRow[] {
     title: i.title ?? '',
     bulk: i.bulkRespondentAllowed ? 'Yes' : 'No',
     fee: i.feeReference ?? '—',
+    isFeeDue: i.isFeeDue ? 'Yes' : 'No',
   }));
 }
 

--- a/src/app/shared/util/standard-applicant-sort-map.ts
+++ b/src/app/shared/util/standard-applicant-sort-map.ts
@@ -1,0 +1,10 @@
+export const STANDARD_APPLICANTS_SORT_MAP: Record<string, string> = {
+  code: 'code',
+  name: 'name',
+  address: 'addressLine1',
+  useFrom: 'from',
+  useTo: 'to',
+};
+
+export const toStandardApplicantSortKey = (uiSortKey: string): string =>
+  STANDARD_APPLICANTS_SORT_MAP[uiSortKey] ?? uiSortKey;

--- a/test/unit/app/core/components/sortable-table/sortable-table.component.spec.ts
+++ b/test/unit/app/core/components/sortable-table/sortable-table.component.spec.ts
@@ -62,7 +62,10 @@ describe('SortableTableComponent', () => {
     }
   };
 
-  async function create(platform: 'browser' | 'server' = 'browser') {
+  async function create(
+    platform: 'browser' | 'server' = 'browser',
+    initialData: Row[] = [{ id: 'abc', name: 'Everest', elevation: 8848 }],
+  ) {
     await TestBed.configureTestingModule({
       imports: [SortableTableComponent],
       providers: [{ provide: PLATFORM_ID, useValue: platform }],
@@ -76,11 +79,9 @@ describe('SortableTableComponent', () => {
       { header: 'Elevation', field: 'elevation', numeric: true },
       { header: 'Actions', field: 'actions', sortable: false },
     ];
-    const data: Row[] = [{ id: 'abc', name: 'Everest', elevation: 8848 }];
-
     setInput('caption', 'Lists', false);
     setInput('columns', columns, false);
-    setInput('data', data, false);
+    setInput('data', initialData, false);
     setInput('idField', 'id', false);
     setInput('idPrefix', 'row-', false);
     fixture.detectChanges();
@@ -97,6 +98,18 @@ describe('SortableTableComponent', () => {
     expect(
       fixture.debugElement.query(By.css('table.govuk-table')),
     ).toBeTruthy();
+  });
+
+  it('renders no-data message and no table when data is empty', async () => {
+    await create('browser', []);
+
+    expect(fixture.debugElement.query(By.css('table.govuk-table'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('thead'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('#no-data-message'))).toBeTruthy();
+    expect(
+      fixture.debugElement.query(By.css('#no-data-message')).nativeElement
+        .textContent,
+    ).toContain('No results found.');
   });
 
   describe('trackRow', () => {
@@ -275,6 +288,16 @@ describe('SortableTableComponent', () => {
 
       expect(SortableTableMock).toHaveBeenCalledTimes(1);
       expect(SortableTableMock).toHaveBeenCalledWith(tableEl);
+    });
+
+    it('does not instantiate MoJ SortableTable when there is no table rendered', async () => {
+      await create('browser', []);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(fixture.debugElement.query(By.css('table'))).toBeNull();
+      expect(SortableTableMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/unit/app/pages/applications-list/applications-list.component.spec.ts
+++ b/test/unit/app/pages/applications-list/applications-list.component.spec.ts
@@ -540,6 +540,39 @@ describe('ApplicationsList – search', () => {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it('preserves existing results and pagination when validation fails', () => {
+      const existingRows = [
+        {
+          id: 'keep',
+          date: '2025-01-01',
+          time: '10:00',
+          location: 'Court A',
+          description: 'Existing list',
+          entries: 2,
+          status: ApplicationListStatus.OPEN,
+        },
+      ] as ApplicationListRow[];
+
+      patchRecordsState(component, {
+        rows: existingRows,
+        totalPages: 4,
+      });
+
+      component.form.controls.date.setErrors({
+        dateInvalid: true,
+        dateErrorText: 'Enter a valid date',
+      });
+
+      const spy = jest.spyOn(component, 'loadApplicationsLists');
+
+      const { e } = submitEvent('search');
+      component.onSubmit(e);
+
+      expect(getRecordsState(component).rows).toEqual(existingRows);
+      expect(getRecordsState(component).totalPages).toBe(4);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('calls loadApplicationsLists(hasAnyParams) for search action when no validation errors', () => {
       const spy = jest
         .spyOn(component, 'loadApplicationsLists')

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -185,4 +185,16 @@ describe('StandardApplicantsComponent', () => {
       { id: 'search', text: 'Request failed' },
     ]);
   });
+
+  it('does not render table no-data state when the search fails', async () => {
+    apiStub.getStandardApplicants.mockReturnValueOnce(
+      throwError(() => new Error('Request failed')),
+    );
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeNull();
+    expect(fixture.nativeElement.querySelector('#no-data-message')).toBeNull();
+  });
 });

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -1,22 +1,181 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
 
 import { StandardApplicants } from '@components/standard-applicants/standard-applicants.component';
+import { StandardApplicantsApi } from '@openapi';
+
+const flushSignalEffects = async (
+  fixture: ComponentFixture<StandardApplicants>,
+): Promise<void> => {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+};
 
 describe('StandardApplicantsComponent', () => {
   let component: StandardApplicants;
   let fixture: ComponentFixture<StandardApplicants>;
+  const apiStub: jest.Mocked<Pick<StandardApplicantsApi, 'getStandardApplicants'>> =
+    {
+      getStandardApplicants: jest.fn(),
+    };
 
   beforeEach(async () => {
+    apiStub.getStandardApplicants.mockReturnValue(
+      of({
+        content: [],
+        totalPages: 0,
+      }),
+    );
+
     await TestBed.configureTestingModule({
       imports: [StandardApplicants],
+      providers: [{ provide: StandardApplicantsApi, useValue: apiStub }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StandardApplicants);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await flushSignalEffects(fixture);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('does not render table or pagination before first search', () => {
+    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('app-pagination'))).toBeNull();
+  });
+
+  it('submits search and requests first page with trimmed filters', async () => {
+    component.form.patchValue({
+      code: '  ABC  ',
+      name: '  Test Applicant  ',
+    });
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).toHaveBeenCalledWith(
+      {
+        code: 'ABC',
+        name: 'Test Applicant',
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['code,asc'],
+      },
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+  });
+
+  it('renders table after first search and shows no-data message for empty results', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('app-pagination'))).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('#no-data-message')?.textContent,
+    ).toContain('No results found.');
+  });
+
+  it('loads selected page when pagination changes', async () => {
+    component.onPageChange(3);
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).toHaveBeenCalledWith(
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 3,
+        pageSize: 10,
+        sort: ['code,asc'],
+      },
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+  });
+
+  it('maps useFrom sort key to backend from parameter', async () => {
+    component.onSortChange({ key: 'useFrom', direction: 'desc' });
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).toHaveBeenCalledWith(
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['from,desc'],
+      },
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+  });
+
+  it('updates rows and total pages on successful response', async () => {
+    apiStub.getStandardApplicants.mockReturnValueOnce(
+      of({
+        content: [
+          {
+            code: 'SA01',
+            applicant: {
+              organisation: {
+                name: 'Applicant Org',
+                contactDetails: { addressLine1: '1 Test Street' },
+              },
+            },
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+          },
+        ],
+        totalPages: 7,
+      }),
+    );
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(component.vm().rows).toEqual([
+      {
+        code: 'SA01',
+        name: 'Applicant Org',
+        address: '1 Test Street',
+        useFrom: '01/01/2026',
+        useTo: '31/12/2026',
+      },
+    ]);
+    expect(component.vm().totalPages).toBe(7);
+    expect(component.vm().searchErrors).toEqual([]);
+  });
+
+  it('captures API errors into searchErrors state', async () => {
+    apiStub.getStandardApplicants.mockReturnValueOnce(
+      throwError(() => new Error('Request failed')),
+    );
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(component.vm().rows).toEqual([]);
+    expect(component.vm().totalPages).toBe(0);
+    expect(component.vm().searchErrors).toEqual([
+      { id: 'search', text: 'Request failed' },
+    ]);
   });
 });

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
 import { StandardApplicants } from '@components/standard-applicants/standard-applicants.component';
@@ -16,10 +17,11 @@ const flushSignalEffects = async (
 describe('StandardApplicantsComponent', () => {
   let component: StandardApplicants;
   let fixture: ComponentFixture<StandardApplicants>;
-  const apiStub: jest.Mocked<Pick<StandardApplicantsApi, 'getStandardApplicants'>> =
-    {
-      getStandardApplicants: jest.fn(),
-    };
+  const apiStub: jest.Mocked<
+    Pick<StandardApplicantsApi, 'getStandardApplicants'>
+  > = {
+    getStandardApplicants: jest.fn(),
+  };
 
   beforeEach(async () => {
     apiStub.getStandardApplicants.mockReturnValue(
@@ -31,7 +33,10 @@ describe('StandardApplicantsComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [StandardApplicants],
-      providers: [{ provide: StandardApplicantsApi, useValue: apiStub }],
+      providers: [
+        provideRouter([]),
+        { provide: StandardApplicantsApi, useValue: apiStub },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StandardApplicants);
@@ -81,7 +86,9 @@ describe('StandardApplicantsComponent', () => {
     component.onSubmit(new SubmitEvent('submit'));
     await flushSignalEffects(fixture);
 
-    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeTruthy();
+    expect(
+      fixture.debugElement.query(By.css('app-sortable-table')),
+    ).toBeTruthy();
     expect(fixture.debugElement.query(By.css('app-pagination'))).toBeTruthy();
     expect(
       fixture.nativeElement.querySelector('#no-data-message')?.textContent,

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -169,7 +169,9 @@ describe('StandardApplicantSelectComponent', () => {
 
     expect(component.vm().pageIndex).toBe(0);
     expect(component.vm().totalPages).toBe(1);
-    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeTruthy();
+    expect(
+      fixture.debugElement.query(By.css('app-sortable-table')),
+    ).toBeTruthy();
     expect(fixture.debugElement.query(By.css('app-pagination'))).toBeTruthy();
   }));
 

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 
 import { StandardApplicantSelectComponent } from '@components/standard-applicant-select/standard-applicant-select.component';
@@ -141,11 +142,17 @@ describe('StandardApplicantSelectComponent', () => {
 
     mockGetStandardApplicants.mockReturnValueOnce(of(page));
 
-    fixture.detectChanges(); // triggers ngOnInit
+    fixture.detectChanges();
     TestBed.tick();
 
     expect(mockGetStandardApplicants).toHaveBeenCalledWith(
-      { pageNumber: 0, pageSize: 10 },
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['code,asc'],
+      },
       'body',
       false,
       expect.objectContaining({ transferCache: true }),
@@ -162,6 +169,8 @@ describe('StandardApplicantSelectComponent', () => {
 
     expect(component.vm().pageIndex).toBe(0);
     expect(component.vm().totalPages).toBe(1);
+    expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('app-pagination'))).toBeTruthy();
   }));
 
   it('uses selectedCode input to initialise selectedIds and emits changes when selection changes', fakeAsync(() => {
@@ -180,7 +189,7 @@ describe('StandardApplicantSelectComponent', () => {
 
     const emitSpy = jest.spyOn(component.selectedCodeChange, 'emit');
 
-    fixture.detectChanges(); // ngOnInit: syncSelectedIdsFromCode + loadPage
+    fixture.detectChanges();
     TestBed.tick();
 
     // After init, selectedIds should reflect selectedCode
@@ -208,7 +217,7 @@ describe('StandardApplicantSelectComponent', () => {
   }));
 
   it('onPageChange triggers API call for requested page and updates pageIndex', fakeAsync(() => {
-    fixture.detectChanges(); // initial load, call #1
+    fixture.detectChanges();
     TestBed.tick();
 
     const secondPage = {
@@ -225,7 +234,13 @@ describe('StandardApplicantSelectComponent', () => {
     TestBed.tick();
 
     expect(mockGetStandardApplicants).toHaveBeenLastCalledWith(
-      { pageNumber: 1, pageSize: 10 },
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 1,
+        pageSize: 10,
+        sort: ['code,asc'],
+      },
       'body',
       false,
       expect.objectContaining({ transferCache: true }),
@@ -247,5 +262,48 @@ describe('StandardApplicantSelectComponent', () => {
     TestBed.tick();
     expect(component.rows).toEqual([]);
     expect(component.vm().totalPages).toBe(0);
+  }));
+
+  it('maps useTo sort key to backend to and reloads first page', fakeAsync(() => {
+    fixture.detectChanges();
+    TestBed.tick();
+
+    component.onSortChange({ key: 'useTo', direction: 'desc' });
+    TestBed.tick();
+
+    expect(mockGetStandardApplicants).toHaveBeenLastCalledWith(
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['to,desc'],
+      },
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
+    expect(component.vm().pageIndex).toBe(0);
+  }));
+
+  it('submits trimmed code and name filters', fakeAsync(() => {
+    fixture.detectChanges();
+    component.form.patchValue({ code: ' SA-1 ', name: ' Example ' });
+
+    component.onSubmit(new SubmitEvent('submit'));
+    TestBed.tick();
+
+    expect(mockGetStandardApplicants).toHaveBeenCalledWith(
+      {
+        code: 'SA-1',
+        name: 'Example',
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['code,asc'],
+      },
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
   }));
 });

--- a/test/unit/app/shared/util/application-code-helpers.spec.ts
+++ b/test/unit/app/shared/util/application-code-helpers.spec.ts
@@ -164,8 +164,14 @@ describe('application-code-helpers', () => {
       } as unknown as ApplicationCodePage;
 
       expect(mapCodeRows(page)).toEqual<CodeRow[]>([
-        { code: 'A1', title: 'Title 1', bulk: 'Yes', fee: 'FEE1' },
-        { code: '', title: '', bulk: 'No', fee: '—' },
+        {
+          code: 'A1',
+          title: 'Title 1',
+          bulk: 'Yes',
+          fee: 'FEE1',
+          isFeeDue: 'No',
+        },
+        { code: '', title: '', bulk: 'No', fee: '—', isFeeDue: 'No' },
       ]);
     });
 
@@ -266,7 +272,15 @@ describe('application-code-helpers', () => {
       );
 
       expect(rows).toEqual<CodeRowsResult>({
-        rows: [{ bulk: 'Yes', code: 'A1', fee: 'FEE1', title: 'Title 1' }],
+        rows: [
+          {
+            bulk: 'Yes',
+            code: 'A1',
+            fee: 'FEE1',
+            isFeeDue: 'No',
+            title: 'Title 1',
+          },
+        ],
         totalPages: 7,
       });
     });


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1188


### Change description
- Added server-side sorting and filterable search flows for standard applicants, including code/name filters and backend sort-key mapping.
- Updated the standard applicant selection experience to support searchable, sortable, paginated results in entry flows.
- Improved sortable table empty-state handling by showing a reusable no-results message when no rows are available.
- Updated application code search rows to surface a dedicated `Fee required` column based on `isFeeDue`.
- Added and refreshed unit tests covering sortable table empty states, standard applicant search/sort behavior, and the updated application-code row mapping.

### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
