### PR TITLE
ARCPOC-1369/1370 Remove alphanumeric from notes and apply wording error summary fix

### DIFF
--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -640,6 +640,15 @@ export class ApplicationsListEntryDetail implements OnInit {
       return;
     }
 
+    if (source === 'wording') {
+      if (this.childErrors.wording.length > 0) {
+        this.wordingAppliedBannerVisible.set(false);
+      }
+
+      this.updateAllErrors();
+      return;
+    }
+
     if (this.vm().formSubmitted) {
       this.updateAllErrors();
     }

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -11,7 +11,6 @@ import { buildEntryCreateDto } from '@components/applications-list-entry-create/
 import { ApplicationNotesForm } from '@components/notes-section/notes-section.component';
 import {
   ADDRESS_REGEX,
-  ALPHANUMERIC_REGEX,
   APPLICATION_CODE_REGEX,
   NAME_REGEX,
   STANDARD_APPLICANT_CODE_REGEX,
@@ -156,16 +155,10 @@ export function buildStandardApplicationForm(
           validators: [Validators.maxLength(4000)],
         }),
         caseReference: fb.control<string | null>(null, {
-          validators: [
-            Validators.maxLength(15),
-            Validators.pattern(ALPHANUMERIC_REGEX),
-          ],
+          validators: [Validators.maxLength(15)],
         }),
         accountReference: fb.control<string | null>(null, {
-          validators: [
-            Validators.maxLength(20),
-            Validators.pattern(ALPHANUMERIC_REGEX),
-          ],
+          validators: [Validators.maxLength(20)],
         }),
       }) as ApplicationNotesForm,
 

--- a/src/app/shared/constants/application-list-entry/error-messages.ts
+++ b/src/app/shared/constants/application-list-entry/error-messages.ts
@@ -56,11 +56,9 @@ const person_org_shared_messages = {
 export const NOTES_ERROR_MESSAGES: NotesErrorMap = {
   accountReference: {
     maxlength: 'Account reference must be 20 characters or fewer',
-    pattern: 'Account reference must only contain letters and numbers',
   },
   caseReference: {
     maxlength: 'Case reference must be 15 characters or fewer',
-    pattern: 'Case reference must only contain letters and numbers',
   },
   notes: {
     maxlength: 'Notes must be 4000 characters or fewer',

--- a/src/app/shared/util/error-click.ts
+++ b/src/app/shared/util/error-click.ts
@@ -14,13 +14,25 @@ function normaliseDomId(idOrHref: string): string {
   return raw.startsWith('#') ? raw.slice(1) : raw;
 }
 
+function resolveTargetElement(id: string): HTMLElement | null {
+  const exactMatch = document.getElementById(id);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  // Error summary ids can be namespaced for uniqueness, while rendered inputs
+  // often keep the leaf control id.
+  const leafId = id.split('.').pop();
+  return leafId ? document.getElementById(leafId) : null;
+}
+
 function focusByIdOrFirstFocusable(idOrHref: string): void {
   const id = normaliseDomId(idOrHref);
   if (!id) {
     return;
   }
 
-  const root = document.getElementById(id);
+  const root = resolveTargetElement(id);
   if (!root) {
     return;
   }

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -153,21 +153,6 @@ describe('applications-list entry form builders', () => {
       expect(form.controls.lodgementDate.errors).toHaveProperty('required');
     });
 
-    it('applicationNotes.caseReference enforces alphanumeric only', () => {
-      const form = buildStandardApplicationForm(fb);
-      const notesGroup = form.controls.applicationNotes;
-
-      notesGroup.controls.caseReference.setValue('ABC-123'); // hyphen not allowed
-      notesGroup.controls.caseReference.updateValueAndValidity();
-      expect(notesGroup.controls.caseReference.errors).toHaveProperty(
-        'pattern',
-      );
-
-      notesGroup.controls.caseReference.setValue('ABC123');
-      notesGroup.controls.caseReference.updateValueAndValidity();
-      expect(notesGroup.controls.caseReference.errors).toBeNull();
-    });
-
     it('official/mags names have maxlength and pattern', () => {
       const form = buildStandardApplicationForm(fb);
 

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -417,6 +417,29 @@ describe('ApplicationsListEntryDetail', () => {
     );
   });
 
+  it('promotes wording child errors into the parent summary and clears the applied banner', () => {
+    component.wordingAppliedBannerVisible.set(true);
+
+    component.onChildErrors('wording', [
+      {
+        id: 'Court',
+        text: 'Enter a Court in the wording section',
+        href: '#Court',
+      },
+    ]);
+
+    expect(component.wordingAppliedBannerVisible()).toBe(false);
+    expect(component['appListEntryDetailState']().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'Court',
+          text: 'Enter a Court in the wording section',
+        }),
+      ]),
+    );
+    expect(component['appListEntryDetailState']().errorFound).toBe(true);
+  });
+
   it('isUpdateDisabled true when entryDetail is not set', () => {
     component['entryDetail'] = null;
 

--- a/test/unit/app/shared/components/notes-section/notes-section.component.spec.ts
+++ b/test/unit/app/shared/components/notes-section/notes-section.component.spec.ts
@@ -57,17 +57,14 @@ describe('NotesSectionComponent', () => {
     });
 
     it('returns mapped messages for known error keys', () => {
-      form.controls.caseReference.setErrors({ maxlength: true, pattern: true });
+      form.controls.caseReference.setErrors({ maxlength: true });
 
       const messages = component.getControlErrorMessages('caseReference');
 
       expect(messages).toContain(
         component.NOTES_FIELD_MESSAGES.caseReference['maxlength'],
       );
-      expect(messages).toContain(
-        component.NOTES_FIELD_MESSAGES.caseReference['pattern'],
-      );
-      expect(messages).toHaveLength(2);
+      expect(messages).toHaveLength(1);
     });
 
     it('ignores unknown error keys', () => {
@@ -124,7 +121,7 @@ describe('NotesSectionComponent', () => {
       const emitSpy = jest.spyOn(component.notesErrors, 'emit');
 
       form.controls.notes.setErrors({ maxlength: true });
-      form.controls.caseReference.setErrors({ pattern: true });
+      form.controls.caseReference.setErrors({ maxlength: true });
       form.controls.accountReference.setErrors({ maxlength: true });
 
       component.emitNotesErrors();
@@ -140,7 +137,7 @@ describe('NotesSectionComponent', () => {
           },
           {
             id: 'caseReference',
-            text: component.NOTES_FIELD_MESSAGES.caseReference['pattern'],
+            text: component.NOTES_FIELD_MESSAGES.caseReference['maxlength'],
           },
           {
             id: 'accountReference',

--- a/test/unit/app/shared/util/error-click.spec.ts
+++ b/test/unit/app/shared/util/error-click.spec.ts
@@ -50,6 +50,25 @@ describe('error focus utils', () => {
       expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
 
+    it('falls back to the leaf control id when href uses a dotted nested id', () => {
+      document.body.innerHTML = '<input id="caseReference" />';
+      const el = document.getElementById('caseReference') as HTMLElement;
+
+      const scrollSpy = jest.spyOn(el, 'scrollIntoView');
+      const focusSpy = jest.spyOn(el, 'focus');
+
+      onCreateErrorClick({
+        href: '#applicationNotes.caseReference',
+      } as unknown as TestErrorItem);
+
+      expect(scrollSpy).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'center',
+      });
+      jest.advanceTimersByTime(50);
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
     it('focuses by id when id is provided (smooth scroll path)', () => {
       document.body.innerHTML = '<input id="x" />';
       const el = document.getElementById('x') as HTMLElement;


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1369
https://tools.hmcts.net/jira/browse/ARCPOC-1370

### Change description
- Removed pattern validation for account & case reference in notes section component
- Fixed error summary anchor focus for notes fields so namespaced fragments like #applicationNotes.caseReference now correctly resolve to the rendered input and move focus as expected.
- Fixed ALE update wording validation so clicking `Apply wording` with empty required fields now pushes the wording error into the parent error summary immediately.
- Cleared the wording “applied” success banner when a subsequent `Apply wording` attempt fails validation, so stale success state is no longer shown.
- Kept staged `wordingFields` persistence unchanged to avoid regressing the existing partial-save behavior where successfully applied wording survives unrelated updates such as payment reference or offsite fee changes.


### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
