### PR TITLE
ARCPOC-1294 Select all functionality for AL details

### DIFF
--- a/src/app/core/components/sortable-table/sortable-table.component.ts
+++ b/src/app/core/components/sortable-table/sortable-table.component.ts
@@ -112,6 +112,8 @@ export class SortableTableComponent
   selectedIds = input<Set<string>>(new Set<string>());
   selectedIdsChange = output<Set<string>>();
   selectedRowsChange = output<Row[]>();
+  selectAllScope = input<'visible' | 'external'>('visible');
+  selectAllChange = output<boolean>();
   idPrefix = input('apps-');
   singleSelect = input(false);
 
@@ -208,6 +210,10 @@ export class SortableTableComponent
 
   toggleSelectAllVisible(checked: boolean): void {
     if (this.singleSelect()) {
+      return;
+    }
+    if (this.selectAllScope() === 'external') {
+      this.selectAllChange.emit(checked);
       return;
     }
     const next = new Set(this.selectedIdsState());

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -126,9 +126,12 @@
         [sortKey]="vm().sortField.key"
         [sortDirection]="vm().sortField.direction"
         idField="id"
+        [selectAllScope]="'external'"
         (sortChange)="onSortChange($event)"
+        (selectAllChange)="onHeaderSelectAllChange($event)"
+        (selectedIdsChange)="onSelectedIdsChange($event)"
         (selectedRowsChange)="onSelectedRowsChange($event)"
-        [(selectedIds)]="vm().selectedIds"
+        [selectedIds]="vm().selectedIds"
         appMojButtonMenu
       >
         <caption
@@ -142,7 +145,7 @@
             role="group"
             aria-label="Table actions"
           >
-            @if (vm().selectedRows.length === 0) {
+            @if (!hasSelection) {
               <button
                 type="button"
                 class="govuk-button govuk-button--small govuk-button--primary table-caption__action-button"

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -107,6 +107,7 @@
     <app-applications-list-detail-search
       [listId]="id"
       [pageSize]="vm().pageSize"
+      (searchStarted)="onSearchStarted($event)"
       (searchResult)="onSearchResult($event)"
     />
 
@@ -145,7 +146,7 @@
             role="group"
             aria-label="Table actions"
           >
-            @if (!hasSelection) {
+            @if (!canUseBulkActions) {
               <button
                 type="button"
                 class="govuk-button govuk-button--small govuk-button--primary table-caption__action-button"

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -23,6 +23,7 @@ import {
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
 
 import { ApplicationsListUpdateComponent } from './applications-list-update/applications-list-update.component';
 import {
@@ -65,6 +66,7 @@ import {
   ApplicationListGetDetailDto,
   ApplicationListGetPrintDto,
   ApplicationListsApi,
+  EntryIdsDto,
   EntryPage,
 } from '@openapi';
 import { ApplicationsListFormService } from '@services/applications-list/applications-list-form.service';
@@ -77,11 +79,17 @@ import {
 import { getProblemText } from '@util/http-error-to-text';
 import { MojButtonMenu, MojButtonMenuDirective } from '@util/moj-button-menu';
 import {
-  filterEntriesToPrint as filterEntriesToPrintDto,
   handlePrintContinuous as handlePrintContinuousPdf,
   handlePrintPage as handlePrintPagePdf,
 } from '@util/pdf-utils';
 import { PlaceFieldsBase } from '@util/place-fields.base';
+import {
+  ServerPaginatedSelectionPatch,
+  buildPageSelectionPatch,
+  buildSelectAllMatchingPatch,
+  getVisibleSelectedRows,
+  isAllMatchingSelected,
+} from '@util/server-paginated-selection';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { parseTimeToDuration } from '@util/time-helpers';
 import { ApplicationListRow } from '@util/types/application-list/types';
@@ -336,7 +344,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
               errorSummary: [{ text: 'No data returned from server.' }],
               rows: [],
               totalPages: 0,
+              totalEntries: 0,
               selectedIds: new Set<string>(),
+              selectedRows: [],
+              allMatchingSelected: false,
             });
             this.listDetailRequest.set(null);
             return;
@@ -375,7 +386,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
             errorSummary: [{ text: getProblemText(err) }],
             rows: [],
             totalPages: 0,
+            totalEntries: 0,
             selectedIds: new Set<string>(),
+            selectedRows: [],
+            allMatchingSelected: false,
           });
           this.listDetailRequest.set(null);
         },
@@ -411,7 +425,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
               errorSummary: [{ text: 'No data returned from server.' }],
               rows: [],
               totalPages: 0,
+              totalEntries: 0,
               selectedIds: new Set<string>(),
+              selectedRows: [],
+              allMatchingSelected: false,
             });
             this.tableDataRequest.set(null);
             return;
@@ -423,16 +440,14 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
           const pageSize = this.vm().pageSize;
           const totalPages = total > pageSize ? Math.ceil(total / pageSize) : 0;
 
-          const visible = new Set(rows.map((r) => r.id));
-          const selectedIds = new Set(
-            [...this.vm().selectedIds].filter((id) => visible.has(id)),
+          this.patchLoadSuccessState(
+            buildPageSelectionPatch({
+              rows,
+              totalPages,
+              totalEntries: total,
+              currentSelectedIds: this.vm().selectedIds,
+            }),
           );
-
-          this.patchLoadSuccessState({
-            rows,
-            totalPages,
-            selectedIds,
-          });
 
           this.tableDataRequest.set(null);
         },
@@ -448,7 +463,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
             errorSummary: [{ text: getProblemText(err) }],
             rows: [],
             totalPages: 0,
+            totalEntries: 0,
             selectedIds: new Set<string>(),
+            selectedRows: [],
+            allMatchingSelected: false,
           });
           this.tableDataRequest.set(null);
         },
@@ -543,6 +561,14 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     return !vm.isLoading && !vm.updateInvalid && (vm.rows?.length ?? 0) === 0;
   }
 
+  get selectedCount(): number {
+    return this.vm().selectedIds.size;
+  }
+
+  get hasSelection(): boolean {
+    return this.selectedCount > 0;
+  }
+
   loadListDetailsInfo(): void {
     if (!this.id) {
       return;
@@ -571,12 +597,100 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     });
   }
 
+  onSelectedIdsChange(ids: Set<string>): void {
+    const vm = this.vm();
+    const selectedIds = new Set(ids);
+
+    this.detailSignalState.patch({
+      selectedIds,
+      selectedRows: getVisibleSelectedRows(vm.rows, selectedIds),
+      allMatchingSelected: isAllMatchingSelected(selectedIds, vm.totalEntries),
+    });
+  }
+
   onSelectedRowsChange(rows: Row[]): void {
     this.detailSignalState.patch({ selectedRows: rows });
   }
 
-  onResultButtonClick(): void {
-    const selected = this.vm().selectedRows as selectedRow[];
+  onHeaderSelectAllChange(checked: boolean): void {
+    if (checked) {
+      void this.onSelectAllMatchingClick();
+      return;
+    }
+
+    this.clearSelection();
+  }
+
+  async onSelectAllMatchingClick(): Promise<void> {
+    if (!this.id) {
+      return;
+    }
+
+    const vm = this.vm();
+    const previousSelection = {
+      selectedIds: new Set(vm.selectedIds),
+      selectedRows: [...vm.selectedRows],
+      allMatchingSelected: vm.allMatchingSelected,
+    };
+    const visibleIds = new Set(
+      vm.rows
+        .map((row) => row['id'])
+        .filter(
+          (id): id is string | number =>
+            typeof id === 'string' || typeof id === 'number',
+        )
+        .map(String),
+    );
+    const optimisticSelectedIds = new Set([
+      ...previousSelection.selectedIds,
+      ...visibleIds,
+    ]);
+
+    this.detailSignalState.patch({
+      isSelectingAll: true,
+      selectedIds: optimisticSelectedIds,
+      selectedRows: [...vm.rows],
+      allMatchingSelected:
+        visibleIds.size > 0 && visibleIds.size === vm.totalEntries,
+      errorSummary: [],
+      errorHint: '',
+    });
+
+    try {
+      const dto = await firstValueFrom(
+        this.appListEntriesApi.getApplicationListEntryIds({
+          listId: this.id,
+          filter: this.vm().getFilters,
+        }),
+      );
+
+      this.applySelectAllMatching(dto);
+    } catch (err) {
+      const errMsg = getProblemText(err);
+      this.detailSignalState.patch({
+        isSelectingAll: false,
+        ...previousSelection,
+        updateInvalid: true,
+        errorHint: errMsg,
+        errorSummary: [{ text: errMsg }],
+      });
+    }
+  }
+
+  clearSelection(): void {
+    this.detailSignalState.patch({
+      selectedIds: new Set<string>(),
+      selectedRows: [],
+      allMatchingSelected: false,
+    });
+  }
+
+  async onResultButtonClick(): Promise<void> {
+    const selected = (await this.resolveSelectedRows()) as selectedRow[];
+
+    if (selected.length === 0) {
+      return;
+    }
 
     // clear any prior messages
     this.detailSignalState.patch({ errorSummary: [], errorHint: '' });
@@ -589,7 +703,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       title: r.title,
     }));
 
-    void this.router.navigate(['result-selected'], {
+    await this.router.navigate(['result-selected'], {
       relativeTo: this.route,
       state: {
         resultingApplications,
@@ -597,8 +711,12 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     });
   }
 
-  onMoveButtonClick(): void {
-    const selected = this.vm().selectedRows as selectedRow[];
+  async onMoveButtonClick(): Promise<void> {
+    const selected = (await this.resolveSelectedRows()) as selectedRow[];
+
+    if (selected.length === 0) {
+      return;
+    }
 
     this.detailSignalState.patch(clearUpdateNotificationsPatch());
 
@@ -611,7 +729,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       resulted: r.resulted,
     }));
 
-    void this.router.navigate(['move'], {
+    await this.router.navigate(['move'], {
       relativeTo: this.route,
       state: {
         entriesToMove,
@@ -669,7 +787,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   onPageChange(page: number): void {
     this.detailSignalState.patch({
       currentPage: page,
-      selectedIds: new Set(), // same behaviour as today
+      selectedRows: [],
     });
     this.loadListDetailsInfo();
   }
@@ -693,7 +811,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       currentPage: 0,
       rows: result.rows,
       totalPages: result.totalPages,
+      totalEntries: result.totalEntries,
       selectedIds: new Set<string>(),
+      selectedRows: [],
+      allMatchingSelected: false,
       updateInvalid: hasErrors,
       errorSummary: hasErrors ? result.errors : [],
       preserveErrorSummaryOnLoad: false,
@@ -718,9 +839,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   }
 
   private patchLoadSuccessState(
-    patch: Partial<
-      Pick<ApplicationsListDetailState, 'rows' | 'totalPages' | 'selectedIds'>
-    >,
+    patch: Partial<ServerPaginatedSelectionPatch>,
   ): void {
     if (this.loadFailed()) {
       return;
@@ -742,10 +861,74 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   private filterEntriesToPrint(
     dto: ApplicationListGetPrintDto,
   ): ApplicationListGetPrintDto {
-    return filterEntriesToPrintDto(
-      dto,
-      this.detailSignalState.state().selectedRows,
+    const selectedIds = this.detailSignalState.state().selectedIds;
+
+    const filteredEntries = dto.entries.filter((entry) =>
+      selectedIds.has(entry.id),
     );
+
+    return {
+      ...dto,
+      entries: filteredEntries,
+    };
+  }
+
+  private applySelectAllMatching(dto: EntryIdsDto): void {
+    this.detailSignalState.patch({
+      isSelectingAll: false,
+      ...buildSelectAllMatchingPatch(
+        dto.ids ?? [],
+        this.vm().rows,
+        this.vm().totalEntries,
+      ),
+    });
+  }
+
+  private async resolveSelectedRows(): Promise<Row[]> {
+    const vm = this.vm();
+
+    if (vm.selectedIds.size === 0) {
+      return vm.selectedRows;
+    }
+
+    if (vm.selectedIds.size === vm.selectedRows.length) {
+      return vm.selectedRows;
+    }
+
+    const selectedIds = new Set(vm.selectedIds);
+    const apiSortKey =
+      APPLICATION_LIST_DETAIL_SORT_MAP[vm.sortField.key] ?? vm.sortField.key;
+    const sort = [`${apiSortKey},${vm.sortField.direction}`];
+    const pageCount =
+      vm.totalPages > 0 ? vm.totalPages : vm.totalEntries > 0 ? 1 : 0;
+    const selectedRows: Row[] = [];
+
+    for (let pageNumber = 0; pageNumber < pageCount; pageNumber += 1) {
+      const page = await firstValueFrom(
+        this.appListEntriesApi.getApplicationListEntries({
+          listId: this.id,
+          pageNumber,
+          pageSize: vm.pageSize,
+          sort,
+          filter: vm.getFilters,
+        }),
+      );
+
+      const rows = mapEntrySummaryRows(page.content ?? []);
+      for (const row of rows) {
+        if (selectedIds.has(row.id)) {
+          selectedRows.push(row);
+        }
+      }
+
+      if (selectedRows.length === selectedIds.size) {
+        break;
+      }
+    }
+
+    this.detailSignalState.patch({ selectedRows });
+
+    return selectedRows;
   }
 
   private async handlePrintPage(

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -170,6 +170,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   private readonly printRequest = signal<PrintRequest | null>(null);
 
   private readonly loadFailed = signal(false);
+  private selectAllRequestVersion = 0;
 
   override form = this.appListFormService.createUpdateForm();
 
@@ -569,6 +570,10 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     return this.selectedCount > 0;
   }
 
+  get canUseBulkActions(): boolean {
+    return this.hasSelection && !this.vm().isSelectingAll;
+  }
+
   loadListDetailsInfo(): void {
     if (!this.id) {
       return;
@@ -626,6 +631,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       return;
     }
 
+    const requestVersion = this.nextSelectAllRequestVersion();
     const vm = this.vm();
     const previousSelection = {
       selectedIds: new Set(vm.selectedIds),
@@ -664,8 +670,16 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
         }),
       );
 
+      if (requestVersion !== this.selectAllRequestVersion) {
+        return;
+      }
+
       this.applySelectAllMatching(dto);
     } catch (err) {
+      if (requestVersion !== this.selectAllRequestVersion) {
+        return;
+      }
+
       const errMsg = getProblemText(err);
       this.detailSignalState.patch({
         isSelectingAll: false,
@@ -678,9 +692,11 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   }
 
   clearSelection(): void {
+    this.invalidateSelectAllRequest();
     this.detailSignalState.patch({
       selectedIds: new Set<string>(),
       selectedRows: [],
+      isSelectingAll: false,
       allMatchingSelected: false,
     });
   }
@@ -803,10 +819,25 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     this.loadListDetailsInfo();
   }
 
+  onSearchStarted(
+    filters: ApplicationsListDetailSearchResult['reqFilter'],
+  ): void {
+    this.invalidateSelectAllRequest();
+    this.detailSignalState.patch({
+      currentPage: 0,
+      getFilters: filters,
+      selectedIds: new Set<string>(),
+      selectedRows: [],
+      isSelectingAll: false,
+      allMatchingSelected: false,
+    });
+  }
+
   onSearchResult(result: ApplicationsListDetailSearchResult): void {
     const hasErrors = result.errors.length > 0;
     const filters = result.reqFilter;
 
+    this.invalidateSelectAllRequest();
     this.detailSignalState.patch({
       currentPage: 0,
       rows: result.rows,
@@ -929,6 +960,15 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
     this.detailSignalState.patch({ selectedRows });
 
     return selectedRows;
+  }
+
+  private nextSelectAllRequestVersion(): number {
+    this.selectAllRequestVersion += 1;
+    return this.selectAllRequestVersion;
+  }
+
+  private invalidateSelectAllRequest(): void {
+    this.selectAllRequestVersion += 1;
   }
 
   private async handlePrintPage(

--- a/src/app/pages/applications-list-detail/util/applications-list-detail.state.ts
+++ b/src/app/pages/applications-list-detail/util/applications-list-detail.state.ts
@@ -14,16 +14,19 @@ export interface ApplicationsListDetailState {
   currentPage: number;
   pageSize: number;
   totalPages: number;
+  totalEntries: number;
   sortField: { key: string; direction: 'desc' | 'asc' };
 
   // rows + selection
   rows: Row[];
   selectedIds: Set<string>;
   selectedRows: Row[];
+  allMatchingSelected: boolean;
 
   // flags
   createDone: boolean;
   isLoading: boolean;
+  isSelectingAll: boolean;
   updateDone: boolean;
   updateInvalid: boolean;
   moveDone: boolean;
@@ -44,14 +47,17 @@ export const initialApplicationsListDetailState: ApplicationsListDetailState = {
   currentPage: 0,
   pageSize: 10,
   totalPages: 0,
+  totalEntries: 0,
   sortField: { key: 'sequenceNumber', direction: 'asc' },
 
   rows: [],
   selectedIds: new Set<string>(),
   selectedRows: [],
+  allMatchingSelected: false,
 
   createDone: false,
   isLoading: true,
+  isSelectingAll: false,
   updateDone: false,
   updateInvalid: false,
   moveDone: false,

--- a/src/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.ts
+++ b/src/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.ts
@@ -45,6 +45,7 @@ const SEARCH_ERROR_HREFS = {
 export type ApplicationsListDetailSearchResult = {
   rows: Row[];
   totalPages: number;
+  totalEntries: number;
   reqFilter: EntryApplicationListGetFilterDto;
   errors: ErrorItem[];
 };
@@ -141,6 +142,7 @@ export class ApplicationsListDetailSearchComponent {
       this.searchResult.emit({
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: localErrors,
       });
@@ -164,6 +166,7 @@ export class ApplicationsListDetailSearchComponent {
       this.searchResult.emit({
         rows: mapEntrySummaryRows(page.content ?? []),
         totalPages: page.totalPages ?? 0,
+        totalEntries: page.totalElements ?? 0,
         reqFilter,
         errors: [],
       });
@@ -177,6 +180,7 @@ export class ApplicationsListDetailSearchComponent {
         this.searchResult.emit({
           rows: [],
           totalPages: 0,
+          totalEntries: 0,
           reqFilter: {},
           errors: apiErrors,
         });

--- a/src/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.ts
+++ b/src/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.ts
@@ -67,6 +67,7 @@ export class ApplicationsListDetailSearchComponent {
   readonly listId = input.required<string>();
   readonly pageSize = input(10);
   readonly searchResult = output<ApplicationsListDetailSearchResult>();
+  readonly searchStarted = output<EntryApplicationListGetFilterDto>();
 
   readonly submitted = signal(false);
   readonly localErrors = signal<ErrorItem[]>([]);
@@ -150,6 +151,7 @@ export class ApplicationsListDetailSearchComponent {
     }
 
     const reqFilter = this.toFilter();
+    this.searchStarted.emit(reqFilter);
 
     try {
       // GET /application-lists/{listId}/entries

--- a/src/app/shared/util/server-paginated-selection.ts
+++ b/src/app/shared/util/server-paginated-selection.ts
@@ -1,0 +1,74 @@
+import { Row } from '@core-types/table/row.types';
+
+export type ServerPaginatedSelectionPatch = {
+  rows: Row[];
+  totalPages: number;
+  totalEntries: number;
+  selectedIds: Set<string>;
+  selectedRows: Row[];
+};
+
+type PageSelectionPatchInput = {
+  rows: Row[];
+  totalPages: number;
+  totalEntries: number;
+  currentSelectedIds: Set<string>;
+};
+
+export function isAllMatchingSelected(
+  selectedIds: Set<string>,
+  totalEntries: number,
+): boolean {
+  return (
+    selectedIds.size > 0 &&
+    totalEntries > 0 &&
+    selectedIds.size === totalEntries
+  );
+}
+
+export function getVisibleSelectedRows(
+  rows: Row[],
+  selectedIds: Set<string>,
+): Row[] {
+  return rows.filter((row) => {
+    const id = row['id'];
+
+    return (
+      (typeof id === 'string' || typeof id === 'number') &&
+      selectedIds.has(String(id))
+    );
+  });
+}
+
+export function buildPageSelectionPatch({
+  rows,
+  totalPages,
+  totalEntries,
+  currentSelectedIds,
+}: PageSelectionPatchInput): ServerPaginatedSelectionPatch {
+  const selectedIds = new Set(currentSelectedIds);
+
+  return {
+    rows,
+    totalPages,
+    totalEntries,
+    selectedIds,
+    selectedRows: getVisibleSelectedRows(rows, selectedIds),
+  };
+}
+
+export function buildSelectAllMatchingPatch(
+  ids: string[],
+  rows: Row[],
+  totalEntries: number,
+): Pick<ServerPaginatedSelectionPatch, 'selectedIds' | 'selectedRows'> & {
+  allMatchingSelected: boolean;
+} {
+  const selectedIds = new Set(ids ?? []);
+
+  return {
+    selectedIds,
+    selectedRows: getVisibleSelectedRows(rows, selectedIds),
+    allMatchingSelected: isAllMatchingSelected(selectedIds, totalEntries),
+  };
+}

--- a/test/unit/app/core/components/sortable-table/sortable-table.component.spec.ts
+++ b/test/unit/app/core/components/sortable-table/sortable-table.component.spec.ts
@@ -241,6 +241,22 @@ describe('SortableTableComponent', () => {
       comp.toggleSelectAllVisible(false);
       expect(new Set(getSelectedIdsState())).toEqual(new Set(['x']));
     });
+
+    it('toggleSelectAllVisible emits external select-all without mutating ids when configured', async () => {
+      await create('browser');
+      setInput('selectable', true);
+      setInput('selectAllScope', 'external');
+      setInput('selectedIds', new Set<string>(['x']));
+
+      const selectAllSpy = jest.spyOn(comp.selectAllChange, 'emit');
+      const selectedIdsSpy = jest.spyOn(comp.selectedIdsChange, 'emit');
+
+      comp.toggleSelectAllVisible(true);
+
+      expect(selectAllSpy).toHaveBeenCalledWith(true);
+      expect(selectedIdsSpy).not.toHaveBeenCalled();
+      expect(new Set(getSelectedIdsState())).toEqual(new Set(['x']));
+    });
   });
 
   describe('caption rendering', () => {

--- a/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
@@ -9,7 +9,7 @@ import { PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router, provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { APPLICATIONS_LIST_ERROR_MESSAGES } from '@components/applications-list/util/applications-list.constants';
 import { ApplicationsListDetail } from '@components/applications-list-detail/applications-list-detail.component';
@@ -31,6 +31,7 @@ import {
   ApplicationListsApi,
   CriminalJusticeAreaGetDto,
   EntryGetSummaryDto,
+  EntryIdsDto,
   EntryPage,
 } from '@openapi';
 import { ReferenceDataFacade } from '@services/reference-data.facade';
@@ -95,9 +96,13 @@ describe('ApplicationsListDetail', () => {
   };
 
   const entriesApiStub: jest.Mocked<
-    Pick<ApplicationListEntriesApi, 'getApplicationListEntries'>
+    Pick<
+      ApplicationListEntriesApi,
+      'getApplicationListEntries' | 'getApplicationListEntryIds'
+    >
   > = {
     getApplicationListEntries: jest.fn(),
+    getApplicationListEntryIds: jest.fn(),
   };
 
   const menuStub: jest.Mocked<Pick<MojButtonMenu, 'initAll'>> = {
@@ -220,6 +225,13 @@ describe('ApplicationsListDetail', () => {
           headers: new HttpHeaders(),
         }),
       ),
+    );
+    entriesApiStub.getApplicationListEntryIds.mockReturnValue(
+      of({
+        ids: ['abc'],
+      } as EntryIdsDto) as unknown as ReturnType<
+        ApplicationListEntriesApi['getApplicationListEntryIds']
+      >,
     );
 
     await TestBed.configureTestingModule({
@@ -495,9 +507,7 @@ describe('ApplicationsListDetail', () => {
       component as unknown as PrintHelpersAccessor;
 
     it('returns only entries whose row ids are selected', () => {
-      patchDetailState({
-        selectedRows: [{ id: 'entry-1' } as Row, { id: 'entry-3' } as Row],
-      });
+      patchDetailState({ selectedIds: new Set(['entry-1', 'entry-3']) });
 
       const dto = {
         entries: [{ id: 'entry-1' }, { id: 'entry-2' }, { id: 'entry-3' }],
@@ -512,7 +522,7 @@ describe('ApplicationsListDetail', () => {
     });
 
     it('returns the dto with an empty entries array when nothing is selected', () => {
-      patchDetailState({ selectedRows: [] });
+      patchDetailState({ selectedIds: new Set<string>() });
 
       const dto = {
         entries: [{ id: 'entry-1' }, { id: 'entry-2' }],
@@ -743,7 +753,7 @@ describe('ApplicationsListDetail', () => {
         )
         .mockResolvedValue();
 
-      patchDetailState({ selectedRows: [{ id: 'entry-1' } as Row] });
+      patchDetailState({ selectedIds: new Set(['entry-1']) });
 
       (component as unknown as PrintRequestSignalAccessor).printRequest.set({
         id: 'list-123',
@@ -790,7 +800,7 @@ describe('ApplicationsListDetail', () => {
         )
         .mockResolvedValue();
 
-      patchDetailState({ selectedRows: [{ id: 'entry-2' } as Row] });
+      patchDetailState({ selectedIds: new Set(['entry-2']) });
 
       (component as unknown as PrintRequestSignalAccessor).printRequest.set({
         id: 'list-123',
@@ -1084,17 +1094,40 @@ describe('ApplicationsListDetail', () => {
     });
   });
 
-  it('onPageChange patches page + clears selectedIds + triggers load', () => {
+  it('onPageChange patches page + preserves selectedIds + triggers load', () => {
     const loadSpy = jest
       .spyOn(component, 'loadListDetailsInfo')
       .mockImplementation(() => undefined);
 
-    patchDetailState({ selectedIds: new Set(['a', 'b']) });
+    patchDetailState({
+      selectedIds: new Set(['a', 'b']),
+      selectedRows: [{ id: 'a' } as Row],
+    });
 
     component.onPageChange(3);
 
     expect(vm().currentPage).toBe(3);
-    expect(vm().selectedIds.size).toBe(0);
+    expect(vm().selectedIds).toEqual(new Set(['a', 'b']));
+    expect(vm().selectedRows).toEqual([]);
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onPageChange preserves selectedIds when all matching rows are selected', () => {
+    const loadSpy = jest
+      .spyOn(component, 'loadListDetailsInfo')
+      .mockImplementation(() => undefined);
+
+    patchDetailState({
+      selectedIds: new Set(['a', 'b']),
+      allMatchingSelected: true,
+      selectedRows: [{ id: 'a' } as Row],
+    });
+
+    component.onPageChange(2);
+
+    expect(vm().currentPage).toBe(2);
+    expect(vm().selectedIds).toEqual(new Set(['a', 'b']));
+    expect(vm().selectedRows).toEqual([]);
     expect(loadSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -1213,7 +1246,8 @@ describe('ApplicationsListDetail', () => {
         },
       ]);
 
-      expect(vm().selectedIds.has('stale-id')).toBe(false);
+      expect(vm().selectedIds.has('stale-id')).toBe(true);
+      expect(vm().selectedRows).toEqual([]);
       expect(vm().totalPages).toBe(0);
     });
 
@@ -1297,6 +1331,108 @@ describe('ApplicationsListDetail', () => {
     expect(vm().selectedRows).toEqual(rows);
   });
 
+  it('onSelectedIdsChange patches selected ids, visible rows, and allMatchingSelected', () => {
+    patchDetailState({
+      rows: [
+        { id: 'id-1', title: 'One' } as Row,
+        { id: 'id-2', title: 'Two' } as Row,
+      ],
+      totalEntries: 2,
+    });
+
+    component.onSelectedIdsChange(new Set(['id-1', 'id-2']));
+
+    expect(vm().selectedIds).toEqual(new Set(['id-1', 'id-2']));
+    expect(vm().selectedRows).toEqual([
+      { id: 'id-1', title: 'One' },
+      { id: 'id-2', title: 'Two' },
+    ]);
+    expect(vm().allMatchingSelected).toBe(true);
+  });
+
+  it('onHeaderSelectAllChange selects all matching rows when checked', () => {
+    const selectAllSpy = jest
+      .spyOn(component, 'onSelectAllMatchingClick')
+      .mockResolvedValue();
+
+    component.onHeaderSelectAllChange(true);
+
+    expect(selectAllSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onHeaderSelectAllChange clears selection when unchecked', () => {
+    patchDetailState({
+      selectedIds: new Set(['id-1']),
+      selectedRows: [{ id: 'id-1' } as Row],
+      allMatchingSelected: true,
+    });
+
+    component.onHeaderSelectAllChange(false);
+
+    expect(vm().selectedIds.size).toBe(0);
+    expect(vm().selectedRows).toEqual([]);
+    expect(vm().allMatchingSelected).toBe(false);
+  });
+
+  it('onSelectAllMatchingClick loads ids from the new endpoint', async () => {
+    entriesApiStub.getApplicationListEntryIds.mockReturnValueOnce(
+      of({ ids: ['abc', 'def'] } as EntryIdsDto) as unknown as ReturnType<
+        ApplicationListEntriesApi['getApplicationListEntryIds']
+      >,
+    );
+
+    patchDetailState({
+      rows: [{ id: 'abc', title: 'Visible row' } as Row],
+      totalEntries: 2,
+      getFilters: { applicantName: 'Smith' },
+    });
+    component.id = 'list-123';
+
+    await component.onSelectAllMatchingClick();
+
+    expect(entriesApiStub.getApplicationListEntryIds).toHaveBeenCalledWith({
+      listId: 'list-123',
+      filter: { applicantName: 'Smith' },
+    });
+    expect(vm().selectedIds).toEqual(new Set(['abc', 'def']));
+    expect(vm().selectedRows).toEqual([{ id: 'abc', title: 'Visible row' }]);
+    expect(vm().allMatchingSelected).toBe(true);
+  });
+
+  it('onSelectAllMatchingClick selects visible rows immediately before ids request completes', async () => {
+    const ids$ = new Subject<EntryIdsDto>();
+    entriesApiStub.getApplicationListEntryIds.mockReturnValueOnce(
+      ids$ as unknown as ReturnType<
+        ApplicationListEntriesApi['getApplicationListEntryIds']
+      >,
+    );
+
+    patchDetailState({
+      rows: [
+        { id: 'abc', title: 'Visible row' } as Row,
+        { id: 'def', title: 'Visible row 2' } as Row,
+      ],
+      totalEntries: 4,
+    });
+    component.id = 'list-123';
+
+    const pending = component.onSelectAllMatchingClick();
+
+    expect(vm().selectedIds).toEqual(new Set(['abc', 'def']));
+    expect(vm().selectedRows).toEqual([
+      { id: 'abc', title: 'Visible row' },
+      { id: 'def', title: 'Visible row 2' },
+    ]);
+    expect(vm().allMatchingSelected).toBe(false);
+
+    ids$.next({ ids: ['abc', 'def', 'ghi', 'jkl'] });
+    ids$.complete();
+    await pending;
+
+    expect(vm().selectedIds).toEqual(new Set(['abc', 'def', 'ghi', 'jkl']));
+    expect(vm().allMatchingSelected).toBe(true);
+  });
+
   it('prefillFromApi: sets listRow when navigation state row is missing', () => {
     component.listRow = undefined;
     component['etag'] = '"etag-v2"';
@@ -1330,9 +1466,9 @@ describe('ApplicationsListDetail', () => {
   });
 
   describe('onResultButtonClick', () => {
-    it('navigates to result-selected with selected  applications', () => {
+    it('navigates to result-selected with selected  applications', async () => {
       const router = TestBed.inject(Router);
-      const navSpy = jest.spyOn(router, 'navigate');
+      const navSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
 
       patchDetailState({
         selectedRows: [
@@ -1353,7 +1489,7 @@ describe('ApplicationsListDetail', () => {
         ],
       });
 
-      component.onResultButtonClick();
+      await component.onResultButtonClick();
 
       expect(navSpy).toHaveBeenCalledTimes(1);
 
@@ -1375,6 +1511,73 @@ describe('ApplicationsListDetail', () => {
                 title: 'T2',
               },
             ],
+          },
+        }),
+      );
+    });
+
+    it('resolves rows across pages when selected ids exceed visible rows', async () => {
+      const router = TestBed.inject(Router);
+      const navSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      entriesApiStub.getApplicationListEntries.mockReturnValueOnce(
+        of({
+          pageNumber: 0,
+          pageSize: 10,
+          totalElements: 2,
+          totalPages: 1,
+          first: true,
+          last: true,
+          elementsOnPage: 2,
+          sort: { orders: [] },
+          content: [
+            {
+              id: 'entry-1',
+              sequenceNumber: 1,
+              accountNumber: '',
+              applicant: undefined,
+              respondent: undefined,
+              applicationTitle: 'First',
+              isFeeRequired: true,
+              isResulted: false,
+              status: ApplicationListStatus.OPEN,
+            },
+            {
+              id: 'entry-2',
+              sequenceNumber: 2,
+              accountNumber: '',
+              applicant: undefined,
+              respondent: undefined,
+              applicationTitle: 'Second',
+              isFeeRequired: false,
+              isResulted: false,
+              status: ApplicationListStatus.OPEN,
+            },
+          ],
+        } as EntryPage) as unknown as ReturnType<
+          ApplicationListEntriesApi['getApplicationListEntries']
+        >,
+      );
+
+      patchDetailState({
+        selectedIds: new Set(['entry-1', 'entry-2']),
+        selectedRows: [
+          { id: 'entry-1', sequenceNumber: 1, title: 'First' } as Row,
+        ],
+        totalEntries: 2,
+        totalPages: 1,
+      });
+
+      await component.onResultButtonClick();
+
+      expect(navSpy).toHaveBeenCalledWith(
+        ['result-selected'],
+        expect.objectContaining({
+          state: {
+            resultingApplications: expect.arrayContaining([
+              expect.objectContaining({ id: 'entry-1', sequenceNumber: 1 }),
+              expect.objectContaining({ id: 'entry-2', sequenceNumber: 2 }),
+            ]),
           },
         }),
       );

--- a/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
@@ -1364,6 +1364,7 @@ describe('ApplicationsListDetail', () => {
     patchDetailState({
       selectedIds: new Set(['id-1']),
       selectedRows: [{ id: 'id-1' } as Row],
+      isSelectingAll: true,
       allMatchingSelected: true,
     });
 
@@ -1371,6 +1372,7 @@ describe('ApplicationsListDetail', () => {
 
     expect(vm().selectedIds.size).toBe(0);
     expect(vm().selectedRows).toEqual([]);
+    expect(vm().isSelectingAll).toBe(false);
     expect(vm().allMatchingSelected).toBe(false);
   });
 
@@ -1431,6 +1433,65 @@ describe('ApplicationsListDetail', () => {
 
     expect(vm().selectedIds).toEqual(new Set(['abc', 'def', 'ghi', 'jkl']));
     expect(vm().allMatchingSelected).toBe(true);
+  });
+
+  it('onSelectAllMatchingClick ignores stale responses after selection is cleared', async () => {
+    const ids$ = new Subject<EntryIdsDto>();
+    entriesApiStub.getApplicationListEntryIds.mockReturnValueOnce(
+      ids$ as unknown as ReturnType<
+        ApplicationListEntriesApi['getApplicationListEntryIds']
+      >,
+    );
+
+    patchDetailState({
+      rows: [{ id: 'abc', title: 'Visible row' } as Row],
+      totalEntries: 2,
+    });
+    component.id = 'list-123';
+
+    const pending = component.onSelectAllMatchingClick();
+    component.clearSelection();
+
+    ids$.next({ ids: ['abc', 'def'] });
+    ids$.complete();
+    await pending;
+
+    expect(vm().selectedIds.size).toBe(0);
+    expect(vm().selectedRows).toEqual([]);
+    expect(vm().allMatchingSelected).toBe(false);
+  });
+
+  it('onSearchStarted clears selection and invalidates pending select all', async () => {
+    const ids$ = new Subject<EntryIdsDto>();
+    entriesApiStub.getApplicationListEntryIds.mockReturnValueOnce(
+      ids$ as unknown as ReturnType<
+        ApplicationListEntriesApi['getApplicationListEntryIds']
+      >,
+    );
+
+    patchDetailState({
+      rows: [{ id: 'abc', title: 'Visible row' } as Row],
+      totalEntries: 2,
+      selectedIds: new Set(['abc']),
+      selectedRows: [{ id: 'abc', title: 'Visible row' } as Row],
+      getFilters: { applicantName: 'Old' },
+    });
+    component.id = 'list-123';
+
+    const pending = component.onSelectAllMatchingClick();
+    component.onSearchStarted({ applicantName: 'New' });
+
+    expect(vm().selectedIds.size).toBe(0);
+    expect(vm().selectedRows).toEqual([]);
+    expect(vm().getFilters).toEqual({ applicantName: 'New' });
+    expect(vm().isSelectingAll).toBe(false);
+
+    ids$.next({ ids: ['abc', 'def'] });
+    ids$.complete();
+    await pending;
+
+    expect(vm().selectedIds.size).toBe(0);
+    expect(vm().selectedRows).toEqual([]);
   });
 
   it('prefillFromApi: sets listRow when navigation state row is missing', () => {

--- a/test/unit/app/shared/components/applications-list-detail-search.component.spec.ts
+++ b/test/unit/app/shared/components/applications-list-detail-search.component.spec.ts
@@ -61,6 +61,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: [
           {
@@ -91,6 +92,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: [
           {
@@ -215,6 +217,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
         },
       ],
       totalPages: 2,
+      totalEntries: 1,
       reqFilter: {
         accountReference: undefined,
         applicantName: 'Applicant Org',
@@ -247,6 +250,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: [
           {

--- a/test/unit/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.spec.ts
+++ b/test/unit/app/shared/components/applications-list-detail-search/applications-list-detail-search.component.spec.ts
@@ -88,6 +88,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: component.localErrors(),
       },
@@ -204,6 +205,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
           sequenceNumber: 12,
         },
         totalPages: 3,
+        totalEntries: 1,
         errors: [],
       },
     ]);
@@ -239,6 +241,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: [
           { id: 'applicantName', text: 'Applicant is invalid' },
@@ -266,6 +269,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {},
         errors: [{ text: 'Request failed' }],
       },
@@ -317,6 +321,7 @@ describe('ApplicationsListDetailSearchComponent', () => {
       {
         rows: [],
         totalPages: 0,
+        totalEntries: 0,
         reqFilter: {
           accountReference: undefined,
           applicantName: undefined,


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1294

### Change description
- Added cross-page selection support to `Applications List Detail`, backed by the new IDs-only backend endpoint for list entries.
- Updated the shared sortable table so the header checkbox can optionally delegate “select all” handling to the parent page, allowing true server-backed select-all behavior where needed.
- Persisted manual row selections across pagination instead of clearing them on page change.
- Made header-checkbox select-all feel immediate by optimistically selecting visible rows first, then completing full cross-page selection when the IDs request returns.
- Extracted reusable server-paginated selection helpers into a shared util to support similar patterns on other screens.
- Kept bulk actions working with cross-page selection by resolving full selected row data on demand for move/result/print flows.
- Refactored Applications List Detail print handling to use shared PDF helper utilities.
- Updated search/result state contracts and unit tests to cover the new `totalEntries` field and the revised selection behavior.


### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
