### PR TITLE
ARCPOC-1312 allow same status and same status date to be added to civil fee

### DIFF
--- a/src/app/shared/components/civil-fee-section/civil-fee-section.component.ts
+++ b/src/app/shared/components/civil-fee-section/civil-fee-section.component.ts
@@ -248,7 +248,7 @@ export class CivilFeeSectionComponent implements OnInit {
     const rows = this.feeForm().controls.feeStatuses.value ?? [];
 
     return rows.map((fs, index) => ({
-      rowId: feeStatusRowId(fs),
+      rowId: feeStatusRowId(fs, index),
       paymentReference: fs.paymentReference ?? '',
       paymentStatus: fs.paymentStatus,
       statusDateRaw: fs.statusDate,

--- a/src/app/shared/util/civil-fee-utils.ts
+++ b/src/app/shared/util/civil-fee-utils.ts
@@ -63,33 +63,14 @@ export function toFeeStatus(payload: {
 }
 
 /**
- * If a row with same paymentStatus|statusDate exists, replace it.
- * Otherwise append.
+ * Legacy behavior appends every fee status entry, even when the
+ * paymentStatus and statusDate match an existing row.
  */
-export function addOrReplaceFeeStatus(
+export function addFeeStatus(
   current: FeeStatus[],
   nextItem: FeeStatus,
 ): { next: FeeStatus[]; changed: boolean } {
-  const id = feeStatusRowId(nextItem);
-
-  const idx = current.findIndex((fs) => feeStatusRowId(fs) === id);
-  if (idx === -1) {
-    return { next: [...current, nextItem], changed: true };
-  }
-
-  const existing = current[idx];
-  const same =
-    existing.paymentStatus === nextItem.paymentStatus &&
-    existing.statusDate === nextItem.statusDate &&
-    (existing.paymentReference ?? '') === (nextItem.paymentReference ?? '');
-
-  if (same) {
-    return { next: current, changed: false };
-  }
-
-  const copy = current.slice();
-  copy[idx] = { ...existing, ...nextItem };
-  return { next: copy, changed: true };
+  return { next: [...current, nextItem], changed: true };
 }
 
 /**
@@ -125,8 +106,10 @@ export function buildCivilFeeHeading(
 
 export function feeStatusRowId(
   fs: Pick<FeeStatus, 'paymentStatus' | 'statusDate'>,
+  index?: number,
 ): string {
-  return `${fs.paymentStatus}|${fs.statusDate}`;
+  const baseId = `${fs.paymentStatus}|${fs.statusDate}`;
+  return typeof index === 'number' ? `${baseId}|${index}` : baseId;
 }
 
 export function readPaymentRefReturnState(state: unknown): {
@@ -164,8 +147,8 @@ export function applyPaymentReferenceUpdateToFeeStatuses(
 ): { next: FeeStatus[]; changed: boolean } {
   let changed = false;
 
-  const next = current.map((fs) => {
-    if (feeStatusRowId(fs) !== updatedRowId) {
+  const next = current.map((fs, index) => {
+    if (feeStatusRowId(fs, index) !== updatedRowId) {
       return fs;
     }
 
@@ -191,10 +174,7 @@ export function updateFeeStatusesControl(
   const current = feeStatusesCtrl.value ?? [];
   const nextItem = toFeeStatus(payload);
 
-  const { next, changed } = addOrReplaceFeeStatus(current, nextItem);
-  if (!changed) {
-    return { next, changed };
-  }
+  const { next, changed } = addFeeStatus(current, nextItem);
 
   feeStatusesCtrl.setValue(next);
   feeStatusesCtrl.markAsDirty();

--- a/test/unit/app/shared/components/civil-fee-section/civil-fee-section.component.spec.ts
+++ b/test/unit/app/shared/components/civil-fee-section/civil-fee-section.component.spec.ts
@@ -14,7 +14,8 @@ import { FeeStatus } from '@openapi';
 jest.mock('@util/civil-fee-utils', () => ({
   buildCivilFeeHeading: jest.fn(() => 'MOCK_HEADING'),
   feeStatusRowId: jest.fn(
-    (fs: FeeStatus) => `row-${fs.paymentStatus}-${fs.statusDate}`,
+    (fs: FeeStatus, index?: number) =>
+      `row-${fs.paymentStatus}-${fs.statusDate}-${index ?? 'none'}`,
   ),
 }));
 
@@ -303,14 +304,14 @@ describe('CivilFeeSectionComponent', () => {
 
     expect(rows).toEqual([
       {
-        rowId: 'row-paid-2025-10-25',
+        rowId: 'row-paid-2025-10-25-0',
         paymentReference: 'REF1',
         paymentStatus: 'paid',
         statusDateRaw: '2025-10-25',
         isLast: false,
       },
       {
-        rowId: 'row-exempt-2025-01-02',
+        rowId: 'row-exempt-2025-01-02-1',
         paymentReference: '',
         paymentStatus: 'exempt',
         statusDateRaw: '2025-01-02',

--- a/test/unit/app/shared/util/civil-fee-utils.spec.ts
+++ b/test/unit/app/shared/util/civil-fee-utils.spec.ts
@@ -14,7 +14,7 @@ import {
   PaymentRefReturnState,
 } from '@shared-types/civil-fee/civil-fee';
 import {
-  addOrReplaceFeeStatus,
+  addFeeStatus,
   applyPaymentReferenceUpdateToFeeStatuses,
   buildCivilFeeHeading,
   feeStatusRowId,
@@ -78,10 +78,22 @@ describe('feeStatusRowId', () => {
 
     expect(rowId).toBe(`${PaymentStatus.REMITTED}|2026-01-01`);
   });
+
+  it('includes the row index when provided', () => {
+    const rowId = feeStatusRowId(
+      {
+        paymentStatus: PaymentStatus.REMITTED,
+        statusDate: '2026-01-01',
+      },
+      3,
+    );
+
+    expect(rowId).toBe(`${PaymentStatus.REMITTED}|2026-01-01|3`);
+  });
 });
 
-describe('addOrReplaceFeeStatus', () => {
-  it("appends when row id doesn't exist", () => {
+describe('addFeeStatus', () => {
+  it('appends a new row', () => {
     const current: FeeStatus[] = [
       mkFeeStatus({
         paymentStatus: PaymentStatus.PAID,
@@ -96,40 +108,19 @@ describe('addOrReplaceFeeStatus', () => {
       paymentReference: 'NEW',
     });
 
-    const { next, changed } = addOrReplaceFeeStatus(current, nextItem);
+    const { next, changed } = addFeeStatus(current, nextItem);
 
     expect(changed).toBe(true);
     expect(next).toEqual([...current, nextItem]);
     expect(next).not.toBe(current);
   });
 
-  it('returns unchanged when same row exists and values are identical', () => {
+  it('still appends when paymentStatus and statusDate match an existing row', () => {
     const current: FeeStatus[] = [
       mkFeeStatus({
         paymentStatus: PaymentStatus.PAID,
         statusDate: '2026-01-10',
         paymentReference: undefined,
-      }),
-    ];
-
-    const nextItem = mkFeeStatus({
-      paymentStatus: PaymentStatus.PAID,
-      statusDate: '2026-01-10',
-      paymentReference: undefined,
-    });
-
-    const res = addOrReplaceFeeStatus(current, nextItem);
-
-    expect(res.changed).toBe(false);
-    expect(res.next).toBe(current); // same reference when unchanged
-  });
-
-  it('replaces when same row exists but paymentReference differs', () => {
-    const current: FeeStatus[] = [
-      mkFeeStatus({
-        paymentStatus: PaymentStatus.PAID,
-        statusDate: '2026-01-10',
-        paymentReference: 'REF1',
       }),
     ];
 
@@ -139,32 +130,11 @@ describe('addOrReplaceFeeStatus', () => {
       paymentReference: 'REF2',
     });
 
-    const { next, changed } = addOrReplaceFeeStatus(current, nextItem);
+    const { next, changed } = addFeeStatus(current, nextItem);
 
     expect(changed).toBe(true);
     expect(next).not.toBe(current);
-    expect(next).toEqual([nextItem]);
-  });
-
-  it('treats undefined and empty string paymentReference as equivalent for equality check', () => {
-    const current: FeeStatus[] = [
-      mkFeeStatus({
-        paymentStatus: PaymentStatus.PAID,
-        statusDate: '2026-01-10',
-        paymentReference: undefined,
-      }),
-    ];
-
-    const nextItem = mkFeeStatus({
-      paymentStatus: PaymentStatus.PAID,
-      statusDate: '2026-01-10',
-      paymentReference: '',
-    });
-
-    const res = addOrReplaceFeeStatus(current, nextItem);
-
-    expect(res.changed).toBe(false);
-    expect(res.next).toBe(current);
+    expect(next).toEqual([...current, nextItem]);
   });
 });
 
@@ -313,7 +283,7 @@ describe('applyPaymentReferenceUpdateToFeeStatuses', () => {
 
     const { next, changed } = applyPaymentReferenceUpdateToFeeStatuses(
       current,
-      `${PaymentStatus.PAID}|2026-01-10`,
+      `${PaymentStatus.PAID}|2026-01-10|0`,
       'REF1',
     );
 
@@ -337,13 +307,38 @@ describe('applyPaymentReferenceUpdateToFeeStatuses', () => {
 
     const { next, changed } = applyPaymentReferenceUpdateToFeeStatuses(
       current,
-      `${PaymentStatus.PAID}|2026-01-10`,
+      `${PaymentStatus.PAID}|2026-01-10|0`,
       'NEW',
     );
 
     expect(changed).toBe(true);
     expect(next[0].paymentReference).toBe('NEW');
     expect(next[1]).toEqual(current[1]);
+  });
+
+  it('only updates the indexed matching row when duplicate status/date rows exist', () => {
+    const current: FeeStatus[] = [
+      mkFeeStatus({
+        paymentStatus: PaymentStatus.PAID,
+        statusDate: '2026-01-10',
+        paymentReference: 'FIRST',
+      }),
+      mkFeeStatus({
+        paymentStatus: PaymentStatus.PAID,
+        statusDate: '2026-01-10',
+        paymentReference: 'SECOND',
+      }),
+    ];
+
+    const { next, changed } = applyPaymentReferenceUpdateToFeeStatuses(
+      current,
+      `${PaymentStatus.PAID}|2026-01-10|1`,
+      'UPDATED',
+    );
+
+    expect(changed).toBe(true);
+    expect(next[0].paymentReference).toBe('FIRST');
+    expect(next[1].paymentReference).toBe('UPDATED');
   });
 
   it('treats undefined paymentReference as empty string when comparing', () => {
@@ -357,7 +352,7 @@ describe('applyPaymentReferenceUpdateToFeeStatuses', () => {
 
     const { changed } = applyPaymentReferenceUpdateToFeeStatuses(
       current,
-      `${PaymentStatus.PAID}|2026-01-10`,
+      `${PaymentStatus.PAID}|2026-01-10|0`,
       '',
     );
 
@@ -366,7 +361,7 @@ describe('applyPaymentReferenceUpdateToFeeStatuses', () => {
 });
 
 describe('updateFeeStatusesControl', () => {
-  it('does not mutate the control when changed=false (no setValue / no markAsDirty)', () => {
+  it('appends to the control and marks it dirty', () => {
     const existing: FeeStatus = mkFeeStatus({
       paymentStatus: PaymentStatus.PAID,
       statusDate: '2026-01-10',
@@ -381,35 +376,7 @@ describe('updateFeeStatusesControl', () => {
     const payload: AddFeeDetailsPayload = {
       feeStatus: PaymentStatus.PAID,
       statusDate: '2026-01-10',
-      paymentReference: 'REF1',
-    };
-
-    const { next, changed } = updateFeeStatusesControl(ctrl, payload);
-
-    expect(changed).toBe(false);
-    expect(next).toBe(ctrl.value);
-    expect(ctrl.dirty).toBe(false);
-
-    expect(setValueSpy).not.toHaveBeenCalled();
-    expect(markAsDirtySpy).not.toHaveBeenCalled();
-  });
-
-  it('mutates the control when changed=true (setValue + markAsDirty)', () => {
-    const existing: FeeStatus = mkFeeStatus({
-      paymentStatus: PaymentStatus.PAID,
-      statusDate: '2026-01-10',
-      paymentReference: 'REF1',
-    });
-
-    const ctrl = new FormControl<FeeStatus[] | null>([existing]);
-
-    const setValueSpy = jest.spyOn(ctrl, 'setValue');
-    const markAsDirtySpy = jest.spyOn(ctrl, 'markAsDirty');
-
-    const payload: AddFeeDetailsPayload = {
-      feeStatus: PaymentStatus.DUE,
-      statusDate: '2026-01-11',
-      paymentReference: null,
+      paymentReference: 'REF2',
     };
 
     const { next, changed } = updateFeeStatusesControl(ctrl, payload);
@@ -417,6 +384,14 @@ describe('updateFeeStatusesControl', () => {
     expect(changed).toBe(true);
     expect(ctrl.value).toEqual(next);
     expect(ctrl.value).toHaveLength(2);
+    expect(ctrl.value).toEqual([
+      existing,
+      mkFeeStatus({
+        paymentStatus: PaymentStatus.PAID,
+        statusDate: '2026-01-10',
+        paymentReference: 'REF2',
+      }),
+    ]);
     expect(ctrl.dirty).toBe(true);
 
     expect(setValueSpy).toHaveBeenCalledTimes(1);
@@ -437,7 +412,7 @@ describe('updatePaymentReferenceInFeeStatusesControl', () => {
     const setValueSpy = jest.spyOn(ctrl, 'setValue');
     const markAsDirtySpy = jest.spyOn(ctrl, 'markAsDirty');
 
-    const rowId = feeStatusRowId(existing);
+    const rowId = feeStatusRowId(existing, 0);
 
     const { next, changed } = updatePaymentReferenceInFeeStatusesControl(
       ctrl,
@@ -465,7 +440,7 @@ describe('updatePaymentReferenceInFeeStatusesControl', () => {
     const setValueSpy = jest.spyOn(ctrl, 'setValue');
     const markAsDirtySpy = jest.spyOn(ctrl, 'markAsDirty');
 
-    const rowId = feeStatusRowId(existing);
+    const rowId = feeStatusRowId(existing, 0);
 
     const { next, changed } = updatePaymentReferenceInFeeStatusesControl(
       ctrl,


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1312

### Change description
- Add civil fee no longer overwrites when duplicate status & date exist, instead now it appends to existing civil fee array.

<!-- Describe what changed and why. -->

### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
