### PR TITLE
ARCPOC-1307 Preserve staged wording when returning from payment reference edit

### DIFF
--- a/src/app/core/components/alert/alert.component.ts
+++ b/src/app/core/components/alert/alert.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 
 import { ALERT_ICON_PATHS, AlertType } from './alert-icons';
 
@@ -15,6 +15,7 @@ export class AlertComponent {
   readonly title = input<string>('');
   readonly allowDismiss = input<boolean>(false);
   readonly href = input<{ href: string; msg: string }>();
+  readonly alertDismissed = output<void>();
 
   private readonly dismissed = signal(false);
 
@@ -30,6 +31,7 @@ export class AlertComponent {
   dismiss(): void {
     if (this.allowDismiss()) {
       this.dismissed.set(true);
+      this.alertDismissed.emit();
     }
   }
 }

--- a/src/app/core/components/date-input/date-input.component.html
+++ b/src/app/core/components/date-input/date-input.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-one-half app-date-tight">
+<div [class]="containerWidthClass() + ' app-date-tight'">
   <div
     class="govuk-form-group"
     [class.govuk-form-group--error]="groupError(submitted())"

--- a/src/app/core/components/date-input/date-input.component.ts
+++ b/src/app/core/components/date-input/date-input.component.ts
@@ -55,6 +55,8 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
   isSearch = input(false);
   disallowFutureDates = input(false);
 
+  containerWidthClass = input('govuk-grid-column-one-half');
+
   disabled = false;
 
   private readonly fb = inject(NonNullableFormBuilder);

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -56,6 +56,7 @@
       <app-wording-section
         #wordingSection
         [wordingObject]="appCodeDetail.wording"
+        [wordingObjectValues]="getWordingObjectValues(appCodeDetail.wording)"
         [wordingSubmitAttempt]="wordingSubmitAttempt()"
         (wordingFieldsDTO)="onWordingFieldsDTO($event)"
         (wordingFieldErrors)="onChildErrors('wording', $event)"

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -58,7 +58,9 @@
         [wordingObject]="appCodeDetail.wording"
         [wordingObjectValues]="getWordingObjectValues(appCodeDetail.wording)"
         [wordingSubmitAttempt]="wordingSubmitAttempt()"
+        [showAppliedBanner]="wordingAppliedBannerVisible()"
         (wordingFieldsDTO)="onWordingFieldsDTO($event)"
+        (appliedBannerDismissed)="onWordingAppliedBannerDismissed()"
         (wordingFieldErrors)="onChildErrors('wording', $event)"
       />
     } @else {

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -71,6 +71,7 @@ import {
 import {
   ApplicationCodesApi,
   ApplicationListEntriesApi,
+  TemplateDetail,
   TemplateSubstitution,
 } from '@openapi';
 import { ApplicationListEntryFormService } from '@services/applications-list-entry/application-list-entry-form.service';
@@ -95,6 +96,7 @@ import { getUniqueErrors } from '@util/error-items';
 import { buildFormErrorSummary } from '@util/error-summary';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
+import { withWordingFieldValues } from '@util/template-substitution-utils';
 
 const ENTRY_CREATE_ERROR_HREFS = {
   lodgementDate: '#lodgement-date-day',
@@ -124,6 +126,9 @@ const ENTRY_CREATE_ERROR_HREFS = {
 })
 export class ApplicationsListEntryCreate implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
+  private lastWordingObjectTemplate: TemplateDetail | null | undefined;
+  private lastWordingObjectValues: TemplateSubstitution[] | null | undefined;
+  private cachedWordingObjectValues: TemplateDetail | undefined;
 
   route = inject(ActivatedRoute);
   appEntryApi = inject(ApplicationListEntriesApi);
@@ -283,6 +288,25 @@ export class ApplicationsListEntryCreate implements OnInit {
     this.forms.form.patchValue({
       wordingFields: dto.wordingFields,
     });
+  }
+
+  getWordingObjectValues(
+    template: TemplateDetail | null | undefined,
+  ): TemplateDetail | undefined {
+    const values = this.form.controls.wordingFields.value;
+
+    if (
+      this.lastWordingObjectTemplate === template &&
+      this.lastWordingObjectValues === values
+    ) {
+      return this.cachedWordingObjectValues;
+    }
+
+    this.lastWordingObjectTemplate = template;
+    this.lastWordingObjectValues = values;
+    this.cachedWordingObjectValues = withWordingFieldValues(template, values);
+
+    return this.cachedWordingObjectValues;
   }
 
   private buildErrorSummary(): ErrorItem[] {

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -96,7 +96,7 @@ import { getUniqueErrors } from '@util/error-items';
 import { buildFormErrorSummary } from '@util/error-summary';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
-import { withWordingFieldValues } from '@util/template-substitution-utils';
+import { createWordingObjectValuesResolver } from '@util/template-substitution-utils';
 
 const ENTRY_CREATE_ERROR_HREFS = {
   lodgementDate: '#lodgement-date-day',
@@ -126,9 +126,8 @@ const ENTRY_CREATE_ERROR_HREFS = {
 })
 export class ApplicationsListEntryCreate implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
-  private lastWordingObjectTemplate: TemplateDetail | null | undefined;
-  private lastWordingObjectValues: TemplateSubstitution[] | null | undefined;
-  private cachedWordingObjectValues: TemplateDetail | undefined;
+  private readonly resolveWordingObjectValues =
+    createWordingObjectValuesResolver();
 
   route = inject(ActivatedRoute);
   appEntryApi = inject(ApplicationListEntriesApi);
@@ -293,20 +292,10 @@ export class ApplicationsListEntryCreate implements OnInit {
   getWordingObjectValues(
     template: TemplateDetail | null | undefined,
   ): TemplateDetail | undefined {
-    const values = this.form.controls.wordingFields.value;
-
-    if (
-      this.lastWordingObjectTemplate === template &&
-      this.lastWordingObjectValues === values
-    ) {
-      return this.cachedWordingObjectValues;
-    }
-
-    this.lastWordingObjectTemplate = template;
-    this.lastWordingObjectValues = values;
-    this.cachedWordingObjectValues = withWordingFieldValues(template, values);
-
-    return this.cachedWordingObjectValues;
+    return this.resolveWordingObjectValues(
+      template,
+      this.form.controls.wordingFields.value,
+    );
   }
 
   private buildErrorSummary(): ErrorItem[] {

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -573,6 +573,8 @@ export class ApplicationsListEntryCreate implements OnInit {
       appCodeDetail: this.appListEntryCreateState().appCodeDetail,
       feeMeta: this.feeMeta,
       isFeeRequired: this.appListEntryCreateState().isFeeRequired,
+      bulkApplicationsAllowed:
+        this.appListEntryCreateState().bulkApplicationsAllowed,
       wordingAppliedBannerVisible: this.wordingAppliedBannerVisible(),
     };
   }
@@ -621,6 +623,7 @@ export class ApplicationsListEntryCreate implements OnInit {
     this.feeMeta = draft.feeMeta ?? null;
     this.appListEntryCreatePatch({
       isFeeRequired: draft.isFeeRequired === true,
+      bulkApplicationsAllowed: draft.bulkApplicationsAllowed === true,
     });
     this.wordingAppliedBannerVisible.set(
       draft.wordingAppliedBannerVisible === true,

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -159,6 +159,7 @@ export class ApplicationsListEntryCreate implements OnInit {
   };
 
   wordingSubmitAttempt = signal(0);
+  wordingAppliedBannerVisible = signal(false);
 
   respondentEntryTypeOptions = RESPONDENT_TYPE_OPTIONS;
   personTitleOptions = PERSON_TITLE_OPTIONS;
@@ -287,6 +288,11 @@ export class ApplicationsListEntryCreate implements OnInit {
     this.forms.form.patchValue({
       wordingFields: dto.wordingFields,
     });
+    this.wordingAppliedBannerVisible.set(true);
+  }
+
+  onWordingAppliedBannerDismissed(): void {
+    this.wordingAppliedBannerVisible.set(false);
   }
 
   getWordingObjectValues(
@@ -448,6 +454,7 @@ export class ApplicationsListEntryCreate implements OnInit {
 
               this.wordingSubmitAttempt.set(0);
               this.formSvc.resetSectionsOnApplicationCodeChange(this.forms);
+              this.wordingAppliedBannerVisible.set(false);
 
               if (hadSubmitAttempt) {
                 this.onChildErrors('wording', []);
@@ -566,6 +573,7 @@ export class ApplicationsListEntryCreate implements OnInit {
       appCodeDetail: this.appListEntryCreateState().appCodeDetail,
       feeMeta: this.feeMeta,
       isFeeRequired: this.appListEntryCreateState().isFeeRequired,
+      wordingAppliedBannerVisible: this.wordingAppliedBannerVisible(),
     };
   }
 
@@ -614,6 +622,9 @@ export class ApplicationsListEntryCreate implements OnInit {
     this.appListEntryCreatePatch({
       isFeeRequired: draft.isFeeRequired === true,
     });
+    this.wordingAppliedBannerVisible.set(
+      draft.wordingAppliedBannerVisible === true,
+    );
 
     const type = this.form.controls.applicantType.value ?? 'person';
     this.formSvc.syncApplicantTypeState(this.forms, type);

--- a/src/app/pages/applications-list-entry-create/util/applications-list-entry-create.types.ts
+++ b/src/app/pages/applications-list-entry-create/util/applications-list-entry-create.types.ts
@@ -15,6 +15,7 @@ export type EntryCreateSnapshot = {
   appCodeDetail: ApplicationCodeGetDetailDto | null;
   feeMeta: CivilFeeMeta | null;
   isFeeRequired: boolean;
+  bulkApplicationsAllowed: boolean;
   wordingAppliedBannerVisible: boolean;
 };
 

--- a/src/app/pages/applications-list-entry-create/util/applications-list-entry-create.types.ts
+++ b/src/app/pages/applications-list-entry-create/util/applications-list-entry-create.types.ts
@@ -15,6 +15,7 @@ export type EntryCreateSnapshot = {
   appCodeDetail: ApplicationCodeGetDetailDto | null;
   feeMeta: CivilFeeMeta | null;
   isFeeRequired: boolean;
+  wordingAppliedBannerVisible: boolean;
 };
 
 export type ApplicantStep = 'select' | 'person' | 'org' | 'standard';

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -67,7 +67,7 @@
       <app-wording-section
         #wordingSection
         [wordingObject]="appCodeDetail.wording"
-        [wordingObjectValues]="entryDetail?.wording!"
+        [wordingObjectValues]="getWordingObjectValues(appCodeDetail.wording)"
         [wordingSubmitAttempt]="wordingSubmitAttempt()"
         (wordingFieldsDTO)="onWordingFieldsDTO($event)"
         (wordingFieldErrors)="onChildErrors('wording', $event)"
@@ -103,6 +103,7 @@
       [feeRequired]="vm().isFeeRequired"
       [autoSaveOffsiteFee]="true"
       [parentSubmitted]="vm().formSubmitted"
+      [changePaymentReferenceStateFactory]="buildChangePaymentReferenceState"
     />
   </ng-template>
 

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -69,7 +69,9 @@
         [wordingObject]="appCodeDetail.wording"
         [wordingObjectValues]="getWordingObjectValues(appCodeDetail.wording)"
         [wordingSubmitAttempt]="wordingSubmitAttempt()"
+        [showAppliedBanner]="wordingAppliedBannerVisible()"
         (wordingFieldsDTO)="onWordingFieldsDTO($event)"
+        (appliedBannerDismissed)="onWordingAppliedBannerDismissed()"
         (wordingFieldErrors)="onChildErrors('wording', $event)"
       />
     } @else {

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -63,6 +63,7 @@ import { ApplicationCodeSearchComponent } from '@components/application-codes-se
 import {
   ApplicantContext,
   EntryDetailNavState,
+  EntryDetailSnapshot,
   PaymentRefReturn,
   readNavState,
 } from '@components/applications-list-entry-detail/util/routing-state-util';
@@ -102,6 +103,7 @@ import {
   EntryGetDetailDto,
   EntryUpdateDto,
   FeeStatus,
+  TemplateDetail,
   TemplateSubstitution,
   UpdateApplicationListEntryRequestParams,
 } from '@openapi';
@@ -136,6 +138,7 @@ import { buildFormErrorSummary } from '@util/error-summary';
 import { markFormGroupClean } from '@util/form-helpers';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
+import { withWordingFieldValues } from '@util/template-substitution-utils';
 
 type ChildErrorSource =
   | 'notes'
@@ -185,6 +188,9 @@ export class ApplicationsListEntryDetail implements OnInit {
   private readonly civilFeeSection?: CivilFeeSectionComponent;
 
   private readonly destroyRef = inject(DestroyRef);
+  private lastWordingObjectTemplate: TemplateDetail | null | undefined;
+  private lastWordingObjectValues: TemplateSubstitution[] | null | undefined;
+  private cachedWordingObjectValues: TemplateDetail | undefined;
 
   // APIs
   private readonly route = inject(ActivatedRoute);
@@ -284,7 +290,7 @@ export class ApplicationsListEntryDetail implements OnInit {
     //Civil fee feeStatus payment ref edit handling
     const pr = state?.paymentRefReturn ?? null;
     if (pr) {
-      this.clearPaymentRefReturnOnly();
+      this.clearPaymentRefNavigationStateOnly();
     }
 
     // Watch applicantType changes
@@ -311,6 +317,25 @@ export class ApplicationsListEntryDetail implements OnInit {
     this.forms.form.patchValue({
       wordingFields: dto.wordingFields,
     });
+  }
+
+  getWordingObjectValues(
+    template: TemplateDetail | null | undefined,
+  ): TemplateDetail | undefined {
+    const values = this.form.controls.wordingFields.value;
+
+    if (
+      this.lastWordingObjectTemplate === template &&
+      this.lastWordingObjectValues === values
+    ) {
+      return this.cachedWordingObjectValues;
+    }
+
+    this.lastWordingObjectTemplate = template;
+    this.lastWordingObjectValues = values;
+    this.cachedWordingObjectValues = withWordingFieldValues(template, values);
+
+    return this.cachedWordingObjectValues;
   }
 
   resetSuccessBanner(): void {
@@ -355,9 +380,9 @@ export class ApplicationsListEntryDetail implements OnInit {
     this.persistFeeStatuses(previousFeeStatuses, next, bannerText);
   }
 
-  private clearPaymentRefReturnOnly(): void {
+  private clearPaymentRefNavigationStateOnly(): void {
     const current = (history.state ?? {}) as Record<string, unknown>;
-    const { paymentRefReturn, ...rest } = current;
+    const { paymentRefReturn, entryDetailSnapshot, ...rest } = current;
     history.replaceState(rest, '');
   }
 
@@ -958,6 +983,7 @@ export class ApplicationsListEntryDetail implements OnInit {
 
           const type = this.form.controls.applicantType.value ?? 'person';
           this.formSvc.syncApplicantTypeState(this.forms, type);
+          this.applyEntryDetailSnapshot(state?.entryDetailSnapshot);
           this.handleResultWordingContext(state);
 
           if (paymentRefReturn) {
@@ -968,10 +994,87 @@ export class ApplicationsListEntryDetail implements OnInit {
           }
 
           this.resultsFacade.loadEntryResults(listId, entryId);
-          this.loadCodesSectionFromEntry(entry);
+
+          if (state?.entryDetailSnapshot) {
+            this.appListEntryDetailPatch({
+              formReady: true,
+            });
+          } else {
+            this.loadCodesSectionFromEntry(entry);
+          }
         },
         error: (err) => this.handleFatalLoadError(err),
       });
+  }
+
+  buildChangePaymentReferenceState = (): Record<string, unknown> => ({
+    entryDetailSnapshot: this.buildEntryDetailSnapshot(),
+  });
+
+  private buildEntryDetailSnapshot(): EntryDetailSnapshot {
+    return {
+      form: this.form.getRawValue(),
+      personForm: this.personForm.getRawValue(),
+      organisationForm: this.organisationForm.getRawValue(),
+      respondentPersonForm: this.forms.respondentPersonForm.getRawValue(),
+      respondentOrganisationForm:
+        this.forms.respondentOrganisationForm.getRawValue(),
+      appCodeDetail: this.appListEntryDetailState().appCodeDetail,
+      feeMeta: this.feeMeta,
+      isFeeRequired: this.appListEntryDetailState().isFeeRequired,
+      bulkApplicationsAllowed:
+        this.appListEntryDetailState().bulkApplicationsAllowed,
+    };
+  }
+
+  private applyEntryDetailSnapshot(
+    state: EntryDetailSnapshot | undefined,
+  ): void {
+    if (!state) {
+      return;
+    }
+
+    if (state.form) {
+      this.form.patchValue(state.form, { emitEvent: false });
+    }
+    if (state.personForm) {
+      this.personForm.patchValue(state.personForm, { emitEvent: false });
+    }
+    if (state.organisationForm) {
+      this.organisationForm.patchValue(state.organisationForm, {
+        emitEvent: false,
+      });
+    }
+    if (state.respondentPersonForm) {
+      this.forms.respondentPersonForm.patchValue(state.respondentPersonForm, {
+        emitEvent: false,
+      });
+    }
+    if (state.respondentOrganisationForm) {
+      this.forms.respondentOrganisationForm.patchValue(
+        state.respondentOrganisationForm,
+        {
+          emitEvent: false,
+        },
+      );
+    }
+
+    this.feeMeta = state.feeMeta ?? this.feeMeta;
+    this.appListEntryDetailPatch({
+      appCodeDetail:
+        state.appCodeDetail ?? this.appListEntryDetailState().appCodeDetail,
+      isFeeRequired:
+        state.isFeeRequired ?? this.appListEntryDetailState().isFeeRequired,
+      bulkApplicationsAllowed:
+        state.bulkApplicationsAllowed ??
+        this.appListEntryDetailState().bulkApplicationsAllowed,
+    });
+
+    this.selectedStandardApplicantCode =
+      this.form.controls.standardApplicantCode.value;
+
+    const type = this.form.controls.applicantType.value ?? 'person';
+    this.formSvc.syncApplicantTypeState(this.forms, type);
   }
 
   private handleListCreate(): void {
@@ -1018,8 +1121,15 @@ export class ApplicationsListEntryDetail implements OnInit {
 
     if (wordingFields) {
       patch.wordingFields = wordingFields.map((field) => field.value);
+      if (this.entryDetail?.wording) {
+        patch.wording = withWordingFieldValues(
+          this.entryDetail.wording,
+          wordingFields,
+        );
+      }
     } else {
       patch.wordingFields = this.getLegacyWordingFields(this.entryDetail);
+      patch.wording = this.entryDetail?.wording;
     }
 
     return patch;

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -138,7 +138,10 @@ import { buildFormErrorSummary } from '@util/error-summary';
 import { markFormGroupClean } from '@util/form-helpers';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
-import { withWordingFieldValues } from '@util/template-substitution-utils';
+import {
+  createWordingObjectValuesResolver,
+  withWordingFieldValues,
+} from '@util/template-substitution-utils';
 
 type ChildErrorSource =
   | 'notes'
@@ -188,9 +191,8 @@ export class ApplicationsListEntryDetail implements OnInit {
   private readonly civilFeeSection?: CivilFeeSectionComponent;
 
   private readonly destroyRef = inject(DestroyRef);
-  private lastWordingObjectTemplate: TemplateDetail | null | undefined;
-  private lastWordingObjectValues: TemplateSubstitution[] | null | undefined;
-  private cachedWordingObjectValues: TemplateDetail | undefined;
+  private readonly resolveWordingObjectValues =
+    createWordingObjectValuesResolver();
 
   // APIs
   private readonly route = inject(ActivatedRoute);
@@ -322,20 +324,10 @@ export class ApplicationsListEntryDetail implements OnInit {
   getWordingObjectValues(
     template: TemplateDetail | null | undefined,
   ): TemplateDetail | undefined {
-    const values = this.form.controls.wordingFields.value;
-
-    if (
-      this.lastWordingObjectTemplate === template &&
-      this.lastWordingObjectValues === values
-    ) {
-      return this.cachedWordingObjectValues;
-    }
-
-    this.lastWordingObjectTemplate = template;
-    this.lastWordingObjectValues = values;
-    this.cachedWordingObjectValues = withWordingFieldValues(template, values);
-
-    return this.cachedWordingObjectValues;
+    return this.resolveWordingObjectValues(
+      template,
+      this.form.controls.wordingFields.value,
+    );
   }
 
   resetSuccessBanner(): void {

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -246,6 +246,7 @@ export class ApplicationsListEntryDetail implements OnInit {
   };
 
   wordingSubmitAttempt = signal(0);
+  wordingAppliedBannerVisible = signal(false);
 
   // View constants (from helpers)
   applicantColumns: TableColumn[] = APPLICANT_COLUMNS;
@@ -319,6 +320,11 @@ export class ApplicationsListEntryDetail implements OnInit {
     this.forms.form.patchValue({
       wordingFields: dto.wordingFields,
     });
+    this.wordingAppliedBannerVisible.set(true);
+  }
+
+  onWordingAppliedBannerDismissed(): void {
+    this.wordingAppliedBannerVisible.set(false);
   }
 
   getWordingObjectValues(
@@ -478,6 +484,7 @@ export class ApplicationsListEntryDetail implements OnInit {
               this.formSvc.resetSectionsOnApplicationCodeChange(this.forms);
 
               this.wordingSubmitAttempt.set(0);
+              this.wordingAppliedBannerVisible.set(false);
               this.entryDetail!.wording = undefined;
             }
 
@@ -1016,6 +1023,7 @@ export class ApplicationsListEntryDetail implements OnInit {
       isFeeRequired: this.appListEntryDetailState().isFeeRequired,
       bulkApplicationsAllowed:
         this.appListEntryDetailState().bulkApplicationsAllowed,
+      wordingAppliedBannerVisible: this.wordingAppliedBannerVisible(),
     };
   }
 
@@ -1061,6 +1069,9 @@ export class ApplicationsListEntryDetail implements OnInit {
         state.bulkApplicationsAllowed ??
         this.appListEntryDetailState().bulkApplicationsAllowed,
     });
+    this.wordingAppliedBannerVisible.set(
+      state.wordingAppliedBannerVisible === true,
+    );
 
     this.selectedStandardApplicantCode =
       this.form.controls.standardApplicantCode.value;

--- a/src/app/pages/applications-list-entry-detail/util/routing-state-util.ts
+++ b/src/app/pages/applications-list-entry-detail/util/routing-state-util.ts
@@ -2,10 +2,12 @@ import { Location, isPlatformBrowser } from '@angular/common';
 import { FormGroup } from '@angular/forms';
 
 import {
+  ApplicationCodeGetDetailDto,
   ApplicationListGetDetailDto,
   ApplicationListGetSummaryDto,
   ApplicationListStatus,
 } from '@openapi';
+import { CivilFeeMeta } from '@shared-types/civil-fee/civil-fee';
 import { hasStringProp, isRecord } from '@util/data-utils';
 import { has } from '@util/has';
 import { isNullableString } from '@util/string-helpers';
@@ -28,10 +30,23 @@ export type PaymentRefReturn = {
   newPaymentReference: string;
 };
 
+export type EntryDetailSnapshot = {
+  form?: unknown;
+  personForm?: unknown;
+  organisationForm?: unknown;
+  respondentPersonForm?: unknown;
+  respondentOrganisationForm?: unknown;
+  appCodeDetail?: ApplicationCodeGetDetailDto | null;
+  feeMeta?: CivilFeeMeta | null;
+  isFeeRequired?: boolean;
+  bulkApplicationsAllowed?: boolean;
+};
+
 export type EntryDetailNavState = {
   appListId?: string;
   resultApplicantContext?: ApplicantContext;
   paymentRefReturn?: PaymentRefReturn;
+  entryDetailSnapshot?: EntryDetailSnapshot;
 };
 
 function isApplicantContext(x: unknown): boolean {

--- a/src/app/pages/applications-list-entry-detail/util/routing-state-util.ts
+++ b/src/app/pages/applications-list-entry-detail/util/routing-state-util.ts
@@ -40,6 +40,7 @@ export type EntryDetailSnapshot = {
   feeMeta?: CivilFeeMeta | null;
   isFeeRequired?: boolean;
   bulkApplicationsAllowed?: boolean;
+  wordingAppliedBannerVisible?: boolean;
 };
 
 export type EntryDetailNavState = {

--- a/src/app/shared/components/civil-fee-section/civil-fee-section.component.html
+++ b/src/app/shared/components/civil-fee-section/civil-fee-section.component.html
@@ -88,6 +88,7 @@
       id="feeStatusDate"
       [submitted]="showErrors()"
       [disallowFutureDates]="true"
+      containerWidthClass="govuk-grid-column-one-quarter"
     />
 
     <!-- Payment reference -->

--- a/src/app/shared/components/wording-section/wording-section.component.html
+++ b/src/app/shared/components/wording-section/wording-section.component.html
@@ -1,8 +1,9 @@
-@if (saveSuccessful()) {
+@if (showAppliedBanner()) {
   <app-alert
     alertType="success"
     message="Wording applied to this entry. Save the entry to keep these changes."
     [allowDismiss]="true"
+    (alertDismissed)="onAppliedBannerDismissed()"
   />
 }
 

--- a/src/app/shared/components/wording-section/wording-section.component.ts
+++ b/src/app/shared/components/wording-section/wording-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, input, output, signal } from '@angular/core';
+import { Component, ViewChild, input, output } from '@angular/core';
 
 import { AlertComponent } from '@components/alert/alert.component';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
@@ -17,23 +17,25 @@ export class WordingSectionComponent {
   @ViewChild(WordingParserComponent)
   private readonly wordingParser?: WordingParserComponent;
 
-  saveSuccessful = signal(false);
-
   wordingObject = input.required<TemplateDetail>();
   wordingObjectValues = input<TemplateDetail>();
   wordingSubmitAttempt = input.required<number>();
+  showAppliedBanner = input(false);
 
   wordingFieldErrors = output<ErrorItem[]>();
   wordingFieldsDTO = output<{ wordingFields: TemplateSubstitution[] }>();
+  appliedBannerDismissed = output<void>();
 
   onWordingFieldsDTO(dto: { wordingFields: TemplateSubstitution[] }): void {
     this.wordingFieldsDTO.emit(dto);
-    this.saveSuccessful.set(true);
   }
 
   onWordingFieldErrors(errors: ErrorItem[]): void {
     this.wordingFieldErrors.emit(errors);
-    this.saveSuccessful.set(false);
+  }
+
+  onAppliedBannerDismissed(): void {
+    this.appliedBannerDismissed.emit();
   }
 
   validateForSubmit(opts?: WordingValidationOptions): ErrorItem[] {

--- a/src/app/shared/util/template-substitution-utils.ts
+++ b/src/app/shared/util/template-substitution-utils.ts
@@ -1,5 +1,6 @@
 import {
   EntryGetDetailDto,
+  TemplateDetail,
   TemplateKeyWithConstraint,
   TemplateSubstitution,
 } from '@openapi';
@@ -66,4 +67,35 @@ export function getEntryWordingFields(
         typeof item.key === 'string' && typeof item.value === 'string',
     )
     .map(({ key, value }) => ({ key, value }));
+}
+
+export function withWordingFieldValues(
+  template: TemplateDetail | null | undefined,
+  values: TemplateSubstitution[] | null | undefined,
+): TemplateDetail | undefined {
+  if (!template) {
+    return undefined;
+  }
+
+  const valueByKey = new Map(
+    (values ?? [])
+      .filter(
+        (item): item is TemplateSubstitution & { key: string } =>
+          typeof item?.key === 'string',
+      )
+      .map((item) => [item.key, item.value ?? '']),
+  );
+
+  return {
+    ...template,
+    'substitution-key-constraints': (
+      template['substitution-key-constraints'] ?? []
+    ).map((item) => ({
+      ...item,
+      value:
+        typeof item.key === 'string' && valueByKey.has(item.key)
+          ? (valueByKey.get(item.key) ?? '')
+          : item.value,
+    })),
+  };
 }

--- a/src/app/shared/util/template-substitution-utils.ts
+++ b/src/app/shared/util/template-substitution-utils.ts
@@ -99,3 +99,27 @@ export function withWordingFieldValues(
     })),
   };
 }
+
+export function createWordingObjectValuesResolver(): (
+  template: TemplateDetail | null | undefined,
+  values: TemplateSubstitution[] | null | undefined,
+) => TemplateDetail | undefined {
+  let previousTemplate: TemplateDetail | null | undefined;
+  let previousValues: TemplateSubstitution[] | null | undefined;
+  let previousResolved: TemplateDetail | undefined;
+
+  return (
+    template: TemplateDetail | null | undefined,
+    values: TemplateSubstitution[] | null | undefined,
+  ): TemplateDetail | undefined => {
+    if (previousTemplate === template && previousValues === values) {
+      return previousResolved;
+    }
+
+    previousTemplate = template;
+    previousValues = values;
+    previousResolved = withWordingFieldValues(template, values);
+
+    return previousResolved;
+  };
+}

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -545,7 +545,12 @@ describe('ApplicationsListEntryCreate (payment reference return)', () => {
     const appCodeDetail = {
       applicationCode: 'APP-1',
       title: 'Title',
-      wording: { template: 'Template' },
+      wording: {
+        template: 'At {{Court}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: '', constraint: { length: 20 } },
+        ],
+      },
       requiresRespondent: false,
       bulkRespondentAllowed: false,
     } as unknown as ApplicationCodeGetDetailDto;
@@ -556,6 +561,7 @@ describe('ApplicationsListEntryCreate (payment reference return)', () => {
           applicantType: 'person',
           applicationCode: 'APP-1',
           lodgementDate: '2026-01-10',
+          wordingFields: [{ key: 'Court', value: 'Court A' }],
           feeStatuses: [
             {
               paymentStatus: 'Paid',
@@ -595,6 +601,12 @@ describe('ApplicationsListEntryCreate (payment reference return)', () => {
     expect(component.vm().appCodeDetail?.applicationCode).toBe('APP-1');
     expect(component.vm().isFeeRequired).toBe(true);
     expect(component.feeMeta?.feeReference).toBe('CO9.2');
+    expect(component.getWordingObjectValues(appCodeDetail.wording)).toEqual({
+      template: 'At {{Court}}',
+      'substitution-key-constraints': [
+        { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+      ],
+    });
 
     expect(updatePaymentReferenceInFeeStatusesControlSpy).toHaveBeenCalledWith(
       component.form.controls.feeStatuses,

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -581,6 +581,7 @@ describe('ApplicationsListEntryCreate (payment reference return)', () => {
           offsiteFeeAmount: null,
         },
         isFeeRequired: true,
+        bulkApplicationsAllowed: true,
       },
       paymentRefReturn: {
         updatedRowId: 'Paid|2026-01-10',
@@ -600,6 +601,7 @@ describe('ApplicationsListEntryCreate (payment reference return)', () => {
     );
     expect(component.vm().appCodeDetail?.applicationCode).toBe('APP-1');
     expect(component.vm().isFeeRequired).toBe(true);
+    expect(component.vm().bulkApplicationsAllowed).toBe(true);
     expect(component.feeMeta?.feeReference).toBe('CO9.2');
     expect(component.getWordingObjectValues(appCodeDetail.wording)).toEqual({
       template: 'At {{Court}}',

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -19,6 +19,7 @@ import {
   buildOfficialsFromFormValue,
   officialsToFormPatch,
 } from '@components/applications-list-entry-detail/util/entry-detail.form';
+import * as routingStateUtil from '@components/applications-list-entry-detail/util/routing-state-util';
 import {
   ApplicationCodeGetDetailDto,
   ApplicationCodePage,
@@ -677,10 +678,11 @@ describe('ApplicationsListEntryDetail', () => {
     ).toBe('The application list entry has been created successfully.');
   });
 
-  it('clearPaymentRefReturnOnly removes paymentRefReturn from history.state and preserves other keys', () => {
+  it('clearPaymentRefNavigationStateOnly removes payment reference nav state and preserves other keys', () => {
     history.replaceState(
       {
         paymentRefReturn: { updatedRowId: 'ROW-1', newPaymentReference: 'REF' },
+        entryDetailSnapshot: { form: { wordingFields: [] } },
         keep: 'KEEP_ME',
       },
       '',
@@ -689,15 +691,102 @@ describe('ApplicationsListEntryDetail', () => {
     const replaceSpy = jest.spyOn(history, 'replaceState');
 
     const subject = component as unknown as {
-      clearPaymentRefReturnOnly: () => void;
+      clearPaymentRefNavigationStateOnly: () => void;
     };
 
-    subject.clearPaymentRefReturnOnly();
+    subject.clearPaymentRefNavigationStateOnly();
 
     expect(replaceSpy).toHaveBeenCalledTimes(1);
     expect(replaceSpy).toHaveBeenCalledWith({ keep: 'KEEP_ME' }, '');
 
     replaceSpy.mockRestore();
+  });
+
+  it('restores staged snapshot before applying payment reference update', () => {
+    const readNavStateSpy = jest
+      .spyOn(routingStateUtil, 'readNavState')
+      .mockReturnValue({
+        entryDetailSnapshot: {
+          form: {
+            applicantType: 'person',
+            applicationCode: 'APP-200',
+            lodgementDate: '2025-11-01',
+            wordingFields: [
+              { key: 'Court', value: 'New Court' },
+              { key: 'Date', value: '2026-04-14' },
+            ],
+            feeStatuses: [
+              {
+                paymentStatus: 'Paid',
+                statusDate: '2025-11-01',
+                paymentReference: 'OLD',
+              },
+            ],
+          },
+          personForm: { firstName: 'Jane', surname: 'Doe' },
+          organisationForm: { name: '' },
+          respondentPersonForm: { firstName: '', surname: '' },
+          respondentOrganisationForm: { name: '' },
+          appCodeDetail: {
+            applicationCode: 'APP-200',
+            title: 'Staged title',
+            wording: {
+              template: 'At {{Court}} for {{Date}}',
+              'substitution-key-constraints': [
+                {
+                  key: 'Court',
+                  value: '',
+                  constraint: { length: 20 },
+                },
+                {
+                  key: 'Date',
+                  value: '',
+                  constraint: { length: 10 },
+                },
+              ],
+            },
+            bulkRespondentAllowed: false,
+            isFeeDue: false,
+            requiresRespondent: false,
+            feeReference: undefined,
+            startDate: '2025-01-01',
+            endDate: null,
+          },
+          feeMeta: null,
+          isFeeRequired: false,
+          bulkApplicationsAllowed: false,
+        },
+        paymentRefReturn: {
+          updatedRowId: 'Paid|2025-11-01',
+          newPaymentReference: 'NEW',
+        },
+      });
+
+    mockUpdateApplicationListEntry.mockClear();
+
+    const freshFixture = TestBed.createComponent(ApplicationsListEntryDetail);
+    const freshComponent = freshFixture.componentInstance;
+    freshFixture.detectChanges();
+
+    expect(freshComponent['form'].controls.wordingFields.value).toEqual([
+      { key: 'Court', value: 'New Court' },
+      { key: 'Date', value: '2026-04-14' },
+    ]);
+
+    expect(mockUpdateApplicationListEntry).toHaveBeenCalled();
+    expect(
+      mockUpdateApplicationListEntry.mock.calls[0][0].entryUpdateDto
+        .wordingFields,
+    ).toEqual([
+      { key: 'Court', value: 'New Court' },
+      { key: 'Date', value: '2026-04-14' },
+    ]);
+    expect(
+      mockUpdateApplicationListEntry.mock.calls[0][0].entryUpdateDto
+        .applicationCode,
+    ).toBe('APP-200');
+
+    readNavStateSpy.mockRestore();
   });
 
   it('persistFeeStatus does not call update API when fee details are added but entryDetail is missing', () => {
@@ -958,6 +1047,20 @@ describe('ApplicationsListEntryDetail', () => {
   });
 
   it('toEntryDetailPatch maps wordingFields to values and preserves other fields', () => {
+    component['entryDetail'] = {
+      wording: {
+        template: 'At {{courtName}} for {{organisationName}}',
+        'substitution-key-constraints': [
+          { key: 'courtName', value: 'Old Court', constraint: { length: 20 } },
+          {
+            key: 'organisationName',
+            value: 'Old Org',
+            constraint: { length: 20 },
+          },
+        ],
+      },
+    } as EntryGetDetailDto;
+
     const entryUpdateDto = {
       applicationCode: 'APP-200',
       lodgementDate: '2026-01-01',
@@ -980,8 +1083,46 @@ describe('ApplicationsListEntryDetail', () => {
         applicationCode: 'APP-200',
         lodgementDate: '2026-01-01',
         wordingFields: ['Court A', 'Org B'],
+        wording: {
+          template: 'At {{courtName}} for {{organisationName}}',
+          'substitution-key-constraints': [
+            {
+              key: 'courtName',
+              value: 'Court A',
+              constraint: { length: 20 },
+            },
+            {
+              key: 'organisationName',
+              value: 'Org B',
+              constraint: { length: 20 },
+            },
+          ],
+        },
       }),
     );
+  });
+
+  it('getWordingObjectValues prefers staged form wording over entry detail wording', () => {
+    component['form'].controls.wordingFields.setValue([
+      { key: 'Court', value: 'Court B' },
+      { key: 'Date', value: '2026-05-01' },
+    ]);
+
+    expect(
+      component.getWordingObjectValues({
+        template: 'At {{Court}} for {{Date}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+          { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+        ],
+      }),
+    ).toEqual({
+      template: 'At {{Court}} for {{Date}}',
+      'substitution-key-constraints': [
+        { key: 'Court', value: 'Court B', constraint: { length: 20 } },
+        { key: 'Date', value: '2026-05-01', constraint: { length: 10 } },
+      ],
+    });
   });
 
   it('mergeEntryDetailUpdate applies patch and lets response override', () => {

--- a/test/unit/app/shared/components/wording-section/wording-section.component.spec.ts
+++ b/test/unit/app/shared/components/wording-section/wording-section.component.spec.ts
@@ -58,18 +58,28 @@ describe('WordingSectionComponent', () => {
     expect(component.validateForSubmit()).toEqual(expectedErrors);
   });
 
-  it('onWordingFieldsDTO sets saveSuccessful() to true', () => {
+  it('onWordingFieldsDTO emits without mutating local banner state', () => {
+    fixture.componentRef.setInput('showAppliedBanner', false);
     const dto = {
       wordingFields: [{ key: 'a', value: 'b' }] as TemplateSubstitution[],
     };
 
     component.onWordingFieldsDTO(dto);
-    expect(component.saveSuccessful()).toEqual(true);
+    expect(component.showAppliedBanner()).toBe(false);
   });
 
-  it('onWordingFieldErrors sets saveSuccessful() to false', () => {
+  it('onWordingFieldErrors emits without mutating local banner state', () => {
+    fixture.componentRef.setInput('showAppliedBanner', true);
     const errors: ErrorItem[] = [{ text: 'some error' }];
     component.onWordingFieldErrors(errors);
-    expect(component.saveSuccessful()).toEqual(false);
+    expect(component.showAppliedBanner()).toBe(true);
+  });
+
+  it('onAppliedBannerDismissed emits via appliedBannerDismissed output', () => {
+    const spy = jest.spyOn(component.appliedBannerDismissed, 'emit');
+
+    component.onAppliedBannerDismissed();
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/app/shared/util/template-substitution-utils.spec.ts
+++ b/test/unit/app/shared/util/template-substitution-utils.spec.ts
@@ -1,5 +1,6 @@
 import { EntryGetDetailDto, TemplateSubstitution } from '@openapi';
 import {
+  createWordingObjectValuesResolver,
   getEntryWordingFields,
   isTemplateSubstitution,
   toTemplateSubstitutions,
@@ -143,6 +144,85 @@ describe('template-substitution-utils', () => {
 
     it('returns undefined when there is no template detail', () => {
       expect(withWordingFieldValues(undefined, [])).toBeUndefined();
+    });
+  });
+
+  describe('createWordingObjectValuesResolver', () => {
+    it('resolves wording object values on first call', () => {
+      const resolve = createWordingObjectValuesResolver();
+      const template = {
+        template: 'At {{Court}} for {{Date}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+          { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+        ],
+      };
+      const values = [{ key: 'Court', value: 'Court B' }];
+
+      expect(resolve(template, values)).toEqual({
+        template: 'At {{Court}} for {{Date}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court B', constraint: { length: 20 } },
+          { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+        ],
+      });
+    });
+
+    it('returns the same object instance when inputs are unchanged', () => {
+      const resolve = createWordingObjectValuesResolver();
+      const template = {
+        template: 'At {{Court}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+        ],
+      };
+      const values = [{ key: 'Court', value: 'Court B' }];
+
+      const first = resolve(template, values);
+      const second = resolve(template, values);
+
+      expect(first).toBe(second);
+    });
+
+    it('returns a new object when the template reference changes', () => {
+      const resolve = createWordingObjectValuesResolver();
+      const values = [{ key: 'Court', value: 'Court B' }];
+
+      const first = resolve(
+        {
+          template: 'At {{Court}}',
+          'substitution-key-constraints': [
+            { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+          ],
+        },
+        values,
+      );
+      const second = resolve(
+        {
+          template: 'At {{Court}}',
+          'substitution-key-constraints': [
+            { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+          ],
+        },
+        values,
+      );
+
+      expect(first).not.toBe(second);
+    });
+
+    it('returns a new object when the values reference changes', () => {
+      const resolve = createWordingObjectValuesResolver();
+      const template = {
+        template: 'At {{Court}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+        ],
+      };
+
+      const first = resolve(template, [{ key: 'Court', value: 'Court B' }]);
+      const second = resolve(template, [{ key: 'Court', value: 'Court B' }]);
+
+      expect(first).not.toBe(second);
     });
   });
 });

--- a/test/unit/app/shared/util/template-substitution-utils.spec.ts
+++ b/test/unit/app/shared/util/template-substitution-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   isTemplateSubstitution,
   toTemplateSubstitutions,
   toWordingValues,
+  withWordingFieldValues,
   wordingFromFields,
 } from '@util/template-substitution-utils';
 
@@ -115,6 +116,33 @@ describe('template-substitution-utils', () => {
 
     it('returns undefined when entry has no wording', () => {
       expect(getEntryWordingFields({} as EntryGetDetailDto)).toBeUndefined();
+    });
+  });
+
+  describe('withWordingFieldValues', () => {
+    it('overlays staged wording values onto a template detail', () => {
+      expect(
+        withWordingFieldValues(
+          {
+            template: 'At {{Court}} for {{Date}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+              { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+            ],
+          },
+          [{ key: 'Court', value: 'Court B' }],
+        ),
+      ).toEqual({
+        template: 'At {{Court}} for {{Date}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court B', constraint: { length: 20 } },
+          { key: 'Date', value: '2026-04-13', constraint: { length: 10 } },
+        ],
+      });
+    });
+
+    it('returns undefined when there is no template detail', () => {
+      expect(withWordingFieldValues(undefined, [])).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1307

### Change description

High-level PR list:
- Preserve staged entry-detail form state across the Change Payment Reference route so applied wording is not lost on return.
- Restore the update-entry snapshot before applying the payment-reference partial save, allowing fee-only updates to keep staged `wordingFields`.
- Rehydrate wording inputs from staged applied values without changing the existing “must click Apply wording” validation behavior.
- Add unit coverage for wording rehydration and update-entry payment-reference return flow.
- Added dynamic width class to date input
- Display state of wording section applied banner is now controlled in entry update/create parents, now banner persists from return navigation of change payment reference screen unless user dismisses.

### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
