### PR TITLE
ARCPOC-1351 select all applications changes

### DIFF
--- a/src/app/pages/applications/applications.component.html
+++ b/src/app/pages/applications/applications.component.html
@@ -1,6 +1,13 @@
 <h1 class="govuk-heading-xl">Applications</h1>
 
-@if (vm().searchErrors.length) {
+@if (vm().errorSummary.length) {
+  <app-error-summary
+    [title]="'There is a problem'"
+    [items]="vm().errorSummary"
+    targetId="search"
+    (itemSelect)="onCreateErrorClick($event)"
+  />
+} @else if (vm().searchErrors.length) {
   <app-error-summary
     [title]="'There is a problem'"
     [items]="vm().searchErrors"
@@ -195,7 +202,9 @@
     [data]="tableRows()"
     [selectable]="true"
     idField="id"
+    [selectAllScope]="'external'"
     [selectedIds]="vm().selectedIds"
+    (selectAllChange)="onHeaderSelectAllChange($event)"
     (selectedIdsChange)="onSelectedIdsChange($event)"
     (selectedRowsChange)="onSelectedRowsChange($event)"
     appMojButtonMenu
@@ -215,7 +224,7 @@
         role="group"
         aria-label="Table actions"
       >
-        @if (!vm().selectedRows.length) {
+        @if (!canUseBulkActions) {
           <button
             type="button"
             class="govuk-button govuk-button--small govuk-button--primary table-caption__action-button"

--- a/src/app/pages/applications/applications.component.ts
+++ b/src/app/pages/applications/applications.component.ts
@@ -16,7 +16,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { forkJoin, map } from 'rxjs';
+import { firstValueFrom, forkJoin, map } from 'rxjs';
 
 import {
   clearNotificationsPatch,
@@ -65,6 +65,10 @@ import {
   handlePrintPage,
 } from '@util/pdf-utils';
 import { PlaceFieldsBase } from '@util/place-fields.base';
+import {
+  getVisibleSelectedRows,
+  isAllMatchingSelected,
+} from '@util/server-paginated-selection';
 import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
 import { addLocationValidatorsToForm } from '@validators/add-location-validators-to-form';
 
@@ -79,6 +83,7 @@ type ApplicationsPrintResponse = {
   mode: 'page' | 'continuous';
   selectedRows: ApplicationRow[];
 };
+
 @Component({
   selector: 'app-applications',
   standalone: true,
@@ -117,6 +122,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
   private readonly errorMap = APPLICATIONS_ERROR_MAP;
 
   private readonly printRequest = signal<ApplicationsPrintRequest | null>(null);
+  private selectAllRequestVersion = 0;
 
   override form = new FormGroup({
     date: new FormControl<string | null>(null),
@@ -153,6 +159,18 @@ export class Applications extends PlaceFieldsBase implements OnInit {
   ];
 
   onCreateErrorClick = onCreateErrorClickFn; // Clickable error summary hints
+
+  get selectedCount(): number {
+    return this.vm().selectedIds.size;
+  }
+
+  get hasSelection(): boolean {
+    return this.selectedCount > 0;
+  }
+
+  get canUseBulkActions(): boolean {
+    return this.hasSelection && !this.vm().isSelectingAll;
+  }
 
   ngOnInit(): void {
     this.initPlaceFields(this.form, this.refFacade);
@@ -231,14 +249,12 @@ export class Applications extends PlaceFieldsBase implements OnInit {
 
   onSubmit(e: SubmitEvent): void {
     e.preventDefault();
+    this.invalidateSelectAllRequest();
 
     this.patchApp({
       ...clearNotificationsPatch(),
       submitted: true,
       isSearch: true,
-      rows: [],
-      selectedIds: new Set<string>(),
-      selectedRows: [],
     });
 
     this.form.markAllAsTouched();
@@ -261,41 +277,67 @@ export class Applications extends PlaceFieldsBase implements OnInit {
       });
       return;
     }
+
+    this.patchApp({
+      currentPage: 0,
+      rows: [],
+      selectedIds: new Set<string>(),
+      selectedRows: [],
+      allMatchingSelected: false,
+      isSelectingAll: false,
+    });
+
     this.loadApplications();
   }
 
-  onPrintContinuousClick(): void {
+  async onPrintContinuousClick(): Promise<void> {
     this.patchApp(clearNotificationsPatch());
-    const selectedRowsListIds = this.getArrOfPrintListId(
-      this.vm().selectedRows,
-    );
+    let selectedRows: ApplicationRow[];
+    try {
+      selectedRows = await this.resolveSelectedRows();
+    } catch (err) {
+      this.patchPrintError(getProblemText(err));
+      return;
+    }
+
+    if (selectedRows.length === 0) {
+      return;
+    }
+
+    const selectedRowsListIds = this.getArrOfPrintListId(selectedRows);
 
     this.printRequest.set({
       ids: selectedRowsListIds,
       mode: 'continuous',
-      selectedRows: this.vm().selectedRows,
+      selectedRows,
     });
   }
 
-  onPrintPageClick(): void {
+  async onPrintPageClick(): Promise<void> {
     this.patchApp(clearNotificationsPatch());
-    const selectedRowsListIds = this.getArrOfPrintListId(
-      this.vm().selectedRows,
-    );
+    let selectedRows: ApplicationRow[];
+    try {
+      selectedRows = await this.resolveSelectedRows();
+    } catch (err) {
+      this.patchPrintError(getProblemText(err));
+      return;
+    }
+
+    if (selectedRows.length === 0) {
+      return;
+    }
+
+    const selectedRowsListIds = this.getArrOfPrintListId(selectedRows);
 
     this.printRequest.set({
       ids: selectedRowsListIds,
       mode: 'page',
-      selectedRows: this.vm().selectedRows,
+      selectedRows,
     });
   }
 
   loadApplications(): void {
     if (this.vm().isLoading) {
-      return;
-    }
-
-    if (this.vm().searchErrors.length) {
       return;
     }
 
@@ -312,7 +354,14 @@ export class Applications extends PlaceFieldsBase implements OnInit {
       .subscribe({
         next: (page) => {
           const rows = page?.content ?? ([] as EntryGetSummaryDto[]);
-          this.patchApp(searchSuccessPatch(rows, page?.totalPages ?? 1));
+          this.patchApp({
+            ...searchSuccessPatch(
+              rows,
+              page?.totalPages ?? 1,
+              page?.totalElements ?? 0,
+            ),
+            getFilters: params.filter ?? {},
+          });
         },
         error: () => {
           this.patchApp(searchErrorPatch());
@@ -326,7 +375,13 @@ export class Applications extends PlaceFieldsBase implements OnInit {
   }
 
   onSelectedIdsChange(selectedIds: Set<string>): void {
-    this.patchApp({ selectedIds });
+    this.patchApp({
+      selectedIds,
+      allMatchingSelected: isAllMatchingSelected(
+        selectedIds,
+        this.vm().totalEntries,
+      ),
+    });
   }
 
   onSelectedRowsChange(rows: Row[]): void {
@@ -343,7 +398,17 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     });
   }
 
+  async onHeaderSelectAllChange(checked: boolean): Promise<void> {
+    if (checked) {
+      await this.onSelectAllMatchingClick();
+      return;
+    }
+
+    this.clearSelection();
+  }
+
   clearSearch(): void {
+    this.invalidateSelectAllRequest();
     this.appState.state.set(initialApplicationsState);
 
     this.form.reset({
@@ -458,6 +523,63 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     ];
   }
 
+  private async onSelectAllMatchingClick(): Promise<void> {
+    const requestVersion = this.nextSelectAllRequestVersion();
+    const vm = this.vm();
+    const previousSelection = {
+      selectedIds: new Set(vm.selectedIds),
+      selectedRows: [...vm.selectedRows],
+      allMatchingSelected: vm.allMatchingSelected,
+    };
+    const visibleRows = this.tableRows();
+    const visibleIds = new Set(
+      visibleRows
+        .map((row) => row.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    );
+    const optimisticSelectedIds = new Set([
+      ...previousSelection.selectedIds,
+      ...visibleIds,
+    ]);
+    const selectedRowsFromOtherPages = previousSelection.selectedRows.filter(
+      (row) => !visibleIds.has(row.id),
+    );
+
+    this.patchApp({
+      ...clearNotificationsPatch(),
+      isSelectingAll: true,
+      selectedIds: optimisticSelectedIds,
+      selectedRows: [...selectedRowsFromOtherPages, ...visibleRows],
+      allMatchingSelected:
+        visibleIds.size > 0 && visibleIds.size === vm.totalEntries,
+    });
+
+    try {
+      const dto = await firstValueFrom(
+        this.appListEntryApi.getEntryIds({
+          filter: vm.getFilters,
+        }),
+      );
+
+      if (requestVersion !== this.selectAllRequestVersion) {
+        return;
+      }
+
+      this.applySelectAllMatching(dto.ids ?? []);
+    } catch (err) {
+      if (requestVersion !== this.selectAllRequestVersion) {
+        return;
+      }
+
+      const errMsg = getProblemText(err);
+      this.patchApp({
+        ...previousSelection,
+        isSelectingAll: false,
+        errorSummary: [{ text: errMsg }],
+      });
+    }
+  }
+
   toggleAdvancedSearch(): void {
     this.patchApp({ isAdvancedSearch: !this.vm().isAdvancedSearch });
   }
@@ -470,6 +592,84 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     this.patchApp({
       errorSummary: [{ text: message }],
     });
+  }
+
+  private applySelectAllMatching(ids: string[]): void {
+    const selectedIds = new Set(ids);
+
+    this.patchApp({
+      isSelectingAll: false,
+      selectedIds,
+      selectedRows: getVisibleSelectedRows(
+        this.tableRows(),
+        selectedIds,
+      ) as ApplicationRow[],
+      allMatchingSelected: isAllMatchingSelected(
+        selectedIds,
+        this.vm().totalEntries,
+      ),
+    });
+  }
+
+  private clearSelection(): void {
+    this.invalidateSelectAllRequest();
+    this.patchApp({
+      selectedIds: new Set<string>(),
+      selectedRows: [],
+      allMatchingSelected: false,
+      isSelectingAll: false,
+    });
+  }
+
+  private async resolveSelectedRows(): Promise<ApplicationRow[]> {
+    const vm = this.vm();
+
+    if (vm.selectedIds.size === 0) {
+      return vm.selectedRows;
+    }
+
+    if (vm.selectedIds.size === vm.selectedRows.length) {
+      return vm.selectedRows;
+    }
+
+    const selectedIds = new Set(vm.selectedIds);
+    const pageCount =
+      vm.totalPages > 0 ? vm.totalPages : vm.totalEntries > 0 ? 1 : 0;
+    const selectedRows: ApplicationRow[] = [];
+
+    for (let pageNumber = 0; pageNumber < pageCount; pageNumber += 1) {
+      const page = await firstValueFrom(
+        this.appListEntryApi.getEntries({
+          pageNumber,
+          pageSize: vm.pageSize,
+          filter: vm.getFilters,
+        }),
+      );
+
+      const rows = (page.content ?? []).map(mapToRow);
+      for (const row of rows) {
+        if (selectedIds.has(row.id)) {
+          selectedRows.push(row);
+        }
+      }
+
+      if (selectedRows.length === selectedIds.size) {
+        break;
+      }
+    }
+
+    this.patchApp({ selectedRows });
+
+    return selectedRows;
+  }
+
+  private nextSelectAllRequestVersion(): number {
+    this.selectAllRequestVersion += 1;
+    return this.selectAllRequestVersion;
+  }
+
+  private invalidateSelectAllRequest(): void {
+    this.selectAllRequestVersion += 1;
   }
 
   isControlInvalid<C extends ControlName>(controlName: C): boolean {

--- a/src/app/pages/applications/applications.component.ts
+++ b/src/app/pages/applications/applications.component.ts
@@ -262,7 +262,10 @@ export class Applications extends PlaceFieldsBase implements OnInit {
 
     const validationErrors = this.buildErrorSummary();
     if (validationErrors.length) {
-      this.patchApp({ searchErrors: validationErrors });
+      this.patchApp({
+        searchErrors: validationErrors,
+        isSelectingAll: false,
+      });
       return;
     }
 
@@ -274,6 +277,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
             id: 'search-error',
           },
         ],
+        isSelectingAll: false,
       });
       return;
     }
@@ -293,49 +297,46 @@ export class Applications extends PlaceFieldsBase implements OnInit {
   }
 
   async onPrintContinuousClick(): Promise<void> {
-    this.patchApp(clearNotificationsPatch());
-    let selectedRows: ApplicationRow[];
-    try {
-      selectedRows = await this.resolveSelectedRows();
-    } catch (err) {
-      this.patchPrintError(getProblemText(err));
+    const request = await this.buildPrintRequest('continuous');
+    if (!request) {
       return;
     }
 
-    if (selectedRows.length === 0) {
-      return;
-    }
-
-    const selectedRowsListIds = this.getArrOfPrintListId(selectedRows);
-
-    this.printRequest.set({
-      ids: selectedRowsListIds,
-      mode: 'continuous',
-      selectedRows,
-    });
+    this.printRequest.set(request);
   }
 
   async onPrintPageClick(): Promise<void> {
+    const request = await this.buildPrintRequest('page');
+    if (!request) {
+      return;
+    }
+
+    this.printRequest.set(request);
+  }
+
+  private async buildPrintRequest(
+    mode: ApplicationsPrintRequest['mode'],
+  ): Promise<ApplicationsPrintRequest | null> {
     this.patchApp(clearNotificationsPatch());
     let selectedRows: ApplicationRow[];
     try {
       selectedRows = await this.resolveSelectedRows();
     } catch (err) {
       this.patchPrintError(getProblemText(err));
-      return;
+      return null;
     }
 
     if (selectedRows.length === 0) {
-      return;
+      return null;
     }
 
     const selectedRowsListIds = this.getArrOfPrintListId(selectedRows);
 
-    this.printRequest.set({
+    return {
       ids: selectedRowsListIds,
-      mode: 'page',
+      mode,
       selectedRows,
-    });
+    };
   }
 
   loadApplications(filterOverride?: EntryGetFilterDto): void {
@@ -635,8 +636,12 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     }
 
     const selectedIds = new Set(vm.selectedIds);
-    const pageCount =
-      vm.totalPages > 0 ? vm.totalPages : vm.totalEntries > 0 ? 1 : 0;
+    let pageCount = 0;
+    if (vm.totalPages > 0) {
+      pageCount = vm.totalPages;
+    } else if (vm.totalEntries > 0) {
+      pageCount = 1;
+    }
     const selectedRows: ApplicationRow[] = [];
 
     for (let pageNumber = 0; pageNumber < pageCount; pageNumber += 1) {

--- a/src/app/pages/applications/applications.component.ts
+++ b/src/app/pages/applications/applications.component.ts
@@ -278,6 +278,8 @@ export class Applications extends PlaceFieldsBase implements OnInit {
       return;
     }
 
+    const filter = this.loadQuery();
+
     this.patchApp({
       currentPage: 0,
       rows: [],
@@ -287,7 +289,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
       isSelectingAll: false,
     });
 
-    this.loadApplications();
+    this.loadApplications(filter);
   }
 
   async onPrintContinuousClick(): Promise<void> {
@@ -336,7 +338,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     });
   }
 
-  loadApplications(): void {
+  loadApplications(filterOverride?: EntryGetFilterDto): void {
     if (this.vm().isLoading) {
       return;
     }
@@ -344,7 +346,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
     const params: GetEntriesRequestParams = {
       pageNumber: this.vm().currentPage,
       pageSize: this.vm().pageSize,
-      filter: this.loadQuery(),
+      filter: filterOverride ?? this.loadQuery(),
     };
 
     this.patchApp({ ...startSearchPatch(), ...clearNotificationsPatch() });
@@ -371,7 +373,7 @@ export class Applications extends PlaceFieldsBase implements OnInit {
 
   onPageChange(page: number): void {
     this.patchApp({ currentPage: page });
-    this.loadApplications(); // fetch page `page`
+    this.loadApplications(this.vm().getFilters); // fetch page `page`
   }
 
   onSelectedIdsChange(selectedIds: Set<string>): void {

--- a/src/app/pages/applications/util/applications.state.ts
+++ b/src/app/pages/applications/util/applications.state.ts
@@ -1,5 +1,5 @@
 import { ErrorItem } from '@components/error-summary/error-summary.component';
-import { EntryGetSummaryDto } from '@openapi';
+import { EntryGetFilterDto, EntryGetSummaryDto } from '@openapi';
 import { ApplicationRow } from '@shared-types/applications/applications.type';
 
 export interface ApplicationsState {
@@ -19,10 +19,14 @@ export interface ApplicationsState {
   currentPage: number;
   totalPages: number;
   pageSize: number;
+  totalEntries: number;
 
   // table
   selectedIds: Set<string>;
   selectedRows: ApplicationRow[];
+  allMatchingSelected: boolean;
+  isSelectingAll: boolean;
+  getFilters: EntryGetFilterDto;
 }
 
 export const initialApplicationsState: ApplicationsState = {
@@ -39,8 +43,12 @@ export const initialApplicationsState: ApplicationsState = {
   currentPage: 0,
   totalPages: 1,
   pageSize: 10,
+  totalEntries: 0,
   selectedIds: new Set<string>(),
   selectedRows: [],
+  allMatchingSelected: false,
+  isSelectingAll: false,
+  getFilters: {},
 };
 
 // Clear error/notification state before a new search
@@ -66,9 +74,14 @@ export const startSearchPatch = (): Pick<
 export const searchSuccessPatch = (
   rows: EntryGetSummaryDto[],
   totalPages: number,
-): Pick<ApplicationsState, 'rows' | 'totalPages' | 'isLoading'> => ({
+  totalEntries: number,
+): Pick<
+  ApplicationsState,
+  'rows' | 'totalPages' | 'totalEntries' | 'isLoading'
+> => ({
   rows,
   totalPages,
+  totalEntries,
   isLoading: false,
 });
 

--- a/test/unit/app/pages/applications/applications.component.spec.ts
+++ b/test/unit/app/pages/applications/applications.component.spec.ts
@@ -330,6 +330,19 @@ describe('ApplicationsComponent', () => {
         'existing-row',
       ]);
     });
+
+    it('clears selecting mode when an invalid submit interrupts a pending select-all', () => {
+      appStateSignal(component).update((s) => ({
+        ...s,
+        isSelectingAll: true,
+      }));
+
+      component.form.patchValue({ respondentPostcode: 'AB12 3CDE' });
+
+      submitSearch();
+
+      expect(component.vm().isSelectingAll).toBe(false);
+    });
   });
 
   describe('loadQuery', () => {
@@ -562,9 +575,9 @@ describe('ApplicationsComponent', () => {
       }));
 
       getEntryIdsMock.mockReturnValueOnce(
-        of({ ids: ['entry-1', 'entry-2', 'entry-3', 'entry-4'] }) as ReturnType<
-          ApplicationListEntriesApi['getEntryIds']
-        >,
+        of({
+          ids: ['entry-1', 'entry-2', 'entry-3', 'entry-4'],
+        }) as unknown as ReturnType<ApplicationListEntriesApi['getEntryIds']>,
       );
 
       await component.onHeaderSelectAllChange(true);
@@ -635,7 +648,7 @@ describe('ApplicationsComponent', () => {
       }));
 
       getEntryIdsMock.mockReturnValueOnce(
-        idsSubject.asObservable() as ReturnType<
+        idsSubject.asObservable() as unknown as ReturnType<
           ApplicationListEntriesApi['getEntryIds']
         >,
       );

--- a/test/unit/app/pages/applications/applications.component.spec.ts
+++ b/test/unit/app/pages/applications/applications.component.spec.ts
@@ -518,6 +518,27 @@ describe('ApplicationsComponent', () => {
       expect(component.vm().currentPage).toBe(3);
       expect(loadSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('onPageChange uses the last successful filters instead of the live form', () => {
+      getEntriesMock.mockClear();
+
+      appStateSignal(component).update((s) => ({
+        ...s,
+        getFilters: { applicantOrganisation: 'Saved Org' },
+        isLoading: false,
+      }));
+
+      component.form.patchValue({ respondentPostcode: 'AB12 3CDE' });
+
+      component.onPageChange(2);
+
+      expect(getEntriesMock).toHaveBeenCalledTimes(1);
+      const [params] = getEntriesMock.mock.calls[0];
+      expect(params?.pageNumber).toBe(2);
+      expect(params?.filter).toEqual({
+        applicantOrganisation: 'Saved Org',
+      });
+    });
   });
 
   describe('row selection', () => {

--- a/test/unit/app/pages/applications/applications.component.spec.ts
+++ b/test/unit/app/pages/applications/applications.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { LOCALE_ID, PLATFORM_ID, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { Applications } from '@components/applications/applications.component';
 import { ApplicationsState } from '@components/applications/util/applications.state';
@@ -15,6 +15,7 @@ import {
   ApplicationListsApi,
   EntryGetFilterDto,
   EntryGetSummaryDto,
+  EntryIdsDto,
   EntryPage,
 } from '@openapi';
 import { ReferenceDataFacade } from '@services/reference-data.facade';
@@ -82,6 +83,9 @@ const flushSignalEffects = async (
   await fixture.whenStable();
   await Promise.resolve();
   fixture.detectChanges();
+  await fixture.whenStable();
+  await Promise.resolve();
+  fixture.detectChanges();
 };
 
 describe('ApplicationsComponent', () => {
@@ -99,9 +103,16 @@ describe('ApplicationsComponent', () => {
   const getEntriesMock: jest.MockedFunction<
     ApplicationListEntriesApi['getEntries']
   > = jest.fn();
+  const getEntryIdsMock: jest.MockedFunction<
+    ApplicationListEntriesApi['getEntryIds']
+  > = jest.fn();
 
-  const appListEntriesApiStub: Pick<ApplicationListEntriesApi, 'getEntries'> = {
+  const appListEntriesApiStub: Pick<
+    ApplicationListEntriesApi,
+    'getEntries' | 'getEntryIds'
+  > = {
     getEntries: getEntriesMock,
+    getEntryIds: getEntryIdsMock,
   };
 
   const printApplicationListMock = jest.fn();
@@ -122,6 +133,7 @@ describe('ApplicationsComponent', () => {
 
   beforeEach(async () => {
     getEntriesMock.mockReset();
+    getEntryIdsMock.mockReset();
     printApplicationListMock.mockReset();
     pdfServiceStub.generatePagedApplicationListPdf.mockReset();
     pdfServiceStub.generateContinuousApplicationListsPdf.mockReset();
@@ -133,10 +145,16 @@ describe('ApplicationsComponent', () => {
           body: {
             content: [],
             totalPages: 0,
+            totalElements: 0,
             number: 0,
           } as unknown as EntryPage,
         }),
       ),
+    );
+    getEntryIdsMock.mockReturnValue(
+      of({ ids: [] } as EntryIdsDto) as unknown as ReturnType<
+        ApplicationListEntriesApi['getEntryIds']
+      >,
     );
 
     await TestBed.configureTestingModule({
@@ -168,6 +186,19 @@ describe('ApplicationsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders errorSummary when action-level errors are present', () => {
+    appStateSignal(component).update((s) => ({
+      ...s,
+      errorSummary: [{ text: 'Select all failed' }],
+      searchErrors: [{ id: 'search-error', text: 'Search failed' }],
+    }));
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Select all failed');
+    expect(fixture.nativeElement.textContent).not.toContain('Search failed');
   });
 
   describe('onSubmit validation', () => {
@@ -251,11 +282,17 @@ describe('ApplicationsComponent', () => {
     it('when submitted with a param: calls loadApplications (and API) rather than invalid search criteria', () => {
       getEntriesMock.mockClear();
 
+      appStateSignal(component).update((s) => ({
+        ...s,
+        currentPage: 3,
+      }));
+
       component.form.patchValue({ applicantOrg: 'Some Org' });
 
       submitSearch();
 
       expect(getEntriesMock).toHaveBeenCalledTimes(1);
+      expect(component.vm().currentPage).toBe(0);
       expect(
         component.vm().searchErrors.some((e) => e.id === 'search-error'),
       ).toBe(false);
@@ -263,6 +300,11 @@ describe('ApplicationsComponent', () => {
 
     it('prioritises field validation errors (e.g. postcode too long) over invalid search criteria', () => {
       getEntriesMock.mockClear();
+
+      appStateSignal(component).update((s) => ({
+        ...s,
+        rows: [makeEntry({ id: 'existing-row' })],
+      }));
 
       component.form.patchValue({ respondentPostcode: 'AB12 3CDE' });
 
@@ -284,6 +326,9 @@ describe('ApplicationsComponent', () => {
           }),
         ]),
       );
+      expect(component.vm().rows.map((row) => row.id)).toEqual([
+        'existing-row',
+      ]);
     });
   });
 
@@ -329,7 +374,7 @@ describe('ApplicationsComponent', () => {
   });
 
   describe('loadApplications', () => {
-    it('does nothing when there are existing searchErrors', () => {
+    it('still loads applications when stale searchErrors are present', () => {
       getEntriesMock.mockClear();
 
       appStateSignal(component).update((s) => ({
@@ -340,7 +385,7 @@ describe('ApplicationsComponent', () => {
 
       component.loadApplications();
 
-      expect(getEntriesMock).not.toHaveBeenCalled();
+      expect(getEntriesMock).toHaveBeenCalledTimes(1);
     });
 
     it('does nothing when already loading', () => {
@@ -407,6 +452,7 @@ describe('ApplicationsComponent', () => {
         of({
           content: [makeEntry({ id: 'row-1' })],
           totalPages: 5,
+          totalElements: 11,
           number: 1,
         } as unknown as EntryPage) as unknown as ReturnType<
           ApplicationListEntriesApi['getEntries']
@@ -433,6 +479,7 @@ describe('ApplicationsComponent', () => {
 
       expect(component.vm().rows.map((r) => r.id)).toEqual(['row-1']);
       expect(component.vm().totalPages).toBe(5);
+      expect(component.vm().totalEntries).toBe(11);
       expect(component.vm().currentPage).toBe(2);
       expect(component.vm().isLoading).toBe(false);
     });
@@ -482,6 +529,35 @@ describe('ApplicationsComponent', () => {
       expect(component.vm().selectedIds).toBe(selectedIds);
     });
 
+    it('header select-all fetches matching ids and updates selection', async () => {
+      appStateSignal(component).update((s) => ({
+        ...s,
+        rows: [
+          makeEntry({ id: 'entry-1', listId: 'list-a' }),
+          makeEntry({ id: 'entry-2', listId: 'list-b' }),
+        ],
+        totalEntries: 4,
+        getFilters: { applicantOrganisation: 'Org Ltd' },
+      }));
+
+      getEntryIdsMock.mockReturnValueOnce(
+        of({ ids: ['entry-1', 'entry-2', 'entry-3', 'entry-4'] }) as ReturnType<
+          ApplicationListEntriesApi['getEntryIds']
+        >,
+      );
+
+      await component.onHeaderSelectAllChange(true);
+
+      expect(getEntryIdsMock).toHaveBeenCalledWith({
+        filter: { applicantOrganisation: 'Org Ltd' },
+      });
+      expect(component.vm().selectedIds).toEqual(
+        new Set(['entry-1', 'entry-2', 'entry-3', 'entry-4']),
+      );
+      expect(component.vm().isSelectingAll).toBe(false);
+      expect(component.vm().allMatchingSelected).toBe(true);
+    });
+
     it('keeps selected rows from other pages and replaces only current-page selections', () => {
       const previousPageRow = makeSelectedRow('entry-page-1', 'list-a');
       const deselectedCurrentPageRow = makeSelectedRow(
@@ -506,9 +582,118 @@ describe('ApplicationsComponent', () => {
         selectedCurrentPageRow,
       ]);
     });
+
+    it('clears selection when header select-all is unchecked', async () => {
+      appStateSignal(component).update((s) => ({
+        ...s,
+        selectedIds: new Set(['entry-1']),
+        selectedRows: [makeSelectedRow('entry-1', 'list-a')],
+        allMatchingSelected: true,
+        isSelectingAll: true,
+      }));
+
+      await component.onHeaderSelectAllChange(false);
+
+      expect(component.vm().selectedIds.size).toBe(0);
+      expect(component.vm().selectedRows).toEqual([]);
+      expect(component.vm().allMatchingSelected).toBe(false);
+      expect(component.vm().isSelectingAll).toBe(false);
+    });
+
+    it('ignores stale select-all responses after the selection is cleared', async () => {
+      const idsSubject = new Subject<EntryIdsDto>();
+
+      appStateSignal(component).update((s) => ({
+        ...s,
+        rows: [
+          makeEntry({ id: 'entry-1', listId: 'list-a' }),
+          makeEntry({ id: 'entry-2', listId: 'list-b' }),
+        ],
+        totalEntries: 4,
+        getFilters: { applicantOrganisation: 'Org Ltd' },
+      }));
+
+      getEntryIdsMock.mockReturnValueOnce(
+        idsSubject.asObservable() as ReturnType<
+          ApplicationListEntriesApi['getEntryIds']
+        >,
+      );
+
+      const selectAllPromise = component.onHeaderSelectAllChange(true);
+
+      expect(component.vm().selectedIds).toEqual(
+        new Set(['entry-1', 'entry-2']),
+      );
+      expect(component.vm().isSelectingAll).toBe(true);
+
+      await component.onHeaderSelectAllChange(false);
+
+      idsSubject.next({
+        ids: ['entry-1', 'entry-2', 'entry-3', 'entry-4'],
+      } as EntryIdsDto);
+      idsSubject.complete();
+      await selectAllPromise;
+
+      expect(component.vm().selectedIds.size).toBe(0);
+      expect(component.vm().selectedRows).toEqual([]);
+      expect(component.vm().allMatchingSelected).toBe(false);
+      expect(component.vm().isSelectingAll).toBe(false);
+    });
   });
 
   describe('onPrintContinuousClick', () => {
+    it('resolves selected rows across pages before printing', async () => {
+      appStateSignal(component).update((s) => ({
+        ...s,
+        selectedIds: new Set(['entry-1', 'entry-2']),
+        selectedRows: [makeSelectedRow('entry-1', 'list-a')],
+        totalPages: 2,
+        totalEntries: 2,
+        pageSize: 10,
+        getFilters: { applicantOrganisation: 'Org Ltd' },
+      }));
+
+      getEntriesMock.mockReturnValueOnce(
+        of({
+          content: [
+            makeEntry({ id: 'entry-1', listId: 'list-a' }),
+            makeEntry({ id: 'entry-2', listId: 'list-b' }),
+          ],
+          totalPages: 2,
+          totalElements: 2,
+          number: 0,
+        } as unknown as EntryPage) as unknown as ReturnType<
+          ApplicationListEntriesApi['getEntries']
+        >,
+      );
+
+      printApplicationListMock.mockImplementation(({ listId }) =>
+        of(
+          makePrintDto({
+            entries: [
+              {
+                id: listId === 'list-a' ? 'entry-1' : 'entry-2',
+                applicant: {},
+                applicationCode: '',
+                applicationTitle: '',
+                applicationWording: '',
+              },
+            ],
+          }),
+        ),
+      );
+
+      await component.onPrintContinuousClick();
+      await flushSignalEffects(fixture);
+
+      expect(getEntriesMock).toHaveBeenCalledWith({
+        pageNumber: 0,
+        pageSize: 10,
+        filter: { applicantOrganisation: 'Org Ltd' },
+      });
+      expect(printApplicationListMock).toHaveBeenCalledTimes(2);
+    });
+
     it('fetches each unique list id and generates one filtered continuous PDF', async () => {
       const listADto = makePrintDto({
         courtName: 'Court A',
@@ -572,7 +757,7 @@ describe('ApplicationsComponent', () => {
         return of(listBDto);
       });
 
-      component.onPrintContinuousClick();
+      await component.onPrintContinuousClick();
       await flushSignalEffects(fixture);
 
       expect(printApplicationListMock).toHaveBeenCalledTimes(2);
@@ -630,7 +815,7 @@ describe('ApplicationsComponent', () => {
         ),
       );
 
-      component.onPrintContinuousClick();
+      await component.onPrintContinuousClick();
       await flushSignalEffects(fixture);
 
       expect(
@@ -657,13 +842,42 @@ describe('ApplicationsComponent', () => {
         ),
       );
 
-      component.onPrintContinuousClick();
+      await component.onPrintContinuousClick();
       await flushSignalEffects(fixture);
 
       expect(
         pdfServiceStub.generateContinuousApplicationListsPdf,
       ).not.toHaveBeenCalled();
       expect(component.vm().errorSummary).toEqual([{ text: 'Print failed' }]);
+    });
+
+    it('patches a print error when resolving selected rows fails', async () => {
+      appStateSignal(component).update((s) => ({
+        ...s,
+        selectedIds: new Set(['entry-1', 'entry-2']),
+        selectedRows: [makeSelectedRow('entry-1', 'list-a')],
+        totalPages: 2,
+        totalEntries: 2,
+        pageSize: 10,
+        getFilters: { applicantOrganisation: 'Org Ltd' },
+      }));
+
+      getEntriesMock.mockReturnValueOnce(
+        throwError(
+          () =>
+            new HttpErrorResponse({
+              status: 500,
+              statusText: 'Server Error',
+              error: { detail: 'Resolve failed' },
+            }),
+        ),
+      );
+
+      await component.onPrintContinuousClick();
+      await flushSignalEffects(fixture);
+
+      expect(printApplicationListMock).not.toHaveBeenCalled();
+      expect(component.vm().errorSummary).toEqual([{ text: 'Resolve failed' }]);
     });
 
     it('patches a generic print error when PDF generation rejects', async () => {
@@ -686,11 +900,13 @@ describe('ApplicationsComponent', () => {
           }),
         ),
       );
-      pdfServiceStub.generateContinuousApplicationListsPdf.mockRejectedValueOnce(
-        new Error('pdf failed'),
+      pdfServiceStub.generateContinuousApplicationListsPdf.mockImplementationOnce(
+        () => {
+          throw new Error('pdf failed');
+        },
       );
 
-      component.onPrintContinuousClick();
+      await component.onPrintContinuousClick();
       await flushSignalEffects(fixture);
 
       expect(
@@ -766,7 +982,7 @@ describe('ApplicationsComponent', () => {
         return of(listBDto);
       });
 
-      component.onPrintPageClick();
+      await component.onPrintPageClick();
       await flushSignalEffects(fixture);
 
       expect(printApplicationListMock).toHaveBeenCalledTimes(2);
@@ -827,7 +1043,7 @@ describe('ApplicationsComponent', () => {
         ),
       );
 
-      component.onPrintPageClick();
+      await component.onPrintPageClick();
       await flushSignalEffects(fixture);
 
       expect(
@@ -858,11 +1074,13 @@ describe('ApplicationsComponent', () => {
           }),
         ),
       );
-      pdfServiceStub.generatePagedApplicationListPdf.mockRejectedValueOnce(
-        new Error('pdf failed'),
+      pdfServiceStub.generatePagedApplicationListPdf.mockImplementationOnce(
+        () => {
+          throw new Error('pdf failed');
+        },
       );
 
-      component.onPrintPageClick();
+      await component.onPrintPageClick();
       await flushSignalEffects(fixture);
 
       expect(


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1351

### Change description

- Added cross-page select-all support on the Applications page using the new IDs-only backend endpoint, while keeping the existing paged search endpoint for table rendering.
- Updated the Applications table header checkbox to drive full-result selection across pagination, with immediate visible-row selection followed by background expansion to all matching IDs.
- Persisted manual row selections across pagination instead of limiting selection to the current page.
- Kept bulk actions and print flows safe with cross-page selection by resolving selected rows on demand before printing and disabling actions while select-all is still resolving.
- Extracted and reused shared server-paginated selection helpers so the Applications page follows the same selection model as Application List Detail.
- Improved error handling for action-level failures by surfacing select-all and print-resolution errors in a visible page-level error summary.
- Prevented existing search results from disappearing on validation errors, allowed pagination to continue working when stale search errors are present, and reset valid new searches back to page 1.
- Expanded unit coverage for cross-page selection, stale async responses, print resolution, action-level errors, and updated search/pagination behaviour.


### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
