### PR TITLE
Add ARCPOC-1297 application code sorting coverage

### DIFF
--- a/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
+++ b/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
@@ -507,3 +507,53 @@ Feature: Applications List Entry Create
     Then User Should See The Textbox "Official's first name" Under "Officials" FieldSet In The Accordion "Officials"
     Then User Should See The Textbox "Official's surname" Under "Officials" FieldSet In The Accordion "Officials"
 
+  @applicationListEntry @regression @ARCPOC-1297
+  Scenario Outline: Verify Application Codes sorting behaviour
+    Given User Authenticates Via API As "<User>"
+    # Create Application List
+    When User Makes POST API Request To "/application-lists" With Body:
+      | date      | time   | status   | description   | durationHours | durationMinutes | courtLocationCode |
+      | <APIDate> | <Time> | <Status> | <Description> |               |                 | <CourtCode>       |
+    Then User Verify Response Status Code Should Be "201"
+    Then User Stores Response Body Property "id" As "listId"
+    Given User Is On The Portal Page
+    When User Signs In With Microsoft SSO As "<User>"
+    When User Searches Application List With:
+      | Date         | Time | List description | CourtSearch | Court | Select list status | Other location description | Criminal justice area | CJASearch |
+      | <SearchDate> |      |                  |             |       | <Status>           |                            |                       |           |
+    When User Clicks "<SelectButtonText>" Then "<ButtonName>" From Menu In Row Of Table "<TableName>" With:
+      | Date          | Time   | Location | Description   | Entries   | Status   |
+      | <DisplayDate> | <Time> | <Court>  | <Description> | <Entries> | <Status> |
+    Then User Clicks On The Link "Create application"
+    When User Clicks On The "Search" Button In The Accordion "Application codes"
+    Then User Verifies Table "Codes" Has Sortable Headers "Code, Title, Bulk, Fee required" In The Accordion "Application codes"
+    # Test Code column
+    When User Clicks On Table Header "Code" In Table "Codes"
+    Then User Should See Table "Codes" Header "Code" Has Sort Order "descending"
+    When User Clicks On Table Header "Code" In Table "Codes"
+    Then User Should See Table "Codes" Header "Code" Has Sort Order "ascending"
+    When User Goes To Last Page
+    When User Goes To First Page
+    Then User Should See Table "Codes" Header "Code" Has Sort Order "ascending"
+    # Test Title column
+    When User Clicks On Table Header "Title" In Table "Codes"
+    Then User Should See Table "Codes" Header "Title" Has Sort Order "ascending"
+    When User Clicks On Table Header "Title" In Table "Codes"
+    Then User Should See Table "Codes" Header "Title" Has Sort Order "descending"
+    When User Goes To Last Page
+    When User Goes To First Page
+    Then User Should See Table "Codes" Header "Title" Has Sort Order "descending"
+    # Test Bulk column
+    When User Clicks On Table Header "Bulk" In Table "Codes"
+    Then User Should See Table "Codes" Header "Bulk" Has Sort Order "ascending"
+    When User Clicks On Table Header "Bulk" In Table "Codes"
+    Then User Should See Table "Codes" Header "Bulk" Has Sort Order "descending"
+    # Test Fee required column
+    When User Clicks On Table Header "Fee required" In Table "Codes"
+    Then User Should See Table "Codes" Header "Fee required" Has Sort Order "ascending"
+    When User Clicks On Table Header "Fee required" In Table "Codes"
+    Then User Should See Table "Codes" Header "Fee required" Has Sort Order "descending"
+
+    Examples:
+      | User  | TableName | SelectButtonText | ButtonName | SearchDate | DisplayDate  | APIDate    | Time  | Court                     | CourtCode | Description  | Entries | Status |
+      | user1 | Lists     | Select           | Open       | 12/09/3036 | 12 Sept 3036 | 3036-09-12 | 12:12 | Bristol Crown Court Set 3 | BCC026    | Wave Delta12 | 19      | OPEN   |


### PR DESCRIPTION
### Jira link

<!-- Replace ARCPOC-XXXX with your Jira key. Remove this section if not applicable. -->

See [[ARCPOC-1297](https://tools.hmcts.net/jira/browse/ARCPOC-1297)]

### Change description
- Added ARCPOC-1297 regression coverage for Application codes sorting in ALE create.
- Added search before verifying the Codes table.
- Added pagination round-trip checks to confirm sort state persists.
- Aligned test data dates and added the applicationListEntry tag.

### Testing done
- Ran @ARCPOC-1297 locally and passed.

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
