### PR TITLE
ARCPOC-1318 SA Select maxlength validation

### DIFF
--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -36,6 +36,7 @@
         form.controls.standardApplicantCode.value
       "
       (standardApplicantCodeChange)="onStandardApplicantCodeChanged($event)"
+      (applicantErrorsChange)="onChildErrors('applicant', $event)"
       [showUpdateButton]="false"
     />
   </ng-template>

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -110,7 +110,7 @@
     [id]="'accordion-default'"
     [items]="[
       { heading: 'Applicant', tpl: applicantTpl, expanded: true },
-      { heading: 'Codes', tpl: codesTpl, expanded: false },
+      { heading: 'Application codes', tpl: codesTpl, expanded: false },
       { heading: 'Wording', tpl: wordingTpl, expanded: false },
       { heading: 'Respondent', tpl: respondentTpl, expanded: false },
       { heading: 'Civil fee', tpl: civilFeeTpl, expanded: false },

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -336,6 +336,10 @@ export class ApplicationsListEntryCreate implements OnInit {
       return;
     }
 
+    if (this.form.controls.applicantType.value === 'standard') {
+      return;
+    }
+
     this.childErrors.applicant = [];
   }
 

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -44,6 +44,7 @@
       [errorItems]="applicantErrorItems"
       [selectedStandardApplicantCode]="selectedStandardApplicantCode"
       (standardApplicantCodeChange)="onStandardApplicantCodeChanged($event)"
+      (applicantErrorsChange)="onChildErrors('applicant', $event)"
       [isUpdateDisabled]="isUpdateDisabled"
       (updateClicked)="onUpdateApplicant()"
       [showUpdateButton]="true"

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -43,7 +43,12 @@
       [submitted]="vm().formSubmitted"
       [errorItems]="applicantErrorItems"
       [selectedStandardApplicantCode]="selectedStandardApplicantCode"
+      [savedStandardApplicantCode]="savedStandardApplicantCode"
+      [savedStandardApplicantName]="savedStandardApplicantName"
       (standardApplicantCodeChange)="onStandardApplicantCodeChanged($event)"
+      (standardApplicantSummaryChange)="
+        onSelectedStandardApplicantSummaryChanged($event)
+      "
       (applicantErrorsChange)="onChildErrors('applicant', $event)"
       [isUpdateDisabled]="isUpdateDisabled"
       (updateClicked)="onUpdateApplicant()"

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -149,7 +149,7 @@
     [id]="'accordion-default'"
     [items]="[
       { heading: 'Applicant', tpl: applicantTpl, expanded: false },
-      { heading: 'Codes', tpl: codesTpl, expanded: false },
+      { heading: 'Application codes', tpl: codesTpl, expanded: false },
       { heading: 'Wording', tpl: wordingTpl, expanded: false },
       { heading: 'Respondent', tpl: respondentTpl, expanded: false },
       { heading: 'Civil fee', tpl: civilFeeTpl, expanded: false },

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -84,6 +84,8 @@ import { OfficialsSectionComponent } from '@components/officials-section/officia
 import { RespondentSectionComponent } from '@components/respondent-section/respondent-section.component';
 import { ResultWordingSectionComponent } from '@components/result-wording-section/result-wording-section.component';
 import { TableColumn } from '@components/sortable-table/sortable-table.component';
+import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
+import { mapSaToRow } from '@components/standard-applicant-select/util/standard-applicant-select-row-helpers';
 import { SuccessBannerComponent } from '@components/success-banner/success-banner.component';
 import { WordingSectionComponent } from '@components/wording-section/wording-section.component';
 import { ENTRY_ERROR_MESSAGES } from '@constants/application-list-entry/error-messages';
@@ -103,6 +105,7 @@ import {
   EntryGetDetailDto,
   EntryUpdateDto,
   FeeStatus,
+  StandardApplicantsApi,
   TemplateDetail,
   TemplateSubstitution,
   UpdateApplicationListEntryRequestParams,
@@ -202,6 +205,7 @@ export class ApplicationsListEntryDetail implements OnInit {
   private readonly formSvc = inject(ApplicationListEntryFormService);
   private readonly location = inject(Location);
   private readonly applicationCodesApi = inject(ApplicationCodesApi);
+  private readonly standardApplicantsApi = inject(StandardApplicantsApi);
 
   //Utilising facade for entry results to keep component clean
   readonly resultsFacade = inject(ApplicationListEntryResultsFacade);
@@ -226,6 +230,10 @@ export class ApplicationsListEntryDetail implements OnInit {
   organisationForm!: OrganisationForm;
 
   selectedStandardApplicantCode: string | null = null;
+  savedStandardApplicantCode: string | null = null;
+  savedStandardApplicantName: string | null = null;
+  private pendingStandardApplicantSummary: SelectedStandardApplicantSummary | null =
+    null;
 
   entryDetail: EntryGetDetailDto | null = null;
 
@@ -615,7 +623,10 @@ export class ApplicationsListEntryDetail implements OnInit {
 
   onChildErrors(source: ChildErrorSource, errors: ErrorItem[]): void {
     this.childErrors[source] = errors ?? [];
-    this.updateAllErrors();
+
+    if (this.vm().formSubmitted) {
+      this.updateAllErrors();
+    }
   }
 
   private submitEntryUpdate(
@@ -653,6 +664,7 @@ export class ApplicationsListEntryDetail implements OnInit {
             errorFound: false,
           });
           this.mergeEntryDetailUpdate(entryUpdateDto, res);
+          this.applySavedStandardApplicantSummary();
           this.appListEntryDetailPatch({ successBanner });
 
           if (this.applicantType === 'person') {
@@ -764,6 +776,12 @@ export class ApplicationsListEntryDetail implements OnInit {
     this.formSvc.setStandardApplicantCode(this.forms, code, {
       emitEvent: false,
     });
+  }
+
+  onSelectedStandardApplicantSummaryChanged(
+    summary: SelectedStandardApplicantSummary | null,
+  ): void {
+    this.pendingStandardApplicantSummary = summary;
   }
 
   onOffsiteFeeChanged(nextValue: boolean): void {
@@ -932,6 +950,8 @@ export class ApplicationsListEntryDetail implements OnInit {
         // keep UI state in sync
         this.selectedStandardApplicantCode =
           t === 'standard' ? this.selectedStandardApplicantCode : null;
+        this.pendingStandardApplicantSummary =
+          t === 'standard' ? this.pendingStandardApplicantSummary : null;
 
         // let the service reset the subforms + standard code
         this.formSvc.onApplicantTypeChanged(this.forms, t);
@@ -983,6 +1003,12 @@ export class ApplicationsListEntryDetail implements OnInit {
 
           this.selectedStandardApplicantCode =
             hydrate.selectedStandardApplicantCode;
+          this.savedStandardApplicantCode = hydrate.selectedStandardApplicantCode;
+          this.savedStandardApplicantName = null;
+          this.pendingStandardApplicantSummary = null;
+          this.loadSavedStandardApplicantName(
+            this.savedStandardApplicantCode,
+          );
 
           const type = this.form.controls.applicantType.value ?? 'person';
           this.formSvc.syncApplicantTypeState(this.forms, type);
@@ -1082,6 +1108,64 @@ export class ApplicationsListEntryDetail implements OnInit {
 
     const type = this.form.controls.applicantType.value ?? 'person';
     this.formSvc.syncApplicantTypeState(this.forms, type);
+  }
+
+  private loadSavedStandardApplicantName(code: string | null): void {
+    const trimmedCode = code?.trim() || '';
+
+    if (!trimmedCode) {
+      this.savedStandardApplicantName = null;
+      return;
+    }
+
+    this.standardApplicantsApi
+      .getStandardApplicants(
+        {
+          code: trimmedCode,
+          pageNumber: 0,
+          pageSize: 1,
+          sort: ['code,asc'],
+        },
+        'body',
+        false,
+        { transferCache: true },
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (page) => {
+          const summary = page.content?.[0];
+          this.savedStandardApplicantName = summary
+            ? mapSaToRow(summary).name
+            : null;
+          this.pendingStandardApplicantSummary = this.savedStandardApplicantName
+            ? {
+                code: trimmedCode,
+                name: this.savedStandardApplicantName,
+              }
+            : null;
+        },
+        error: () => {
+          this.savedStandardApplicantName = null;
+          this.pendingStandardApplicantSummary = null;
+        },
+      });
+  }
+
+  private applySavedStandardApplicantSummary(): void {
+    if (this.applicantType !== 'standard') {
+      this.savedStandardApplicantCode = null;
+      this.savedStandardApplicantName = null;
+      this.pendingStandardApplicantSummary = null;
+      return;
+    }
+
+    const pending = this.pendingStandardApplicantSummary;
+    const currentCode = this.selectedStandardApplicantCode?.trim() || '';
+
+    if (pending && pending.code.trim() === currentCode) {
+      this.savedStandardApplicantCode = pending.code.trim() || null;
+      this.savedStandardApplicantName = pending.name.trim() || null;
+    }
   }
 
   private handleListCreate(): void {

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -551,6 +551,10 @@ export class ApplicationsListEntryDetail implements OnInit {
       return;
     }
 
+    if (this.applicantType === 'standard') {
+      return;
+    }
+
     this.childErrors.applicant = [];
   }
 

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -85,7 +85,6 @@ import { RespondentSectionComponent } from '@components/respondent-section/respo
 import { ResultWordingSectionComponent } from '@components/result-wording-section/result-wording-section.component';
 import { TableColumn } from '@components/sortable-table/sortable-table.component';
 import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
-import { mapSaToRow } from '@components/standard-applicant-select/util/standard-applicant-select-row-helpers';
 import { SuccessBannerComponent } from '@components/success-banner/success-banner.component';
 import { WordingSectionComponent } from '@components/wording-section/wording-section.component';
 import { ENTRY_ERROR_MESSAGES } from '@constants/application-list-entry/error-messages';
@@ -141,6 +140,7 @@ import { buildFormErrorSummary } from '@util/error-summary';
 import { markFormGroupClean } from '@util/form-helpers';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
+import { formatPersonName, returnOrgName } from '@util/string-helpers';
 import {
   createWordingObjectValuesResolver,
   withWordingFieldValues,
@@ -1111,19 +1111,23 @@ export class ApplicationsListEntryDetail implements OnInit {
 
   private loadSavedStandardApplicantName(code: string | null): void {
     const trimmedCode = code?.trim() || '';
+    const rawLodgementDate =
+      this.form.controls.lodgementDate.value?.trim() ||
+      this.entryDetail?.lodgementDate?.trim() ||
+      '';
+    const lodgementDate = rawLodgementDate.slice(0, 10);
 
-    if (!trimmedCode) {
+    if (!trimmedCode || !lodgementDate) {
       this.savedStandardApplicantName = null;
+      this.pendingStandardApplicantSummary = null;
       return;
     }
 
     this.standardApplicantsApi
-      .getStandardApplicants(
+      .getStandardApplicantByCodeAndDate(
         {
           code: trimmedCode,
-          pageNumber: 0,
-          pageSize: 1,
-          sort: ['code,asc'],
+          date: lodgementDate,
         },
         'body',
         false,
@@ -1131,11 +1135,12 @@ export class ApplicationsListEntryDetail implements OnInit {
       )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (page) => {
-          const summary = page.content?.[0];
-          this.savedStandardApplicantName = summary
-            ? mapSaToRow(summary).name
-            : null;
+        next: (applicant) => {
+          this.savedStandardApplicantName =
+            applicant.name?.trim() ||
+            returnOrgName(applicant.applicant)?.trim() ||
+            formatPersonName(applicant.applicant)?.trim() ||
+            null;
           this.pendingStandardApplicantSummary = this.savedStandardApplicantName
             ? {
                 code: trimmedCode,

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -1161,7 +1161,7 @@ export class ApplicationsListEntryDetail implements OnInit {
     const pending = this.pendingStandardApplicantSummary;
     const currentCode = this.selectedStandardApplicantCode?.trim() || '';
 
-    if (pending && pending.code.trim() === currentCode) {
+    if (pending?.code.trim() === currentCode) {
       this.savedStandardApplicantCode = pending.code.trim() || null;
       this.savedStandardApplicantName = pending.name.trim() || null;
     }

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -1003,12 +1003,11 @@ export class ApplicationsListEntryDetail implements OnInit {
 
           this.selectedStandardApplicantCode =
             hydrate.selectedStandardApplicantCode;
-          this.savedStandardApplicantCode = hydrate.selectedStandardApplicantCode;
+          this.savedStandardApplicantCode =
+            hydrate.selectedStandardApplicantCode;
           this.savedStandardApplicantName = null;
           this.pendingStandardApplicantSummary = null;
-          this.loadSavedStandardApplicantName(
-            this.savedStandardApplicantCode,
-          );
+          this.loadSavedStandardApplicantName(this.savedStandardApplicantCode);
 
           const type = this.form.controls.applicantType.value ?? 'person';
           this.formSvc.syncApplicantTypeState(this.forms, type);

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -1,5 +1,9 @@
 @if (vm().searchErrors.length) {
-  <app-error-summary [items]="vm().searchErrors" title="There is a problem" />
+  <app-error-summary
+    [items]="vm().searchErrors"
+    title="There is a problem"
+    (itemSelect)="onCreateErrorClick($event)"
+  />
 } @else {
   @if (vm().hasSearched && !vm().isLoading && !vm().rows.length) {
     <app-notification-banner
@@ -21,6 +25,7 @@
       formControlName="code"
       label="Code"
       idPrefix="code"
+      [error]="fieldError('code')?.text ?? null"
       containerWidthClass="govuk-grid-column-one-half"
     />
   </div>
@@ -30,6 +35,7 @@
       formControlName="name"
       label="Standard applicant name"
       idPrefix="name"
+      [error]="fieldError('name')?.text ?? null"
       widthClass="govuk-input--width-20"
       containerWidthClass="govuk-grid-column-one-half"
     />

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -6,7 +6,12 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 
 import {
   ErrorItem,
@@ -27,11 +32,22 @@ import {
   GetStandardApplicantsRequestParams,
   StandardApplicantsApi,
 } from '@openapi';
+import { onCreateErrorClick as onCreateErrorClickFn } from '@util/error-click';
+import { ErrorMessageMap, buildFormErrorSummary } from '@util/error-summary';
 import { getProblemText } from '@util/http-error-to-text';
 import { MojButtonMenuDirective } from '@util/moj-button-menu';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
+
+const STANDARD_APPLICANTS_ERRORS = {
+  code: {
+    maxlength: 'Code must be 10 characters or fewer',
+  },
+  name: {
+    maxlength: 'Standard applicant name must be 100 characters or fewer',
+  },
+} as const;
 
 type StandardApplicantsState = {
   hasSearched: boolean;
@@ -82,10 +98,19 @@ export class StandardApplicants implements OnInit {
 
   private readonly loadRequest =
     signal<GetStandardApplicantsRequestParams | null>(null);
+  readonly submitted = signal(false);
+  private readonly errorMap: ErrorMessageMap = STANDARD_APPLICANTS_ERRORS;
+  onCreateErrorClick = onCreateErrorClickFn;
 
   form = new FormGroup({
-    code: new FormControl<string>('', { nonNullable: true }),
-    name: new FormControl<string>('', { nonNullable: true }),
+    code: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(10)],
+    }),
+    name: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(100)],
+    }),
   });
 
   columns: TableColumn[] = [
@@ -99,8 +124,23 @@ export class StandardApplicants implements OnInit {
 
   onSubmit(event: SubmitEvent): void {
     event.preventDefault();
+    this.submitted.set(true);
+    this.form.markAllAsTouched();
+    this.form.updateValueAndValidity({ emitEvent: false });
+
+    const validationErrors = this.buildErrorSummary();
+    this.signalState.patch({ searchErrors: validationErrors });
+
+    if (validationErrors.length) {
+      return;
+    }
+
     this.signalState.patch({ hasSearched: true });
     this.loadStandardApplicants(0);
+  }
+
+  fieldError(id: string): ErrorItem | undefined {
+    return this.vm().searchErrors.find((e) => e.id === id);
   }
 
   onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
@@ -141,6 +181,10 @@ export class StandardApplicants implements OnInit {
       },
       this.envInjector,
     );
+  }
+
+  private buildErrorSummary(): ErrorItem[] {
+    return buildFormErrorSummary(this.form, this.errorMap);
   }
 
   private loadStandardApplicants(page: number): void {

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -23,11 +23,11 @@ import {
   SortableTableComponent,
   TableColumn,
 } from '@components/sortable-table/sortable-table.component';
+import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from '@components/standard-applicant-select/util/error-messages';
 import {
   mapSaToRow,
   standardAppColumns,
 } from '@components/standard-applicant-select/util/standard-applicant-select-row-helpers';
-import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from '@components/standard-applicant-select/util/error-messages';
 import { TextInputComponent } from '@components/text-input/text-input.component';
 import {
   GetStandardApplicantsRequestParams,

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -144,11 +144,19 @@ export class StandardApplicants implements OnInit {
   }
 
   onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
+    if (!this.canSearch()) {
+      return;
+    }
+
     this.signalState.patch({ sortField: sort });
     this.loadStandardApplicants(0);
   }
 
   onPageChange(page: number): void {
+    if (!this.canSearch()) {
+      return;
+    }
+
     this.loadStandardApplicants(page);
   }
 
@@ -185,6 +193,15 @@ export class StandardApplicants implements OnInit {
 
   private buildErrorSummary(): ErrorItem[] {
     return buildFormErrorSummary(this.form, this.errorMap);
+  }
+
+  private canSearch(): boolean {
+    this.form.updateValueAndValidity({ emitEvent: false });
+
+    const validationErrors = this.buildErrorSummary();
+    this.signalState.patch({ searchErrors: validationErrors });
+
+    return validationErrors.length === 0;
   }
 
   private loadStandardApplicants(page: number): void {

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -27,6 +27,7 @@ import {
   mapSaToRow,
   standardAppColumns,
 } from '@components/standard-applicant-select/util/standard-applicant-select-row-helpers';
+import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from '@components/standard-applicant-select/util/error-messages';
 import { TextInputComponent } from '@components/text-input/text-input.component';
 import {
   GetStandardApplicantsRequestParams,
@@ -39,15 +40,6 @@ import { MojButtonMenuDirective } from '@util/moj-button-menu';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
-
-const STANDARD_APPLICANTS_ERRORS = {
-  code: {
-    maxlength: 'Code must be 10 characters or fewer',
-  },
-  name: {
-    maxlength: 'Standard applicant name must be 100 characters or fewer',
-  },
-} as const;
 
 type StandardApplicantsState = {
   hasSearched: boolean;
@@ -99,7 +91,8 @@ export class StandardApplicants implements OnInit {
   private readonly loadRequest =
     signal<GetStandardApplicantsRequestParams | null>(null);
   readonly submitted = signal(false);
-  private readonly errorMap: ErrorMessageMap = STANDARD_APPLICANTS_ERRORS;
+  private readonly errorMap: ErrorMessageMap =
+    STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES;
   onCreateErrorClick = onCreateErrorClickFn;
 
   form = new FormGroup({

--- a/src/app/shared/components/applicant-section/applicant-section.component.html
+++ b/src/app/shared/components/applicant-section/applicant-section.component.html
@@ -34,6 +34,7 @@
       <app-standard-applicant-select
         [selectedCode]="selectedStandardApplicantCode()"
         (selectedCodeChange)="onStandardChanged($event)"
+        (searchErrorsChange)="onStandardApplicantErrorsChanged($event)"
       />
     }
   }

--- a/src/app/shared/components/applicant-section/applicant-section.component.html
+++ b/src/app/shared/components/applicant-section/applicant-section.component.html
@@ -31,9 +31,21 @@
       />
     }
     @case ('standard') {
+      @if (standardApplicantSummary(); as summary) {
+        <p class="govuk-body govuk-!-margin-bottom-4">
+          <strong class="govuk-tag govuk-tag--blue govuk-!-margin-right-2">
+            Saved
+          </strong>
+          <span>{{ summary.displayText }}</span>
+        </p>
+      }
+
       <app-standard-applicant-select
         [selectedCode]="selectedStandardApplicantCode()"
         (selectedCodeChange)="onStandardChanged($event)"
+        (selectedApplicantSummaryChange)="
+          onSelectedStandardApplicantSummaryChanged($event)
+        "
         (searchErrorsChange)="onStandardApplicantErrorsChanged($event)"
       />
     }

--- a/src/app/shared/components/applicant-section/applicant-section.component.ts
+++ b/src/app/shared/components/applicant-section/applicant-section.component.ts
@@ -9,7 +9,10 @@ import { ErrorItem } from '@components/error-summary/error-summary.component';
 import { OrganisationSectionComponent } from '@components/organisation-section/organisation-section.component';
 import { PersonSectionComponent } from '@components/person-section/person-section.component';
 import { SelectInputComponent } from '@components/select-input/select-input.component';
-import { StandardApplicantSelectComponent } from '@components/standard-applicant-select/standard-applicant-select.component';
+import {
+  SelectedStandardApplicantSummary,
+  StandardApplicantSelectComponent,
+} from '@components/standard-applicant-select/standard-applicant-select.component';
 import { ApplicantType } from '@shared-types/applications-list-entry-create/application-list-entry-form';
 
 @Component({
@@ -35,19 +38,43 @@ export class ApplicantSectionComponent {
   readonly submitted = input(false);
   readonly errorItems = input<ErrorItem[]>([]);
   readonly selectedStandardApplicantCode = input<string | null>(null);
+  readonly savedStandardApplicantCode = input<string | null>(null);
+  readonly savedStandardApplicantName = input<string | null>(null);
   readonly isUpdateDisabled = input(false);
 
   readonly showUpdateButton = input(true);
   readonly updateButtonText = input('Update applicant');
 
   readonly standardApplicantCodeChange = output<string | null>();
+  readonly standardApplicantSummaryChange =
+    output<SelectedStandardApplicantSummary | null>();
   readonly applicantErrorsChange = output<ErrorItem[]>();
   readonly updateClicked = output<void>();
 
   readonly entryTypeOptions = computed(() => this.applicantEntryTypeOptions);
+  readonly standardApplicantSummary = computed(() => {
+    const code = this.savedStandardApplicantCode()?.trim() || null;
+    const name = this.savedStandardApplicantName()?.trim() || null;
+
+    if (!code || !name) {
+      return null;
+    }
+
+    return {
+      code,
+      name,
+      displayText: `${code} ${name}`,
+    };
+  });
 
   onStandardChanged(code: string | null): void {
     this.standardApplicantCodeChange.emit(code);
+  }
+
+  onSelectedStandardApplicantSummaryChanged(
+    summary: SelectedStandardApplicantSummary | null,
+  ): void {
+    this.standardApplicantSummaryChange.emit(summary);
   }
 
   onStandardApplicantErrorsChanged(errors: ErrorItem[]): void {

--- a/src/app/shared/components/applicant-section/applicant-section.component.ts
+++ b/src/app/shared/components/applicant-section/applicant-section.component.ts
@@ -41,12 +41,17 @@ export class ApplicantSectionComponent {
   readonly updateButtonText = input('Update applicant');
 
   readonly standardApplicantCodeChange = output<string | null>();
+  readonly applicantErrorsChange = output<ErrorItem[]>();
   readonly updateClicked = output<void>();
 
   readonly entryTypeOptions = computed(() => this.applicantEntryTypeOptions);
 
   onStandardChanged(code: string | null): void {
     this.standardApplicantCodeChange.emit(code);
+  }
+
+  onStandardApplicantErrorsChanged(errors: ErrorItem[]): void {
+    this.applicantErrorsChange.emit(errors ?? []);
   }
 
   onUpdateClicked(): void {

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
@@ -5,6 +5,7 @@
         formControlName="code"
         label="Code"
         idPrefix="standard-applicant-code"
+        [error]="fieldError('code')?.text ?? null"
         containerWidthClass="govuk-grid-column-one-half"
       />
     </div>
@@ -14,6 +15,7 @@
         formControlName="name"
         label="Standard applicant name"
         idPrefix="standard-applicant-name"
+        [error]="fieldError('name')?.text ?? null"
         widthClass="govuk-input--width-20"
         containerWidthClass="govuk-grid-column-one-half"
       />

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -14,7 +14,12 @@ import {
   output,
   signal,
 } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 
 import {
   mapSaToRow,
@@ -25,6 +30,9 @@ import {
   initialStandardApplicantSelectPagingState,
 } from './util/standard-applicant-select.state';
 
+import {
+  ErrorItem,
+} from '@components/error-summary/error-summary.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
 import {
   SortableTableComponent,
@@ -32,9 +40,19 @@ import {
 } from '@components/sortable-table/sortable-table.component';
 import { TextInputComponent } from '@components/text-input/text-input.component';
 import { StandardApplicantsApi } from '@openapi';
+import { buildFormErrorSummary, ErrorMessageMap } from '@util/error-summary';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
+
+const STANDARD_APPLICANT_SELECT_ERRORS = {
+  code: {
+    maxlength: 'Code must be 10 characters or fewer',
+  },
+  name: {
+    maxlength: 'Standard applicant name must be 100 characters or fewer',
+  },
+} as const;
 
 @Component({
   selector: 'app-standard-applicant-select',
@@ -54,6 +72,7 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
   selectedCode = input<string | null>(null);
   readonly selectedCodeChange = output<string | null>();
+  readonly searchErrorsChange = output<ErrorItem[]>();
 
   rows: StandardApplicantRow[] = [];
 
@@ -74,10 +93,18 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     pageSize: number;
     sort: string[];
   } | null>(null);
+  readonly submitted = signal(false);
+  private readonly errorMap: ErrorMessageMap = STANDARD_APPLICANT_SELECT_ERRORS;
 
   form = new FormGroup({
-    code: new FormControl<string>('', { nonNullable: true }),
-    name: new FormControl<string>('', { nonNullable: true }),
+    code: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(10)],
+    }),
+    name: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(100)],
+    }),
   });
 
   // Selection for the table
@@ -124,8 +151,24 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
   onSubmit(event: SubmitEvent): void {
     event.preventDefault();
+    this.submitted.set(true);
+    this.form.markAllAsTouched();
+    this.form.updateValueAndValidity({ emitEvent: false });
+
+    const validationErrors = this.buildErrorSummary();
+    this.saSignalState.patch({ searchErrors: validationErrors });
+    this.searchErrorsChange.emit(validationErrors);
+
+    if (validationErrors.length) {
+      return;
+    }
+
     this.saSignalState.patch({ hasSearched: true });
     this.loadPage(0);
+  }
+
+  fieldError(id: string): ErrorItem | undefined {
+    return this.vm().searchErrors.find((e) => e.id === id);
   }
 
   private setupEffects(): void {
@@ -143,7 +186,9 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
           this.saSignalState.patch({
             totalPages: page.totalPages,
             loading: false,
+            searchErrors: [],
           });
+          this.searchErrorsChange.emit([]);
 
           // Keep selection consistent when page changes
           this.syncSelectedIdsFromCode();
@@ -152,12 +197,26 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
         },
         onError: () => {
           this.rows = [];
-          this.saSignalState.patch({ totalPages: 0, loading: false });
+          this.saSignalState.patch({
+            totalPages: 0,
+            loading: false,
+            searchErrors: [],
+          });
+          this.searchErrorsChange.emit([]);
           this.loadRequest.set(null);
         },
       },
       this.envInjector,
     );
+  }
+
+  private buildErrorSummary(): ErrorItem[] {
+    return buildFormErrorSummary(this.form, this.errorMap, {
+      hrefs: {
+        code: '#standard-applicant-code',
+        name: '#standard-applicant-name',
+      },
+    });
   }
 
   private loadPage(page: number): void {

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -25,6 +25,7 @@ import {
   mapSaToRow,
   standardAppColumns,
 } from './util/standard-applicant-select-row-helpers';
+import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from './util/error-messages';
 import {
   StandardApplicantSelectPagingState,
   initialStandardApplicantSelectPagingState,
@@ -42,15 +43,6 @@ import { ErrorMessageMap, buildFormErrorSummary } from '@util/error-summary';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
-
-const STANDARD_APPLICANT_SELECT_ERRORS = {
-  code: {
-    maxlength: 'Code must be 10 characters or fewer',
-  },
-  name: {
-    maxlength: 'Standard applicant name must be 100 characters or fewer',
-  },
-} as const;
 
 export type SelectedStandardApplicantSummary = {
   code: string;
@@ -99,7 +91,8 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     sort: string[];
   } | null>(null);
   readonly submitted = signal(false);
-  private readonly errorMap: ErrorMessageMap = STANDARD_APPLICANT_SELECT_ERRORS;
+  private readonly errorMap: ErrorMessageMap =
+    STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES;
 
   form = new FormGroup({
     code: new FormControl<string>('', {

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -21,11 +21,11 @@ import {
   Validators,
 } from '@angular/forms';
 
+import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from './util/error-messages';
 import {
   mapSaToRow,
   standardAppColumns,
 } from './util/standard-applicant-select-row-helpers';
-import { STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES } from './util/error-messages';
 import {
   StandardApplicantSelectPagingState,
   initialStandardApplicantSelectPagingState,

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -30,9 +30,7 @@ import {
   initialStandardApplicantSelectPagingState,
 } from './util/standard-applicant-select.state';
 
-import {
-  ErrorItem,
-} from '@components/error-summary/error-summary.component';
+import { ErrorItem } from '@components/error-summary/error-summary.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
 import {
   SortableTableComponent,
@@ -40,7 +38,7 @@ import {
 } from '@components/sortable-table/sortable-table.component';
 import { TextInputComponent } from '@components/text-input/text-input.component';
 import { StandardApplicantsApi } from '@openapi';
-import { buildFormErrorSummary, ErrorMessageMap } from '@util/error-summary';
+import { ErrorMessageMap, buildFormErrorSummary } from '@util/error-summary';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
@@ -53,6 +51,11 @@ const STANDARD_APPLICANT_SELECT_ERRORS = {
     maxlength: 'Standard applicant name must be 100 characters or fewer',
   },
 } as const;
+
+export type SelectedStandardApplicantSummary = {
+  code: string;
+  name: string;
+};
 
 @Component({
   selector: 'app-standard-applicant-select',
@@ -72,6 +75,8 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
   selectedCode = input<string | null>(null);
   readonly selectedCodeChange = output<string | null>();
+  readonly selectedApplicantSummaryChange =
+    output<SelectedStandardApplicantSummary | null>();
   readonly searchErrorsChange = output<ErrorItem[]>();
 
   rows: StandardApplicantRow[] = [];
@@ -128,14 +133,30 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
     const first = ids.values().next().value;
     const code = first ?? null;
+    const selectedRow =
+      code === null
+        ? null
+        : (this.rows.find((row) => row.code === code) ?? null);
 
     if (code !== this.selectedCode()) {
       this.selectedCodeChange.emit(code);
     }
+
+    this.selectedApplicantSummaryChange.emit(
+      selectedRow
+        ? {
+            code: selectedRow.code ?? '',
+            name: selectedRow.name ?? '',
+          }
+        : null,
+    );
   }
 
   onPageChange(page: number): void {
     if (!this.saState().hasSearched) {
+      return;
+    }
+    if (!this.canLoadPage()) {
       return;
     }
     this.loadPage(page);
@@ -143,6 +164,9 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
   onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
     if (!this.saState().hasSearched) {
+      return;
+    }
+    if (!this.canLoadPage()) {
       return;
     }
     this.saSignalState.patch({ sortField: sort });
@@ -169,6 +193,16 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
 
   fieldError(id: string): ErrorItem | undefined {
     return this.vm().searchErrors.find((e) => e.id === id);
+  }
+
+  private canLoadPage(): boolean {
+    this.form.updateValueAndValidity({ emitEvent: false });
+
+    const validationErrors = this.buildErrorSummary();
+    this.saSignalState.patch({ searchErrors: validationErrors });
+    this.searchErrorsChange.emit(validationErrors);
+
+    return validationErrors.length === 0;
   }
 
   private setupEffects(): void {

--- a/src/app/shared/components/standard-applicant-select/util/error-messages.ts
+++ b/src/app/shared/components/standard-applicant-select/util/error-messages.ts
@@ -1,0 +1,8 @@
+export const STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES = {
+  code: {
+    maxlength: 'Code must be 10 characters or fewer',
+  },
+  name: {
+    maxlength: 'Standard applicant name must be 100 characters or fewer',
+  },
+} as const;

--- a/src/app/shared/components/standard-applicant-select/util/standard-applicant-select.state.ts
+++ b/src/app/shared/components/standard-applicant-select/util/standard-applicant-select.state.ts
@@ -1,3 +1,5 @@
+import { ErrorItem } from '@components/error-summary/error-summary.component';
+
 export interface StandardApplicantSelectPagingState {
   hasSearched: boolean;
   pageIndex: number;
@@ -5,6 +7,7 @@ export interface StandardApplicantSelectPagingState {
   pageSize: number;
   sortField: { key: string; direction: 'desc' | 'asc' };
   loading: boolean;
+  searchErrors: ErrorItem[];
 }
 
 export const initialStandardApplicantSelectPagingState: StandardApplicantSelectPagingState =
@@ -15,4 +18,5 @@ export const initialStandardApplicantSelectPagingState: StandardApplicantSelectP
     pageSize: 10,
     sortField: { key: 'code', direction: 'asc' },
     loading: false,
+    searchErrors: [],
   };

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -130,6 +130,39 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     expect(component.respondentErrorItems).toEqual([]);
   });
 
+  it('includes relayed standard applicant search errors in the parent summary', () => {
+    component.form.patchValue({ applicantType: 'standard' });
+    (
+      component as unknown as {
+        appListEntryCreatePatch: (patch: Record<string, unknown>) => void;
+      }
+    ).appListEntryCreatePatch({ submitted: true });
+
+    component.onChildErrors('applicant', [
+      {
+        id: 'standard-applicant-code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+    ]);
+
+    expect(component.applicantErrorItems).toEqual([
+      {
+        id: 'standard-applicant-code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+    ]);
+    expect(component.vm().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'standard-applicant-code',
+          text: 'Code must be 10 characters or fewer',
+        }),
+      ]),
+    );
+  });
+
   it('payload: omits applicant/respondent when empty', () => {
     component.form.patchValue({
       applicationCode: 'A001',

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -31,6 +31,9 @@ import {
   GetApplicationCodesRequestParams,
   OfficialType,
   PaymentStatus,
+  StandardApplicantGetDetailDto,
+  StandardApplicantPage,
+  StandardApplicantsApi,
   TemplateConstraintTypeEnum,
   UpdateApplicationListEntryRequestParams,
 } from '@openapi';
@@ -67,6 +70,26 @@ type GetCodeDetailFn = (
   options?: { transferCache?: boolean; context?: unknown },
 ) => Observable<ApplicationCodeGetDetailDto>;
 
+type GetStandardApplicantDetailFn = (
+  params: { code: string; date: string },
+  observe?: 'body',
+  reportProgress?: boolean,
+  options?: { transferCache?: boolean; context?: unknown },
+) => Observable<StandardApplicantGetDetailDto>;
+
+type GetStandardApplicantsFn = (
+  params?: {
+    code?: string;
+    name?: string;
+    pageNumber?: number;
+    pageSize?: number;
+    sort?: string[];
+  },
+  observe?: 'body',
+  reportProgress?: boolean,
+  options?: { transferCache?: boolean; context?: unknown },
+) => Observable<StandardApplicantPage>;
+
 type PaymentRefApplier = {
   applyPaymentRefReturn: (updatedRowId: string, newRef: string) => void;
 };
@@ -81,6 +104,8 @@ describe('ApplicationsListEntryDetail', () => {
 
   let mockGetApplicationCodes: jest.MockedFunction<GetCodesFn>;
   let mockGetApplicationCodeByCodeAndDate: jest.MockedFunction<GetCodeDetailFn>;
+  let mockGetStandardApplicants: jest.MockedFunction<GetStandardApplicantsFn>;
+  let mockGetStandardApplicantByCodeAndDate: jest.MockedFunction<GetStandardApplicantDetailFn>;
   let mockGetApplicationListEntry: jest.MockedFunction<GetEntryFn>;
   let mockUpdateApplicationListEntry: jest.MockedFunction<UpdateEntryFn>;
 
@@ -118,6 +143,8 @@ describe('ApplicationsListEntryDetail', () => {
 
     mockGetApplicationCodes = jest.fn();
     mockGetApplicationCodeByCodeAndDate = jest.fn();
+    mockGetStandardApplicants = jest.fn();
+    mockGetStandardApplicantByCodeAndDate = jest.fn();
     mockGetApplicationListEntry = jest.fn();
     mockUpdateApplicationListEntry = jest.fn();
 
@@ -158,6 +185,17 @@ describe('ApplicationsListEntryDetail', () => {
       } as ApplicationCodeGetDetailDto),
     );
 
+    mockGetStandardApplicants.mockReturnValue(
+      of({
+        pageNumber: 0,
+        pageSize: 10,
+        totalElements: 0,
+        totalPages: 0,
+        elementsOnPage: 0,
+        content: [],
+      }),
+    );
+
     mockUpdateApplicationListEntry.mockReturnValue(of({}));
 
     const codesApiMock = {
@@ -170,6 +208,11 @@ describe('ApplicationsListEntryDetail', () => {
       updateApplicationListEntry: mockUpdateApplicationListEntry,
     } as unknown as ApplicationListEntriesApi;
 
+    const standardApplicantsApiMock = {
+      getStandardApplicants: mockGetStandardApplicants,
+      getStandardApplicantByCodeAndDate: mockGetStandardApplicantByCodeAndDate,
+    } as unknown as StandardApplicantsApi;
+
     await TestBed.configureTestingModule({
       imports: [ApplicationsListEntryDetail],
       providers: [
@@ -177,6 +220,7 @@ describe('ApplicationsListEntryDetail', () => {
         { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: ApplicationCodesApi, useValue: codesApiMock },
         { provide: ApplicationListEntriesApi, useValue: entriesApiMock },
+        { provide: StandardApplicantsApi, useValue: standardApplicantsApiMock },
         { provide: ActivatedRoute, useValue: routeStub },
         ApplicationListEntryFormService,
         provideHttpClient(),
@@ -254,6 +298,71 @@ describe('ApplicationsListEntryDetail', () => {
       { key: 'Court', value: 'Court A' },
       { key: 'Date', value: '2026-04-13' },
     ]);
+  });
+
+  it('hydrates saved standard applicant name via exact code and lodgement date lookup', () => {
+    mockGetApplicationListEntry.mockReturnValueOnce(
+      of({
+        lodgementDate: '2025-11-01T12:34:56Z',
+        applicationCode: 'APP-100',
+        standardApplicantCode: 'SA-123',
+      } as unknown as EntryGetDetailDto),
+    );
+    mockGetStandardApplicantByCodeAndDate.mockReturnValueOnce(
+      of({
+        code: 'SA-123',
+        name: 'Exact Applicant Name',
+        startDate: '2025-01-01',
+        endDate: null,
+      }),
+    );
+
+    const freshFixture = TestBed.createComponent(ApplicationsListEntryDetail);
+    const freshComponent = freshFixture.componentInstance;
+
+    freshFixture.detectChanges();
+
+    expect(mockGetStandardApplicantByCodeAndDate).toHaveBeenCalledWith(
+      { code: 'SA-123', date: '2025-11-01' },
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
+    expect(freshComponent.savedStandardApplicantName).toBe(
+      'Exact Applicant Name',
+    );
+  });
+
+  it('hydrates saved standard applicant name from applicant details when top-level name is absent', () => {
+    mockGetApplicationListEntry.mockReturnValueOnce(
+      of({
+        lodgementDate: '2025-11-01T12:34:56Z',
+        applicationCode: 'APP-100',
+        standardApplicantCode: 'SA-123',
+      } as unknown as EntryGetDetailDto),
+    );
+    mockGetStandardApplicantByCodeAndDate.mockReturnValueOnce(
+      of({
+        code: 'SA-123',
+        applicant: {
+          organisation: {
+            name: 'Fallback Organisation Name',
+            contactDetails: {},
+          },
+        },
+        startDate: '2025-01-01',
+        endDate: null,
+      } as unknown as StandardApplicantGetDetailDto),
+    );
+
+    const freshFixture = TestBed.createComponent(ApplicationsListEntryDetail);
+    const freshComponent = freshFixture.componentInstance;
+
+    freshFixture.detectChanges();
+
+    expect(freshComponent.savedStandardApplicantName).toBe(
+      'Fallback Organisation Name',
+    );
   });
 
   it('includes relayed standard applicant search errors in the parent summary', () => {

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -256,6 +256,34 @@ describe('ApplicationsListEntryDetail', () => {
     ]);
   });
 
+  it('includes relayed standard applicant search errors in the parent summary', () => {
+    component['form'].patchValue({ applicantType: 'standard' });
+
+    component.onChildErrors('applicant', [
+      {
+        id: 'standard-applicant-code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+    ]);
+
+    expect(component.applicantErrorItems).toEqual([
+      {
+        id: 'standard-applicant-code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+    ]);
+    expect(component['appListEntryDetailState']().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'standard-applicant-code',
+          text: 'Code must be 10 characters or fewer',
+        }),
+      ]),
+    );
+  });
+
   it('isUpdateDisabled true when entryDetail is not set', () => {
     component['entryDetail'] = null;
 

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -258,6 +258,11 @@ describe('ApplicationsListEntryDetail', () => {
 
   it('includes relayed standard applicant search errors in the parent summary', () => {
     component['form'].patchValue({ applicantType: 'standard' });
+    (
+      component as unknown as {
+        appListEntryDetailPatch: (patch: Record<string, unknown>) => void;
+      }
+    ).appListEntryDetailPatch({ formSubmitted: true });
 
     component.onChildErrors('applicant', [
       {

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -82,6 +82,51 @@ describe('StandardApplicantsComponent', () => {
     );
   });
 
+  it('shows validation errors and prevents submit when filters exceed max lengths', async () => {
+    component.form.patchValue({
+      code: '12345678901',
+      name: 'x'.repeat(101),
+    });
+
+    apiStub.getStandardApplicants.mockClear();
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#code',
+      },
+      {
+        id: 'name',
+        text: 'Standard applicant name must be 100 characters or fewer',
+        href: '#name',
+      },
+    ]);
+    expect(component.fieldError('code')?.text).toBe(
+      'Code must be 10 characters or fewer',
+    );
+    expect(component.fieldError('name')?.text).toBe(
+      'Standard applicant name must be 100 characters or fewer',
+    );
+
+    const errorMessages = fixture.debugElement
+      .queryAll(By.css('.govuk-error-message'))
+      .map((debugEl) => debugEl.nativeElement.textContent.trim());
+
+    expect(errorMessages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Code must be 10 characters or fewer'),
+        expect.stringContaining(
+          'Standard applicant name must be 100 characters or fewer',
+        ),
+      ]),
+    );
+  });
+
   it('renders table after first search and shows no-data message for empty results', async () => {
     component.onSubmit(new SubmitEvent('submit'));
     await flushSignalEffects(fixture);

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -180,6 +180,46 @@ describe('StandardApplicantsComponent', () => {
     );
   });
 
+  it('does not sort when filters are invalid', async () => {
+    component.form.patchValue({
+      name: 'x'.repeat(101),
+    });
+    apiStub.getStandardApplicants.mockClear();
+
+    component.onSortChange({ key: 'useFrom', direction: 'desc' });
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().sortField).toEqual({ key: 'code', direction: 'asc' });
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'name',
+        text: 'Standard applicant name must be 100 characters or fewer',
+        href: '#name',
+      },
+    ]);
+  });
+
+  it('does not paginate when filters are invalid', async () => {
+    component.form.patchValue({
+      code: '12345678901',
+    });
+    apiStub.getStandardApplicants.mockClear();
+
+    component.onPageChange(3);
+    await flushSignalEffects(fixture);
+
+    expect(apiStub.getStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().currentPage).toBe(0);
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#code',
+      },
+    ]);
+  });
+
   it('updates rows and total pages on successful response', async () => {
     apiStub.getStandardApplicants.mockReturnValueOnce(
       of({

--- a/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
+++ b/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
@@ -35,6 +35,7 @@ class MockOrganisationSectionComponent {
 })
 class MockStandardApplicantSelectComponent {
   readonly selectedCode = input<string | null>(null);
+  readonly selectedApplicantSummaryChange = output<unknown>();
   readonly selectedCodeChange = output<string | null>();
   readonly searchErrorsChange = output<unknown[]>();
 }
@@ -129,6 +130,33 @@ describe('ApplicantSectionComponent', () => {
     ).toBeNull();
   });
 
+  it('renders the saved standard applicant tag and text when saved values exist', () => {
+    fixture.componentRef.setInput('applicantType', 'standard' as ApplicantType);
+    fixture.componentRef.setInput('savedStandardApplicantCode', 'SA-123');
+    fixture.componentRef.setInput(
+      'savedStandardApplicantName',
+      'Example Org',
+    );
+    fixture.detectChanges();
+
+    const tag = fixture.debugElement.query(By.css('.govuk-tag'));
+    const body = fixture.debugElement.query(By.css('.govuk-body'));
+
+    expect(tag).toBeTruthy();
+    expect(tag.nativeElement.textContent).toContain('Saved');
+    expect(body).toBeTruthy();
+    expect(body.nativeElement.textContent).toContain('SA-123');
+    expect(body.nativeElement.textContent).toContain('Example Org');
+  });
+
+  it('does not render saved standard applicant text without a saved name', () => {
+    fixture.componentRef.setInput('applicantType', 'standard' as ApplicantType);
+    fixture.componentRef.setInput('savedStandardApplicantCode', 'SA-123');
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.govuk-tag'))).toBeNull();
+  });
+
   it('emits updateClicked when the update button is clicked', () => {
     const spy = jest.fn();
     component.updateClicked.subscribe(spy);
@@ -173,6 +201,16 @@ describe('ApplicantSectionComponent', () => {
 
     component.onStandardApplicantErrorsChanged(errors);
     expect(spy).toHaveBeenCalledWith(errors);
+  });
+
+  it('emits standardApplicantSummaryChange when standard applicant summary is relayed', () => {
+    const spy = jest.fn();
+    const summary = { code: 'SA-123', name: 'Example Org' };
+
+    component.standardApplicantSummaryChange.subscribe(spy);
+
+    component.onSelectedStandardApplicantSummaryChanged(summary);
+    expect(spy).toHaveBeenCalledWith(summary);
   });
 
   it('disables update button when isUpdateDisabled is true', () => {

--- a/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
+++ b/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
@@ -36,6 +36,7 @@ class MockOrganisationSectionComponent {
 class MockStandardApplicantSelectComponent {
   readonly selectedCode = input<string | null>(null);
   readonly selectedCodeChange = output<string | null>();
+  readonly searchErrorsChange = output<unknown[]>();
 }
 
 describe('ApplicantSectionComponent', () => {
@@ -162,6 +163,16 @@ describe('ApplicantSectionComponent', () => {
 
     component.onStandardChanged('ABC123');
     expect(spy).toHaveBeenCalledWith('ABC123');
+  });
+
+  it('emits applicantErrorsChange when standard applicant errors are relayed', () => {
+    const spy = jest.fn();
+    const errors = [{ id: 'code', text: 'Bad code', href: '#code' }];
+
+    component.applicantErrorsChange.subscribe(spy);
+
+    component.onStandardApplicantErrorsChanged(errors);
+    expect(spy).toHaveBeenCalledWith(errors);
   });
 
   it('disables update button when isUpdateDisabled is true', () => {

--- a/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
+++ b/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
@@ -133,10 +133,7 @@ describe('ApplicantSectionComponent', () => {
   it('renders the saved standard applicant tag and text when saved values exist', () => {
     fixture.componentRef.setInput('applicantType', 'standard' as ApplicantType);
     fixture.componentRef.setInput('savedStandardApplicantCode', 'SA-123');
-    fixture.componentRef.setInput(
-      'savedStandardApplicantName',
-      'Example Org',
-    );
+    fixture.componentRef.setInput('savedStandardApplicantName', 'Example Org');
     fixture.detectChanges();
 
     const tag = fixture.debugElement.query(By.css('.govuk-tag'));

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -309,6 +309,52 @@ describe('StandardApplicantSelectComponent', () => {
     );
   }));
 
+  it('does not sort when filters are invalid', fakeAsync(() => {
+    fixture.detectChanges();
+    TestBed.tick();
+
+    mockGetStandardApplicants.mockClear();
+    component.form.patchValue({
+      name: 'x'.repeat(101),
+    });
+
+    component.onSortChange({ key: 'useTo', direction: 'desc' });
+    fixture.detectChanges();
+
+    expect(mockGetStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().sortField).toEqual({ key: 'code', direction: 'asc' });
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'name',
+        text: 'Standard applicant name must be 100 characters or fewer',
+        href: '#standard-applicant-name',
+      },
+    ]);
+  }));
+
+  it('does not paginate when filters are invalid', fakeAsync(() => {
+    fixture.detectChanges();
+    TestBed.tick();
+
+    mockGetStandardApplicants.mockClear();
+    component.form.patchValue({
+      code: '12345678901',
+    });
+
+    component.onPageChange(1);
+    fixture.detectChanges();
+
+    expect(mockGetStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().pageIndex).toBe(0);
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+    ]);
+  }));
+
   it('shows validation errors and prevents submit when filters exceed max lengths', fakeAsync(() => {
     fixture.detectChanges();
     TestBed.tick();

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -308,4 +308,52 @@ describe('StandardApplicantSelectComponent', () => {
       expect.objectContaining({ transferCache: true }),
     );
   }));
+
+  it('shows validation errors and prevents submit when filters exceed max lengths', fakeAsync(() => {
+    fixture.detectChanges();
+    TestBed.tick();
+
+    mockGetStandardApplicants.mockClear();
+
+    component.form.patchValue({
+      code: '12345678901',
+      name: 'x'.repeat(101),
+    });
+
+    component.onSubmit(new SubmitEvent('submit'));
+    fixture.detectChanges();
+
+    expect(mockGetStandardApplicants).not.toHaveBeenCalled();
+    expect(component.vm().searchErrors).toEqual([
+      {
+        id: 'code',
+        text: 'Code must be 10 characters or fewer',
+        href: '#standard-applicant-code',
+      },
+      {
+        id: 'name',
+        text: 'Standard applicant name must be 100 characters or fewer',
+        href: '#standard-applicant-name',
+      },
+    ]);
+    expect(component.fieldError('code')?.text).toBe(
+      'Code must be 10 characters or fewer',
+    );
+    expect(component.fieldError('name')?.text).toBe(
+      'Standard applicant name must be 100 characters or fewer',
+    );
+
+    const errorMessages = fixture.debugElement
+      .queryAll(By.css('.govuk-error-message'))
+      .map((debugEl) => debugEl.nativeElement.textContent.trim());
+
+    expect(errorMessages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Code must be 10 characters or fewer'),
+        expect.stringContaining(
+          'Standard applicant name must be 100 characters or fewer',
+        ),
+      ]),
+    );
+  }));
 });


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1318

### Change description
- Added max-length validation for standard applicant search fields:
  - code limited to 10 characters
  - name limited to 100 characters
- Applied the validation consistently in both:
  - the standalone `standard-applicants` page
  - the shared `standard-applicant-select` component
- Wired validation errors into the existing GOV.UK error summary and inline field error pattern
- Prevented sort and pagination actions from bypassing validation when search filters are invalid
- Added parent-level propagation of standard-applicant search errors into entry create/detail flows
- Fixed error-summary focus so standard applicant validation links target the correct input IDs
- Added saved standard applicant display in applicant section for update/detail flows only
- Refined saved standard applicant presentation to a compact GOV.UK tag plus text treatment
- Ensured saved standard applicant display is driven by persisted API-backed data, not unsaved in-progress selection or snapshot state
- Preserved unsaved picker selection separately from the saved summary on the detail page
- Added and updated unit tests to cover:
  - max-length validation
  - blocked submit/sort/pagination on invalid filters
  - parent error-summary propagation
  - saved standard applicant display behavior

### Testing done
- Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
