### PR TITLE
ARCPOC-1300 Standardise name display

### DIFF
--- a/src/app/core/components/sortable-table/sortable-table.component.scss
+++ b/src/app/core/components/sortable-table/sortable-table.component.scss
@@ -172,6 +172,26 @@
   right: 0;
 }
 
+:host ::ng-deep .moj-button-menu {
+  position: relative;
+  z-index: 0;
+}
+
+:host ::ng-deep .app-moj-button-menu--open {
+  z-index: 1000;
+}
+
+:host ::ng-deep .app-moj-button-menu--open .moj-button-menu__wrapper {
+  z-index: 1001;
+}
+
+:host ::ng-deep .app-moj-button-menu--open-up .moj-button-menu__wrapper {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+
 :host ::ng-deep th.govuk-table__header[aria-sort] > button > svg {
   position: static;
   top: auto;

--- a/src/app/core/components/sortable-table/sortable-table.component.scss
+++ b/src/app/core/components/sortable-table/sortable-table.component.scss
@@ -15,6 +15,7 @@
   position: relative;
   max-width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.scss
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.scss
@@ -10,10 +10,6 @@
   margin-bottom: 0;
 }
 
-:host ::ng-deep .app-sortable-table__frame {
-  padding-bottom: 50px; /* Prevent vertical scrollbar on single records */
-}
-
 :host ::ng-deep .app-sortable-table__frame .moj-button-menu {
   position: relative;
 }

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -74,7 +74,7 @@ import { getProblemText } from '@util/http-error-to-text';
 import { MojButtonMenu, MojButtonMenuDirective } from '@util/moj-button-menu';
 import { PlaceFieldsBase } from '@util/place-fields.base';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
-import { formatPersonName, returnOrgName } from '@util/string-helpers';
+import { formatPartyName } from '@util/string-helpers';
 import { parseTimeToDuration } from '@util/time-helpers';
 import { ApplicationListRow } from '@util/types/application-list/types';
 import { closePermitted } from '@validators/applications-list-close.validator';
@@ -726,12 +726,8 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
         id: entry.id,
         sequenceNumber: entry.sequenceNumber!,
         accountNumber: entry.accountNumber ?? '',
-        applicant: entry.applicant?.person
-          ? formatPersonName(entry.applicant)
-          : returnOrgName(entry.applicant),
-        respondent: entry.respondent?.person
-          ? formatPersonName(entry.respondent)
-          : returnOrgName(entry.respondent),
+        applicant: formatPartyName(entry.applicant),
+        respondent: formatPartyName(entry.respondent),
         postCode:
           entry.respondent?.person?.contactDetails?.postcode ??
           entry.respondent?.organisation?.contactDetails?.postcode ??

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -133,7 +133,7 @@ import { buildFormErrorSummary } from '@util/error-summary';
 import { markFormGroupClean } from '@util/form-helpers';
 import { respondentFormsHaveAnyValue } from '@util/respondent-helpers';
 import { createSignalState } from '@util/signal-state-helpers';
-import { formatPersonName, returnOrgName } from '@util/string-helpers';
+import { formatPartyName } from '@util/string-helpers';
 import {
   createWordingObjectValuesResolver,
   withWordingFieldValues,
@@ -1159,8 +1159,7 @@ export class ApplicationsListEntryDetail implements OnInit {
         next: (applicant) => {
           this.savedStandardApplicantName =
             applicant.name?.trim() ||
-            returnOrgName(applicant.applicant)?.trim() ||
-            formatPersonName(applicant.applicant)?.trim() ||
+            formatPartyName(applicant.applicant)?.trim() ||
             null;
           this.pendingStandardApplicantSummary = this.savedStandardApplicantName
             ? {

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
@@ -47,7 +47,12 @@ export const APPLICATION_ENTRIES_MOVE_COLUMNS = [
 export const RESULT_WORDING_COLUMNS = [
   { header: 'Applicant(s)', field: 'applicant' },
   { header: 'Respondent(s)', field: 'respondent' },
-  { header: 'Application title(s)', field: 'title' },
+  {
+    header: 'Application title(s)',
+    field: 'title',
+    maxWidth: '25rem',
+    wrap: true,
+  },
 ];
 
 export const EXISTING_RESULTS_WORDING_COLUMNS = [

--- a/src/app/pages/applications-list-entry-detail/util/result-context.util.ts
+++ b/src/app/pages/applications-list-entry-detail/util/result-context.util.ts
@@ -1,7 +1,7 @@
 import { ApplicantContext } from './routing-state-util';
 
-import { Applicant, EntryGetDetailDto, FullName, Respondent } from '@openapi';
-import { returnOrgName } from '@util/string-helpers';
+import { EntryGetDetailDto } from '@openapi';
+import { formatPartyName } from '@util/string-helpers';
 
 export function buildResultApplicantContext(
   entry: EntryGetDetailDto,
@@ -15,7 +15,7 @@ export function buildResultApplicantContext(
 }
 
 function formatApplicantForResultContext(entry: EntryGetDetailDto): string {
-  const applicantDisplay = formatApplicantLike(entry.applicant);
+  const applicantDisplay = formatPartyName(entry.applicant) ?? '';
   if (applicantDisplay) {
     return applicantDisplay;
   }
@@ -24,38 +24,5 @@ function formatApplicantForResultContext(entry: EntryGetDetailDto): string {
 }
 
 function formatRespondentForResultContext(entry: EntryGetDetailDto): string {
-  return formatRespondentLike(entry.respondent);
-}
-
-function formatApplicantLike(applicant: Applicant | undefined): string {
-  if (returnOrgName(applicant)) {
-    return returnOrgName(applicant) ?? '';
-  }
-
-  return formatPersonNameSurnameFirst(applicant?.person?.name);
-}
-
-function formatRespondentLike(respondent: Respondent | undefined): string {
-  if (respondent?.organisation?.name?.trim()) {
-    return respondent.organisation.name.trim();
-  }
-
-  return formatPersonNameSurnameFirst(respondent?.person?.name);
-}
-
-function formatPersonNameSurnameFirst(
-  name: FullName | null | undefined,
-): string {
-  if (!name) {
-    return '';
-  }
-
-  const surname = name.surname?.trim() ?? '';
-  const firstForename = name.firstForename?.trim() ?? '';
-
-  if (surname && firstForename) {
-    return `${surname}, ${firstForename}`;
-  }
-
-  return surname || firstForename;
+  return formatPartyName(entry.respondent) ?? '';
 }

--- a/src/app/pages/applications/util/table-mapper.ts
+++ b/src/app/pages/applications/util/table-mapper.ts
@@ -1,37 +1,13 @@
-import { Applicant, EntryGetSummaryDto, Person } from '@openapi';
+import { EntryGetSummaryDto } from '@openapi';
 import { ApplicationRow } from '@shared-types/applications/applications.type';
-import { returnOrgName } from '@util/string-helpers';
-
-function formatFullName(person: Person): string {
-  const n = person.name;
-
-  return [n.title, n.firstForename, n.surname]
-    .filter((x): x is string => !!x && x.trim().length > 0)
-    .join(' ');
-}
-
-function applicantLikeDisplay(a?: Applicant): string {
-  if (!a) {
-    return '';
-  }
-
-  if (a.organisation) {
-    return returnOrgName(a) ?? '';
-  }
-
-  if (a.person) {
-    return formatFullName(a.person);
-  }
-
-  return '';
-}
+import { formatPartyName } from '@util/string-helpers';
 
 export function mapToRow(dto: EntryGetSummaryDto): ApplicationRow {
   return {
     id: dto.id,
     date: dto.date ?? '',
-    applicant: applicantLikeDisplay(dto.applicant),
-    respondent: applicantLikeDisplay(dto.respondent),
+    applicant: formatPartyName(dto.applicant) ?? '',
+    respondent: formatPartyName(dto.respondent) ?? '',
     title: dto.applicationTitle ?? '',
     fee: dto.isFeeRequired ? 'Yes' : 'No',
     resulted: dto.isResulted ? 'Yes' : 'No',

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.ts
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.ts
@@ -215,6 +215,7 @@ export class ApplicationCodeSearchComponent implements OnInit {
 
   onAddCode(row: CodeRow): void {
     this.submitted.set(false);
+    this.hasSearched.set(false);
     this.codesRows = [];
 
     if (!this.listId) {

--- a/src/app/shared/components/civil-fee-section/civil-fee-section.component.html
+++ b/src/app/shared/components/civil-fee-section/civil-fee-section.component.html
@@ -67,49 +67,51 @@
     </app-sortable-table>
   </section>
 
-  @if (feeRequired()) {
-    <h2 class="govuk-heading-s">Update fee status</h2>
-  }
-  <div class="govuk-grid-row">
-    <!-- Fee status -->
-    <app-select-input
-      formControlName="feeStatus"
-      label="Fee status"
-      hint="Select the status of the fee to be paid"
-      id="feeStatus"
-      [options]="feeStatusOptionsWithPlaceholder()"
-      [submitted]="showErrors()"
-    />
+  <div class="govuk-!-margin-top-8">
+    @if (feeRequired()) {
+      <h2 class="govuk-heading-s">Update fee status</h2>
+    }
+    <div class="govuk-grid-row">
+      <!-- Fee status -->
+      <app-select-input
+        formControlName="feeStatus"
+        label="Fee status"
+        hint="Select the status of the fee to be paid"
+        id="feeStatus"
+        [options]="feeStatusOptionsWithPlaceholder()"
+        [submitted]="showErrors()"
+      />
 
-    <!-- Status date -->
-    <app-date-input
-      formControlName="feeStatusDate"
-      label="Status date"
-      hint="For example, 15 5 2025"
-      id="feeStatusDate"
-      [submitted]="showErrors()"
-      [disallowFutureDates]="true"
-      containerWidthClass="govuk-grid-column-one-quarter"
-    />
+      <!-- Status date -->
+      <app-date-input
+        formControlName="feeStatusDate"
+        label="Status date"
+        hint="For example, 15 5 2025"
+        id="feeStatusDate"
+        [submitted]="showErrors()"
+        [disallowFutureDates]="true"
+        containerWidthClass="govuk-grid-column-one-quarter"
+      />
 
-    <!-- Payment reference -->
-    <app-text-input
-      formControlName="paymentRef"
-      label="Payment reference"
-      hint="Enter the unique reference assigned to this payment"
-      id="paymentRef"
-      [error]="getControlErrorMessages('paymentRef')[0]"
-    />
-  </div>
+      <!-- Payment reference -->
+      <app-text-input
+        formControlName="paymentRef"
+        label="Payment reference"
+        hint="Enter the unique reference assigned to this payment"
+        id="paymentRef"
+        [error]="getControlErrorMessages('paymentRef')[0]"
+      />
+    </div>
 
-  <div class="govuk-button-group">
-    <button
-      type="button"
-      class="govuk-button"
-      [disabled]="!feeRequired()"
-      (click)="onAddFeeDetailsClick()"
-    >
-      Add fee details
-    </button>
+    <div class="govuk-button-group">
+      <button
+        type="button"
+        class="govuk-button"
+        [disabled]="!feeRequired()"
+        (click)="onAddFeeDetailsClick()"
+      >
+        Add fee details
+      </button>
+    </div>
   </div>
 </div>

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.html
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.html
@@ -4,10 +4,9 @@
   [captionSize]="captionSize()"
   [columns]="applicantRespondentColumns()"
   [data]="resultApplicantContext()"
-  appMojButtonMenu
 />
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-!-margin-top-8">
   <app-suggestions
     id="result-code"
     label="Result code"

--- a/src/app/shared/components/standard-applicant-select/util/standard-applicant-select-row-helpers.ts
+++ b/src/app/shared/components/standard-applicant-select/util/standard-applicant-select-row-helpers.ts
@@ -1,7 +1,7 @@
 import { TableColumn } from '@components/sortable-table/sortable-table.component';
 import { StandardApplicantGetSummaryDto } from '@openapi';
 import { formatDate } from '@util/standard-applicant-helpers';
-import { formatPersonName, returnOrgName } from '@util/string-helpers';
+import { formatPartyName } from '@util/string-helpers';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
 
 export const standardAppColumns: TableColumn[] = [
@@ -20,7 +20,7 @@ export function mapSaToRow(
   const person = sa.applicant?.person;
   const organisation = sa.applicant?.organisation;
 
-  const name = returnOrgName(applicant) ?? formatPersonName(applicant) ?? '';
+  const name = formatPartyName(applicant) ?? '';
 
   const address =
     organisation?.contactDetails?.addressLine1 ??

--- a/src/app/shared/util/moj-button-menu.ts
+++ b/src/app/shared/util/moj-button-menu.ts
@@ -16,6 +16,9 @@ interface MojInitEl extends HTMLElement {
   __mojInit?: boolean;
 }
 
+const OPEN_MENU_CLASS = 'app-moj-button-menu--open';
+const OPEN_UP_MENU_CLASS = 'app-moj-button-menu--open-up';
+
 @Injectable({ providedIn: 'root' })
 export class MojButtonMenu {
   private cachedCtor?: ButtonMenuCtor;
@@ -89,15 +92,55 @@ export class MojButtonMenuDirective implements AfterViewInit, OnDestroy {
 
     // initial scan
     void this.menus.initAll(this.el.nativeElement);
+    this.syncOpenMenuClasses();
 
     // observe future inserts (e.g., first page render, pagination, sorts)
     this.mo = new MutationObserver(() => {
       void this.menus.initAll(this.el.nativeElement);
+      this.syncOpenMenuClasses();
     });
-    this.mo.observe(this.el.nativeElement, { childList: true, subtree: true });
+    this.mo.observe(this.el.nativeElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['aria-expanded'],
+    });
   }
 
   ngOnDestroy(): void {
     this.mo?.disconnect();
+  }
+
+  private syncOpenMenuClasses(): void {
+    const menus = this.el.nativeElement.querySelectorAll<HTMLElement>(
+      '[data-module="moj-button-menu"]',
+    );
+
+    for (const menu of menus) {
+      const toggle = menu.querySelector<HTMLElement>(
+        '.moj-button-menu__toggle-button[aria-expanded="true"]',
+      );
+      const isOpen = !!toggle;
+      menu.classList.toggle(OPEN_MENU_CLASS, isOpen);
+      const shouldOpenUp = isOpen ? this.shouldOpenUp(menu) : false;
+      menu.classList.toggle(OPEN_UP_MENU_CLASS, shouldOpenUp);
+    }
+  }
+
+  private shouldOpenUp(menu: HTMLElement): boolean {
+    const wrapper = menu.querySelector<HTMLElement>('.moj-button-menu__wrapper');
+    if (!wrapper) {
+      return false;
+    }
+
+    const hostRect = this.el.nativeElement.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const wrapperHeight = wrapper.offsetHeight;
+    const gap = 8;
+
+    const spaceBelow = hostRect.bottom - menuRect.bottom;
+    const spaceAbove = menuRect.top - hostRect.top;
+
+    return spaceBelow < wrapperHeight + gap && spaceAbove > spaceBelow;
   }
 }

--- a/src/app/shared/util/moj-button-menu.ts
+++ b/src/app/shared/util/moj-button-menu.ts
@@ -128,7 +128,9 @@ export class MojButtonMenuDirective implements AfterViewInit, OnDestroy {
   }
 
   private shouldOpenUp(menu: HTMLElement): boolean {
-    const wrapper = menu.querySelector<HTMLElement>('.moj-button-menu__wrapper');
+    const wrapper = menu.querySelector<HTMLElement>(
+      '.moj-button-menu__wrapper',
+    );
     if (!wrapper) {
       return false;
     }

--- a/src/app/shared/util/string-helpers.ts
+++ b/src/app/shared/util/string-helpers.ts
@@ -1,6 +1,6 @@
 import { FormGroup } from '@angular/forms';
 
-import { Applicant } from '@openapi';
+import { Applicant, FullName } from '@openapi';
 
 export function trimToString(v: unknown): string {
   return typeof v === 'string' ? v.trim() : '';
@@ -80,27 +80,32 @@ export function getTrimmedStringOrNullFromGroup(
   return s || null;
 }
 
-export function formatPersonName(applicant?: Applicant): string | null {
-  const name = applicant?.person?.name;
+type PartyWithName = Pick<Applicant, 'person' | 'organisation'>;
+
+export function formatFullName(name?: FullName | null): string | null {
   if (!name) {
     return null;
   }
 
-  const forenames = [
-    name.firstForename,
-    name.secondForename,
-    name.thirdForename,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const parts = [
+    trimToString(name.firstForename),
+    trimToString(name.surname),
+  ].filter(Boolean);
 
-  return [name.title, forenames, name.surname].filter(Boolean).join(', ');
+  return parts.length > 0 ? parts.join(' ') : null;
 }
 
-export function returnOrgName(applicant?: Applicant): string | null {
-  const organisation = applicant?.organisation;
-  if (!organisation) {
-    return null;
-  }
-  return organisation.name;
+/** Formats a person's display name for UI use: first forename, surname. */
+export function formatPersonName(party?: PartyWithName): string | null {
+  return formatFullName(party?.person?.name);
+}
+
+/** Formats an applicant/respondent display name, preferring organisation name. */
+export function returnOrgName(party?: PartyWithName): string | null {
+  const name = trimToString(party?.organisation?.name);
+  return name || null;
+}
+
+export function formatPartyName(party?: PartyWithName): string | null {
+  return returnOrgName(party) ?? formatPersonName(party);
 }

--- a/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
@@ -432,8 +432,8 @@ describe('ApplicationsListDetail', () => {
         id: 'entry-2',
         sequenceNumber: 7,
         accountNumber: '',
-        applicant: 'Mr, Alex J, Brown',
-        respondent: 'Sam, Green',
+        applicant: 'Alex Brown',
+        respondent: 'Sam Green',
         postCode: 'CC3 3CC',
         title: 'Another title',
         feeReq: 'No',
@@ -893,7 +893,7 @@ describe('ApplicationsListDetail', () => {
         },
       } as Applicant;
 
-      expect(formatPersonName(applicant)).toBe('Mr, John Paul George, Smith');
+      expect(formatPersonName(applicant)).toBe('John Smith');
     });
 
     it('skips missing forenames', () => {
@@ -909,7 +909,7 @@ describe('ApplicationsListDetail', () => {
         },
       } as Applicant;
 
-      expect(formatPersonName(applicant)).toBe('Mr, John, Smith');
+      expect(formatPersonName(applicant)).toBe('John Smith');
     });
   });
 

--- a/test/unit/app/pages/applications-list-entry-detail/util/result-context.util.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/util/result-context.util.spec.ts
@@ -15,7 +15,7 @@ function makeEntry(
 }
 
 describe('buildResultApplicantContext', () => {
-  it('formats applicant person as surname, firstForename', () => {
+  it('formats applicant person with the shared full-name display format', () => {
     const entry = makeEntry({
       applicant: {
         person: {
@@ -34,7 +34,7 @@ describe('buildResultApplicantContext', () => {
     });
 
     expect(buildResultApplicantContext(entry, 'Application title')).toEqual({
-      applicant: 'Blooer, Simon',
+      applicant: 'Simon Blooer',
       respondent: '',
       title: 'Application title',
     });
@@ -59,7 +59,7 @@ describe('buildResultApplicantContext', () => {
     });
   });
 
-  it('formats respondent person as surname, firstForename', () => {
+  it('formats respondent person with the shared full-name display format', () => {
     const entry = makeEntry({
       respondent: {
         person: {
@@ -78,7 +78,7 @@ describe('buildResultApplicantContext', () => {
 
     expect(buildResultApplicantContext(entry, 'Application title')).toEqual({
       applicant: '',
-      respondent: 'Smith, John',
+      respondent: 'John Smith',
       title: 'Application title',
     });
   });
@@ -116,7 +116,7 @@ describe('buildResultApplicantContext', () => {
     });
 
     expect(buildResultApplicantContext(entry, 'Application title')).toEqual({
-      applicant: 'Smith, John',
+      applicant: 'John Smith',
       respondent: '',
       title: 'Application title',
     });

--- a/test/unit/app/pages/applications/util/table-mapper.spec.ts
+++ b/test/unit/app/pages/applications/util/table-mapper.spec.ts
@@ -175,6 +175,26 @@ describe('mapToRow', () => {
     expect(row.respondent).toBe('Olivia Harris');
   });
 
+  it('uses only first forename and surname for person display names', () => {
+    const dto = makeDto({
+      applicant: makeApplicant({
+        person: makePerson({
+          name: {
+            title: 'Mr',
+            firstForename: 'John',
+            secondForename: 'Paul',
+            thirdForename: 'George',
+            surname: 'Smith',
+          },
+        }),
+      }),
+    });
+
+    const row = mapToRow(dto);
+
+    expect(row.applicant).toBe('John Smith');
+  });
+
   it('maps fee/resulted booleans to Yes/No', () => {
     const dto = makeDto({
       isFeeRequired: false,

--- a/test/unit/app/pages/applications/util/table-mapper.spec.ts
+++ b/test/unit/app/pages/applications/util/table-mapper.spec.ts
@@ -98,8 +98,8 @@ describe('mapToRow', () => {
     expect(row).toEqual({
       id: 'id-123',
       date: '2025-04-24',
-      applicant: 'Ms Jane Doe',
-      respondent: 'Ms Bob Smith',
+      applicant: 'Jane Doe',
+      respondent: 'Bob Smith',
       title: 'Request for something',
       fee: 'Yes',
       resulted: 'No',

--- a/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
+++ b/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
@@ -206,6 +206,7 @@ describe('ApplicationCodeSearchComponent', () => {
     const emitSpy = jest.spyOn(component.selectCodeAndLodgementDate, 'emit');
 
     component.form.patchValue({ lodgementDate: '2024-01-01' });
+    component.hasSearched.set(true);
 
     const rowWithWhitespace: CodeRow = {
       code: ` ${mockRows.rows[0].code} `,
@@ -226,6 +227,7 @@ describe('ApplicationCodeSearchComponent', () => {
     expect(component.form.value.title).toBe(mockRows.rows[0].title);
 
     expect(component.submitted()).toBe(false);
+    expect(component.hasSearched()).toBe(false);
     expect(component.codesRows).toEqual([]);
   });
 

--- a/test/unit/app/shared/util/moj-button-menu.spec.ts
+++ b/test/unit/app/shared/util/moj-button-menu.spec.ts
@@ -1,0 +1,179 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { MojButtonMenu, MojButtonMenuDirective } from '@util/moj-button-menu';
+
+@Component({
+  standalone: true,
+  imports: [MojButtonMenuDirective],
+  template: `
+    <div id="host" appMojButtonMenu>
+      <div id="menu-1" class="moj-button-menu" data-module="moj-button-menu">
+        <button
+          type="button"
+          class="moj-button-menu__toggle-button"
+          aria-expanded="false"
+        >
+          Toggle
+        </button>
+        <ul class="moj-button-menu__wrapper"></ul>
+      </div>
+    </div>
+  `,
+})
+class HostComponent {}
+
+describe('MojButtonMenuDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let directive: MojButtonMenuDirective;
+  let initAll: jest.Mock<Promise<void>, [ParentNode?]>;
+
+  const syncClasses = () => {
+    (
+      directive as unknown as {
+        syncOpenMenuClasses: () => void;
+      }
+    ).syncOpenMenuClasses();
+    fixture.detectChanges();
+  };
+
+  const getMenu = (): HTMLElement =>
+    fixture.debugElement.query(By.css('#menu-1')).nativeElement as HTMLElement;
+
+  const getToggle = (): HTMLElement =>
+    fixture.debugElement.query(By.css('.moj-button-menu__toggle-button'))
+      .nativeElement as HTMLElement;
+
+  const getWrapper = (): HTMLElement =>
+    fixture.debugElement.query(By.css('.moj-button-menu__wrapper'))
+      .nativeElement as HTMLElement;
+
+  const mockRects = ({
+    hostTop,
+    hostBottom,
+    menuTop,
+    menuBottom,
+    wrapperHeight,
+  }: {
+    hostTop: number;
+    hostBottom: number;
+    menuTop: number;
+    menuBottom: number;
+    wrapperHeight: number;
+  }) => {
+    const host = fixture.debugElement.query(By.css('#host'))
+      .nativeElement as HTMLElement;
+    const menu = getMenu();
+    const wrapper = getWrapper();
+
+    jest.spyOn(host, 'getBoundingClientRect').mockReturnValue({
+      top: hostTop,
+      bottom: hostBottom,
+    } as DOMRect);
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: menuTop,
+      bottom: menuBottom,
+    } as DOMRect);
+    Object.defineProperty(wrapper, 'offsetHeight', {
+      configurable: true,
+      value: wrapperHeight,
+    });
+  };
+
+  beforeEach(async () => {
+    initAll = jest.fn().mockResolvedValue(undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        {
+          provide: MojButtonMenu,
+          useValue: { initAll },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    directive = fixture.debugElement
+      .query(By.directive(MojButtonMenuDirective))
+      .injector.get(MojButtonMenuDirective);
+  });
+
+  it('initialises button menus under the host element', () => {
+    expect(initAll).toHaveBeenCalledWith(
+      fixture.debugElement.query(By.css('#host')).nativeElement,
+    );
+  });
+
+  it('adds the open class when a menu toggle is expanded', () => {
+    getToggle().setAttribute('aria-expanded', 'true');
+
+    syncClasses();
+
+    expect(getMenu().classList.contains('app-moj-button-menu--open')).toBe(
+      true,
+    );
+  });
+
+  it('removes open state classes when a menu is collapsed', () => {
+    const menu = getMenu();
+    getToggle().setAttribute('aria-expanded', 'true');
+    mockRects({
+      hostTop: 0,
+      hostBottom: 300,
+      menuTop: 250,
+      menuBottom: 280,
+      wrapperHeight: 120,
+    });
+
+    syncClasses();
+    expect(menu.classList.contains('app-moj-button-menu--open')).toBe(true);
+    expect(menu.classList.contains('app-moj-button-menu--open-up')).toBe(true);
+
+    getToggle().setAttribute('aria-expanded', 'false');
+    syncClasses();
+
+    expect(menu.classList.contains('app-moj-button-menu--open')).toBe(false);
+    expect(menu.classList.contains('app-moj-button-menu--open-up')).toBe(false);
+  });
+
+  it('marks an open menu to open upward when there is not enough space below', () => {
+    getToggle().setAttribute('aria-expanded', 'true');
+    mockRects({
+      hostTop: 0,
+      hostBottom: 300,
+      menuTop: 250,
+      menuBottom: 280,
+      wrapperHeight: 120,
+    });
+
+    syncClasses();
+
+    expect(getMenu().classList.contains('app-moj-button-menu--open-up')).toBe(
+      true,
+    );
+  });
+
+  it('keeps an open menu opening downward when there is enough space below', () => {
+    getToggle().setAttribute('aria-expanded', 'true');
+    mockRects({
+      hostTop: 0,
+      hostBottom: 400,
+      menuTop: 120,
+      menuBottom: 150,
+      wrapperHeight: 120,
+    });
+
+    syncClasses();
+
+    expect(getMenu().classList.contains('app-moj-button-menu--open')).toBe(
+      true,
+    );
+    expect(getMenu().classList.contains('app-moj-button-menu--open-up')).toBe(
+      false,
+    );
+  });
+});

--- a/test/unit/app/shared/util/standard-applicant-helpers.spec.ts
+++ b/test/unit/app/shared/util/standard-applicant-helpers.spec.ts
@@ -56,7 +56,7 @@ describe('buildStandardApplicantRows', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toEqual({
       code: 'SA-001',
-      name: 'Mr, John Q, Public',
+      name: 'John Public',
       address: '1 Test Street',
       useFrom: '1 Dec 2025',
       useTo: '31 Dec 2025',

--- a/test/unit/app/shared/util/string-helpers.spec.ts
+++ b/test/unit/app/shared/util/string-helpers.spec.ts
@@ -1,5 +1,7 @@
 import { Applicant } from '@openapi';
 import {
+  formatFullName,
+  formatPartyName,
   formatPersonName,
   mapOptionValueToTitle,
   mapTitleToOptionValue,
@@ -131,6 +133,37 @@ describe('mapOptionValueToTitle', () => {
   });
 });
 
+describe('formatFullName', () => {
+  it('returns null when name is missing', () => {
+    expect(formatFullName()).toBeNull();
+    expect(formatFullName(null)).toBeNull();
+  });
+
+  it('formats first forename and surname only', () => {
+    expect(
+      formatFullName({
+        title: 'Mr',
+        firstForename: 'John',
+        secondForename: 'Paul',
+        thirdForename: 'George',
+        surname: 'Smith',
+      }),
+    ).toBe('John Smith');
+  });
+
+  it('returns the available non-empty name part when one is missing', () => {
+    expect(
+      formatFullName({
+        title: 'Mr',
+        firstForename: 'John',
+        secondForename: null,
+        thirdForename: undefined,
+        surname: 'Smith',
+      }),
+    ).toBe('John Smith');
+  });
+});
+
 describe('formatPersonName', () => {
   it('returns null when applicant or person name is missing', () => {
     expect(formatPersonName()).toBeNull();
@@ -151,7 +184,7 @@ describe('formatPersonName', () => {
       },
     } as Applicant;
 
-    expect(formatPersonName(applicant)).toBe('Mr, John Paul George, Smith');
+    expect(formatPersonName(applicant)).toBe('John Smith');
   });
 
   it('skips missing forenames and empty title parts', () => {
@@ -167,7 +200,7 @@ describe('formatPersonName', () => {
       },
     } as Applicant;
 
-    expect(formatPersonName(applicant)).toBe('Mr, John, Smith');
+    expect(formatPersonName(applicant)).toBe('John Smith');
   });
 });
 
@@ -185,5 +218,36 @@ describe('returnOrgName', () => {
     } as Applicant;
 
     expect(returnOrgName(applicant)).toBe('Acme Ltd');
+  });
+});
+
+describe('formatPartyName', () => {
+  it('prefers organisation name over person name', () => {
+    const applicant = {
+      organisation: { name: 'Acme Ltd' },
+      person: {
+        name: {
+          title: 'Ms',
+          firstForename: 'Jane',
+          surname: 'Doe',
+        },
+      },
+    } as Applicant;
+
+    expect(formatPartyName(applicant)).toBe('Acme Ltd');
+  });
+
+  it('falls back to person name when organisation is absent', () => {
+    const applicant = {
+      person: {
+        name: {
+          title: 'Ms',
+          firstForename: 'Jane',
+          surname: 'Doe',
+        },
+      },
+    } as Applicant;
+
+    expect(formatPartyName(applicant)).toBe('Jane Doe');
   });
 });


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1300

### Change description

- Standardised applicant/respondent/standard-applicant display names through shared formatting helpers so person names now render consistently as `firstForename surname`.
- Replaced ad hoc name formatting in application list, list detail, result context, and standard applicant mapping with the shared helper.
- Improved MoJ button menu behaviour inside sortable tables so open menus take visual priority and can flip upward when there isn’t enough space below.
- Removed the temporary table-clearance approach once upward-opening menu behaviour proved sufficient.
- Added and updated unit tests for shared name formatting and the new MoJ button menu directive behaviour.

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
