### PR TITLE
ARCPOC-1355 SA page and ale sa bug fixes, pagination, no refresh on sort

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('Infrastructure')
+@Library('Infrastructure@removemavencentral')
 
 def type = 'angular'
 def product = 'appreg'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('Infrastructure@removemavencentral')
+@Library('Infrastructure')
 
 def type = 'angular'
 def product = 'appreg'

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -50,12 +50,17 @@
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />
 
-@if (vm().hasSearched && !vm().isLoading && !vm().searchErrors.length) {
+@if (
+  vm().hasSearched &&
+  (!vm().isLoading || vm().rows.length) &&
+  (vm().rows.length || !vm().searchErrors.length)
+) {
   <!-- Sortable table component -->
   <app-sortable-table
     id="sa-sortable-table"
     [columns]="columns"
     [data]="vm().rows"
+    [loading]="vm().isLoading"
     [clientOrServerSort]="'server'"
     [sortKey]="vm().sortField.key"
     [sortDirection]="vm().sortField.direction"

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -40,10 +40,10 @@ import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
 
-type StandardApplicantFilters = {
-  code?: string;
-  name?: string;
-};
+type StandardApplicantFilters = Pick<
+  GetStandardApplicantsRequestParams,
+  'code' | 'name'
+>;
 
 type StandardApplicantsState = {
   hasSearched: boolean;

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -40,6 +40,11 @@ import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
 import { StandardApplicantRow } from '@util/types/applications-list-entry/types';
 
+type StandardApplicantFilters = {
+  code?: string;
+  name?: string;
+};
+
 type StandardApplicantsState = {
   hasSearched: boolean;
   currentPage: number;
@@ -91,6 +96,7 @@ export class StandardApplicants implements OnInit {
   readonly submitted = signal(false);
   private readonly errorMap: ErrorMessageMap =
     STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES;
+  private appliedFilters: StandardApplicantFilters = {};
   onCreateErrorClick = onCreateErrorClickFn;
 
   form = new FormGroup({
@@ -126,8 +132,9 @@ export class StandardApplicants implements OnInit {
       return;
     }
 
+    this.appliedFilters = this.getTrimmedFilters();
     this.signalState.patch({ hasSearched: true });
-    this.loadStandardApplicants(0);
+    this.loadStandardApplicants(0, this.appliedFilters);
   }
 
   fieldError(id: string): ErrorItem | undefined {
@@ -135,16 +142,16 @@ export class StandardApplicants implements OnInit {
   }
 
   onSortChange(sort: { key: string; direction: 'desc' | 'asc' }): void {
-    if (!this.canSearch()) {
+    if (!this.vm().hasSearched) {
       return;
     }
 
     this.signalState.patch({ sortField: sort });
-    this.loadStandardApplicants(0);
+    this.loadStandardApplicants(this.vm().currentPage);
   }
 
   onPageChange(page: number): void {
-    if (!this.canSearch()) {
+    if (!this.vm().hasSearched) {
       return;
     }
 
@@ -186,22 +193,24 @@ export class StandardApplicants implements OnInit {
     return buildFormErrorSummary(this.form, this.errorMap);
   }
 
-  private canSearch(): boolean {
-    this.form.updateValueAndValidity({ emitEvent: false });
+  private getTrimmedFilters(): StandardApplicantFilters {
+    const code = this.form.controls.code.value.trim();
+    const name = this.form.controls.name.value.trim();
 
-    const validationErrors = this.buildErrorSummary();
-    this.signalState.patch({ searchErrors: validationErrors });
-
-    return validationErrors.length === 0;
+    return {
+      code: code || undefined,
+      name: name || undefined,
+    };
   }
 
-  private loadStandardApplicants(page: number): void {
+  private loadStandardApplicants(
+    page: number,
+    filters: StandardApplicantFilters = this.appliedFilters,
+  ): void {
     if (this.vm().isLoading) {
       return;
     }
 
-    const code = this.form.controls.code.value.trim();
-    const name = this.form.controls.name.value.trim();
     const sort = this.vm().sortField;
     const apiSortKey = toStandardApplicantSortKey(sort.key);
 
@@ -212,8 +221,8 @@ export class StandardApplicants implements OnInit {
     });
 
     this.loadRequest.set({
-      code: code || undefined,
-      name: name || undefined,
+      code: filters.code,
+      name: filters.name,
       pageNumber: page,
       pageSize: this.vm().pageSize,
       sort: [`${apiSortKey},${sort.direction}`],

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.html
@@ -26,12 +26,13 @@
     </div>
   </form>
 
-  @if (vm().hasSearched && !vm().loading) {
+  @if (vm().hasSearched && (!vm().loading || rows.length)) {
     <app-sortable-table
       id="standard-applicant-table"
       caption="Standard applicants"
       [columns]="columns"
       [data]="rows"
+      [loading]="vm().loading"
       [clientOrServerSort]="'server'"
       [sortKey]="vm().sortField.key"
       [sortDirection]="vm().sortField.direction"

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -37,7 +37,10 @@ import {
   TableColumn,
 } from '@components/sortable-table/sortable-table.component';
 import { TextInputComponent } from '@components/text-input/text-input.component';
-import { StandardApplicantsApi } from '@openapi';
+import {
+  GetStandardApplicantsRequestParams,
+  StandardApplicantsApi,
+} from '@openapi';
 import { ErrorMessageMap, buildFormErrorSummary } from '@util/error-summary';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { toStandardApplicantSortKey } from '@util/standard-applicant-sort-map';
@@ -48,10 +51,10 @@ export type SelectedStandardApplicantSummary = {
   name: string;
 };
 
-type StandardApplicantFilters = {
-  code?: string;
-  name?: string;
-};
+type StandardApplicantFilters = Pick<
+  GetStandardApplicantsRequestParams,
+  'code' | 'name'
+>;
 
 @Component({
   selector: 'app-standard-applicant-select',
@@ -86,13 +89,8 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
   private readonly saState = this.saSignalState.state;
   readonly vm = this.saSignalState.vm;
 
-  private readonly loadRequest = signal<{
-    code?: string;
-    name?: string;
-    pageNumber: number;
-    pageSize: number;
-    sort: string[];
-  } | null>(null);
+  private readonly loadRequest =
+    signal<GetStandardApplicantsRequestParams | null>(null);
   readonly submitted = signal(false);
   private readonly errorMap: ErrorMessageMap =
     STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES;

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -48,6 +48,11 @@ export type SelectedStandardApplicantSummary = {
   name: string;
 };
 
+type StandardApplicantFilters = {
+  code?: string;
+  name?: string;
+};
+
 @Component({
   selector: 'app-standard-applicant-select',
   standalone: true,
@@ -91,6 +96,7 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
   readonly submitted = signal(false);
   private readonly errorMap: ErrorMessageMap =
     STANDARD_APPLICANT_SEARCH_ERROR_MESSAGES;
+  private appliedFilters: StandardApplicantFilters = {};
 
   form = new FormGroup({
     code: new FormControl<string>('', {
@@ -147,9 +153,6 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     if (!this.saState().hasSearched) {
       return;
     }
-    if (!this.canLoadPage()) {
-      return;
-    }
     this.loadPage(page);
   }
 
@@ -157,11 +160,8 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     if (!this.saState().hasSearched) {
       return;
     }
-    if (!this.canLoadPage()) {
-      return;
-    }
     this.saSignalState.patch({ sortField: sort });
-    this.loadPage(0);
+    this.loadPage(this.vm().pageIndex);
   }
 
   onSubmit(event: SubmitEvent): void {
@@ -178,22 +178,13 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
       return;
     }
 
+    this.appliedFilters = this.getTrimmedFilters();
     this.saSignalState.patch({ hasSearched: true });
-    this.loadPage(0);
+    this.loadPage(0, this.appliedFilters);
   }
 
   fieldError(id: string): ErrorItem | undefined {
     return this.vm().searchErrors.find((e) => e.id === id);
-  }
-
-  private canLoadPage(): boolean {
-    this.form.updateValueAndValidity({ emitEvent: false });
-
-    const validationErrors = this.buildErrorSummary();
-    this.saSignalState.patch({ searchErrors: validationErrors });
-    this.searchErrorsChange.emit(validationErrors);
-
-    return validationErrors.length === 0;
   }
 
   private setupEffects(): void {
@@ -244,7 +235,20 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     });
   }
 
-  private loadPage(page: number): void {
+  private getTrimmedFilters(): StandardApplicantFilters {
+    const code = this.form.controls.code.value.trim();
+    const name = this.form.controls.name.value.trim();
+
+    return {
+      code: code || undefined,
+      name: name || undefined,
+    };
+  }
+
+  private loadPage(
+    page: number,
+    filters: StandardApplicantFilters = this.appliedFilters,
+  ): void {
     if (this.saState().loading) {
       return;
     }
@@ -254,13 +258,11 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     const pageSize = this.saState().pageSize;
     const sort = this.saState().sortField;
     const apiSortKey = toStandardApplicantSortKey(sort.key);
-    const code = this.form.controls.code.value.trim();
-    const name = this.form.controls.name.value.trim();
 
     this.loadRequest.set({
-      code: code || undefined,
-      name: name || undefined,
-      pageNumber: this.saState().pageIndex,
+      code: filters.code,
+      name: filters.name,
+      pageNumber: page,
       pageSize,
       sort: [`${apiSortKey},${sort.direction}`],
     });

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, Subject, of, throwError } from 'rxjs';
 
 import { StandardApplicants } from '@components/standard-applicants/standard-applicants.component';
 import { StandardApplicantPage, StandardApplicantsApi } from '@openapi';
@@ -36,6 +36,7 @@ describe('StandardApplicantsComponent', () => {
   };
 
   beforeEach(async () => {
+    getStandardApplicantsMock.mockReset();
     getStandardApplicantsMock.mockReturnValue(
       of({
         pageNumber: 0,
@@ -110,18 +111,21 @@ describe('StandardApplicantsComponent', () => {
     await flushSignalEffects(fixture);
 
     expect(getStandardApplicantsMock).not.toHaveBeenCalled();
-    expect(component.vm().searchErrors).toEqual([
-      {
-        id: 'code',
-        text: 'Code must be 10 characters or fewer',
-        href: '#code',
-      },
-      {
-        id: 'name',
-        text: 'Standard applicant name must be 100 characters or fewer',
-        href: '#name',
-      },
-    ]);
+    expect(component.vm().searchErrors).toHaveLength(2);
+    expect(component.vm().searchErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'code',
+          text: 'Code must be 10 characters or fewer',
+          href: '#code',
+        }),
+        expect.objectContaining({
+          id: 'name',
+          text: 'Standard applicant name must be 100 characters or fewer',
+          href: '#name',
+        }),
+      ]),
+    );
     expect(component.fieldError('code')?.text).toBe(
       'Code must be 10 characters or fewer',
     );
@@ -156,7 +160,128 @@ describe('StandardApplicantsComponent', () => {
     ).toContain('No results found.');
   });
 
+  it('keeps the table mounted while a sort request is in flight when rows already exist', async () => {
+    const inFlightResponse = new Subject<StandardApplicantPage>();
+
+    getStandardApplicantsMock.mockReturnValueOnce(
+      of({
+        pageNumber: 0,
+        pageSize: 10,
+        totalElements: 1,
+        content: [
+          {
+            code: 'SA01',
+            applicant: {
+              organisation: {
+                name: 'Applicant Org',
+                contactDetails: { addressLine1: '1 Test Street' },
+              },
+            },
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+          },
+        ],
+        elementsOnPage: 1,
+        totalPages: 1,
+      }),
+    );
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    getStandardApplicantsMock.mockReturnValueOnce(inFlightResponse);
+
+    component.onSortChange({ key: 'name', direction: 'desc' });
+    fixture.detectChanges();
+
+    const table = fixture.debugElement.query(By.css('app-sortable-table'));
+    expect(table).toBeTruthy();
+    expect(table.componentInstance.loading()).toBe(true);
+
+    inFlightResponse.next({
+      pageNumber: 0,
+      pageSize: 10,
+      totalElements: 1,
+      content: [
+        {
+          code: 'SA01',
+          applicant: {
+            organisation: {
+              name: 'Applicant Org',
+              contactDetails: { addressLine1: '1 Test Street' },
+            },
+          },
+          startDate: '2026-01-01',
+          endDate: '2026-12-31',
+        },
+      ],
+      elementsOnPage: 1,
+      totalPages: 1,
+    });
+    inFlightResponse.complete();
+    await flushSignalEffects(fixture);
+
+    expect(
+      fixture.debugElement.query(By.css('app-sortable-table')),
+    ).toBeTruthy();
+  });
+
+  it('keeps existing results visible when validation errors are shown', async () => {
+    getStandardApplicantsMock.mockReturnValueOnce(
+      of({
+        pageNumber: 0,
+        pageSize: 10,
+        totalElements: 1,
+        content: [
+          {
+            code: 'SA01',
+            applicant: {
+              organisation: {
+                name: 'Applicant Org',
+                contactDetails: { addressLine1: '1 Test Street' },
+              },
+            },
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+          },
+        ],
+        elementsOnPage: 1,
+        totalPages: 1,
+      }),
+    );
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    component.form.patchValue({
+      name: 'x'.repeat(101),
+    });
+
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    expect(component.vm().searchErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'name',
+          text: 'Standard applicant name must be 100 characters or fewer',
+          href: '#name',
+        }),
+      ]),
+    );
+    expect(
+      fixture.debugElement.query(By.css('app-error-summary')),
+    ).toBeTruthy();
+    expect(
+      fixture.debugElement.query(By.css('app-sortable-table')),
+    ).toBeTruthy();
+  });
+
   it('loads selected page when pagination changes', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+    getStandardApplicantsMock.mockClear();
+
     component.onPageChange(3);
     await flushSignalEffects(fixture);
 
@@ -176,7 +301,11 @@ describe('StandardApplicantsComponent', () => {
     );
   });
 
-  it('maps useFrom sort key to backend from parameter', async () => {
+  it('maps useFrom sort key to backend from parameter on the current page', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+    getStandardApplicantsMock.mockClear();
+
     component.onSortChange({ key: 'useFrom', direction: 'desc' });
     await flushSignalEffects(fixture);
 
@@ -196,7 +325,84 @@ describe('StandardApplicantsComponent', () => {
     );
   });
 
-  it('does not sort when filters are invalid', async () => {
+  it('keeps the current page number when sorting after paging', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
+    getStandardApplicantsMock.mockReturnValueOnce(
+      of({
+        pageNumber: 1,
+        pageSize: 10,
+        totalElements: 11,
+        content: [
+          {
+            code: 'SA10',
+            applicant: {
+              organisation: {
+                name: 'Applicant Org',
+                contactDetails: { addressLine1: '10 Test Street' },
+              },
+            },
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+          },
+        ],
+        elementsOnPage: 1,
+        totalPages: 2,
+      }),
+    );
+
+    getStandardApplicantsMock.mockClear();
+    component.onPageChange(1);
+    await flushSignalEffects(fixture);
+
+    getStandardApplicantsMock.mockReturnValueOnce(
+      of({
+        pageNumber: 1,
+        pageSize: 10,
+        totalElements: 11,
+        content: [
+          {
+            code: 'SA01',
+            applicant: {
+              organisation: {
+                name: 'Applicant Org',
+                contactDetails: { addressLine1: '1 Test Street' },
+              },
+            },
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+          },
+        ],
+        elementsOnPage: 1,
+        totalPages: 2,
+      }),
+    );
+
+    component.onSortChange({ key: 'useFrom', direction: 'desc' });
+    await flushSignalEffects(fixture);
+
+    expect(getStandardApplicantsMock).toHaveBeenLastCalledWith(
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 1,
+        pageSize: 10,
+        sort: ['from,desc'],
+      },
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+    expect(component.vm().currentPage).toBe(1);
+  });
+
+  it('sorts using the last applied filters when the current form is invalid', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
     component.form.patchValue({
       name: 'x'.repeat(101),
     });
@@ -205,18 +411,30 @@ describe('StandardApplicantsComponent', () => {
     component.onSortChange({ key: 'useFrom', direction: 'desc' });
     await flushSignalEffects(fixture);
 
-    expect(getStandardApplicantsMock).not.toHaveBeenCalled();
-    expect(component.vm().sortField).toEqual({ key: 'code', direction: 'asc' });
-    expect(component.vm().searchErrors).toEqual([
+    expect(getStandardApplicantsMock).toHaveBeenCalledWith(
       {
-        id: 'name',
-        text: 'Standard applicant name must be 100 characters or fewer',
-        href: '#name',
+        code: undefined,
+        name: undefined,
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['from,desc'],
       },
-    ]);
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+    expect(component.vm().sortField).toEqual({
+      key: 'useFrom',
+      direction: 'desc',
+    });
   });
 
-  it('does not paginate when filters are invalid', async () => {
+  it('paginates using the last applied filters when the current form is invalid', async () => {
+    component.onSubmit(new SubmitEvent('submit'));
+    await flushSignalEffects(fixture);
+
     component.form.patchValue({
       code: '12345678901',
     });
@@ -225,15 +443,21 @@ describe('StandardApplicantsComponent', () => {
     component.onPageChange(3);
     await flushSignalEffects(fixture);
 
-    expect(getStandardApplicantsMock).not.toHaveBeenCalled();
-    expect(component.vm().currentPage).toBe(0);
-    expect(component.vm().searchErrors).toEqual([
+    expect(getStandardApplicantsMock).toHaveBeenCalledWith(
       {
-        id: 'code',
-        text: 'Code must be 10 characters or fewer',
-        href: '#code',
+        code: undefined,
+        name: undefined,
+        pageNumber: 3,
+        pageSize: 10,
+        sort: ['code,asc'],
       },
-    ]);
+      'body',
+      false,
+      {
+        transferCache: true,
+      },
+    );
+    expect(component.vm().currentPage).toBe(3);
   });
 
   it('updates rows and total pages on successful response', async () => {
@@ -286,12 +510,20 @@ describe('StandardApplicantsComponent', () => {
 
     expect(component.vm().rows).toEqual([]);
     expect(component.vm().totalPages).toBe(0);
-    expect(component.vm().searchErrors).toEqual([
-      { id: 'search', text: 'Request failed' },
-    ]);
+    expect(component.vm().searchErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'search',
+          text: 'Request failed',
+        }),
+      ]),
+    );
+    expect(
+      fixture.debugElement.query(By.css('app-error-summary')),
+    ).toBeTruthy();
   });
 
-  it('does not render table no-data state when the search fails', async () => {
+  it('shows an error state instead of the table no-data state when the search fails', async () => {
     getStandardApplicantsMock.mockReturnValueOnce(
       throwError(() => new Error('Request failed')),
     );
@@ -299,7 +531,13 @@ describe('StandardApplicantsComponent', () => {
     component.onSubmit(new SubmitEvent('submit'));
     await flushSignalEffects(fixture);
 
+    expect(
+      fixture.debugElement.query(By.css('app-error-summary')),
+    ).toBeTruthy();
     expect(fixture.debugElement.query(By.css('app-sortable-table'))).toBeNull();
     expect(fixture.nativeElement.querySelector('#no-data-message')).toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('app-notification-banner')),
+    ).toBeNull();
   });
 });

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { StandardApplicantSelectComponent } from '@components/standard-applicant-select/standard-applicant-select.component';
 import {
@@ -266,7 +266,7 @@ describe('StandardApplicantSelectComponent', () => {
     expect(component.vm().totalPages).toBe(0);
   });
 
-  it('maps useTo sort key to backend to and reloads first page', () => {
+  it('maps useTo sort key to backend to and reloads the current page', () => {
     fixture.detectChanges();
     fixture.detectChanges();
 
@@ -286,6 +286,87 @@ describe('StandardApplicantSelectComponent', () => {
       expect.objectContaining({ transferCache: true }),
     );
     expect(component.vm().pageIndex).toBe(0);
+  });
+
+  it('keeps the current page number when sorting after paging', () => {
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    mockGetStandardApplicants.mockReturnValueOnce(
+      of({
+        content: [makeSummary({ code: 'SA-10' })],
+        pageNumber: 1,
+        pageSize: 10,
+        totalElements: 11,
+        totalPages: 2,
+      }),
+    );
+
+    component.onPageChange(1);
+    fixture.detectChanges();
+
+    mockGetStandardApplicants.mockReturnValueOnce(
+      of({
+        content: [makeSummary({ code: 'SA-1' })],
+        pageNumber: 1,
+        pageSize: 10,
+        totalElements: 11,
+        totalPages: 2,
+      }),
+    );
+
+    component.onSortChange({ key: 'useTo', direction: 'desc' });
+    fixture.detectChanges();
+
+    expect(mockGetStandardApplicants).toHaveBeenLastCalledWith(
+      {
+        code: undefined,
+        name: undefined,
+        pageNumber: 1,
+        pageSize: 10,
+        sort: ['to,desc'],
+      },
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
+    expect(component.vm().pageIndex).toBe(1);
+  });
+
+  it('keeps the table mounted while a sort request is in flight when rows already exist', () => {
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const inFlightResponse = new Subject<{
+      content: StandardApplicantGetSummaryDto[];
+      pageNumber: number;
+      pageSize: number;
+      totalElements: number;
+      totalPages: number;
+    }>();
+
+    mockGetStandardApplicants.mockReturnValueOnce(inFlightResponse);
+
+    component.onSortChange({ key: 'name', direction: 'desc' });
+    fixture.detectChanges();
+
+    const table = fixture.debugElement.query(By.css('app-sortable-table'));
+    expect(table).toBeTruthy();
+    expect(table.componentInstance.loading()).toBe(true);
+
+    inFlightResponse.next({
+      content: [makeSummary({ code: 'SA-1' })],
+      pageNumber: 0,
+      pageSize: 10,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    inFlightResponse.complete();
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('app-sortable-table')),
+    ).toBeTruthy();
   });
 
   it('submits trimmed code and name filters', () => {
@@ -309,7 +390,7 @@ describe('StandardApplicantSelectComponent', () => {
     );
   });
 
-  it('does not sort when filters are invalid', fakeAsync(() => {
+  it('sorts using the last applied filters when the current form is invalid', fakeAsync(() => {
     fixture.detectChanges();
     TestBed.tick();
 
@@ -321,18 +402,25 @@ describe('StandardApplicantSelectComponent', () => {
     component.onSortChange({ key: 'useTo', direction: 'desc' });
     fixture.detectChanges();
 
-    expect(mockGetStandardApplicants).not.toHaveBeenCalled();
-    expect(component.vm().sortField).toEqual({ key: 'code', direction: 'asc' });
-    expect(component.vm().searchErrors).toEqual([
+    expect(mockGetStandardApplicants).toHaveBeenCalledWith(
       {
-        id: 'name',
-        text: 'Standard applicant name must be 100 characters or fewer',
-        href: '#standard-applicant-name',
+        code: undefined,
+        name: undefined,
+        pageNumber: 0,
+        pageSize: 10,
+        sort: ['to,desc'],
       },
-    ]);
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
+    expect(component.vm().sortField).toEqual({
+      key: 'useTo',
+      direction: 'desc',
+    });
   }));
 
-  it('does not paginate when filters are invalid', fakeAsync(() => {
+  it('paginates using the last applied filters when the current form is invalid', fakeAsync(() => {
     fixture.detectChanges();
     TestBed.tick();
 
@@ -344,15 +432,19 @@ describe('StandardApplicantSelectComponent', () => {
     component.onPageChange(1);
     fixture.detectChanges();
 
-    expect(mockGetStandardApplicants).not.toHaveBeenCalled();
-    expect(component.vm().pageIndex).toBe(0);
-    expect(component.vm().searchErrors).toEqual([
+    expect(mockGetStandardApplicants).toHaveBeenCalledWith(
       {
-        id: 'code',
-        text: 'Code must be 10 characters or fewer',
-        href: '#standard-applicant-code',
+        code: undefined,
+        name: undefined,
+        pageNumber: 1,
+        pageSize: 10,
+        sort: ['code,asc'],
       },
-    ]);
+      'body',
+      false,
+      expect.objectContaining({ transferCache: true }),
+    );
+    expect(component.vm().pageIndex).toBe(1);
   }));
 
   it('shows validation errors and prevents submit when filters exceed max lengths', fakeAsync(() => {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1355

### Change description
- Fixes standard applicant sorting and pagination behavior on both the standalone `Standard applicants` page and the shared `standard-applicant-select` component.
- Keeps the table mounted during server-side reloads so sorting no longer makes results disappear and re-render abruptly.
- Preserves visible results when validation errors are shown, instead of hiding the table.
- Uses the last successfully applied filters for sorting and paging, so invalid draft form input does not block interaction with existing results.
- Keeps the user on the current page when sorting, instead of resetting back to page 1.
- Updates and stabilises unit tests to reflect the new UX and reduce brittle error-state assertions.

<!-- Describe what changed and why. -->

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
