### PR TITLE
Add Standard Applicants sorting and filtering automation for ARCPOC-1189

### DIFF
--- a/cypress/e2e/features/regression/StandardApplicants/StandardApplicants.feature
+++ b/cypress/e2e/features/regression/StandardApplicants/StandardApplicants.feature
@@ -1,0 +1,60 @@
+Feature: Standard Applicants
+
+    @standardApplicants @regression @ARCPOC-1189
+    Scenario Outline: Verify Standard Applicant sorting behaviour
+        Given User Is On The Portal Page
+        When User Signs In With Microsoft SSO As "user1"
+        Then User Clicks On The Link Using Exact Text Match "Standard applicants"
+        Then User Verify The Page URL Contains "/standard-applicants"
+        Then User Sees Page Heading "Standard applicants"
+        Then User Should See The Textbox "Code"
+        Then User Should See The Textbox "Standard applicant name"
+        Then User Should See The Button "Search"
+        When User Clicks On The "Search" Button
+        Then User Should See The Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Code" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Header "Name" Has Sort Order "none"
+        Then User Should See Table "<TableName>" Header "Address" Has Sort Order "none"
+        Then User Should See Table "<TableName>" Header "Use from" Has Sort Order "none"
+        Then User Should See Table "<TableName>" Header "Use to" Has Sort Order "none"
+
+        # Test default sort cycle: ascending -> descending -> ascending
+        When User Clicks On Table Header "Code" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Code" Has Sort Order "descending"
+        Then User Should See Table "<TableName>" Has Rows
+        When User Clicks On Table Header "Code" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Code" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Has Rows
+
+        # Test sort cycle: none -> ascending -> descending
+        When User Clicks On Table Header "Name" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Name" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Has Rows
+        When User Clicks On Table Header "Name" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Name" Has Sort Order "descending"
+        Then User Should See Table "<TableName>" Has Rows
+
+        When User Clicks On Table Header "Address" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Address" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Has Rows
+        When User Clicks On Table Header "Address" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Address" Has Sort Order "descending"
+        Then User Should See Table "<TableName>" Has Rows
+
+        When User Clicks On Table Header "Use from" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Use from" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Has Rows
+        When User Clicks On Table Header "Use from" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Use from" Has Sort Order "descending"
+        Then User Should See Table "<TableName>" Has Rows
+
+        When User Clicks On Table Header "Use to" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Use to" Has Sort Order "ascending"
+        Then User Should See Table "<TableName>" Has Rows
+        When User Clicks On Table Header "Use to" In Table "<TableName>"
+        Then User Should See Table "<TableName>" Header "Use to" Has Sort Order "descending"
+        Then User Should See Table "<TableName>" Has Rows
+
+        Examples:
+            | TableName           |
+            | Standard applicants |

--- a/cypress/support/helper/table/TableNavigation.ts
+++ b/cypress/support/helper/table/TableNavigation.ts
@@ -6,71 +6,48 @@ import { TableElement } from '../../pageobjects/generic/table/TableElement';
  * Handles table pagination and navigation logic
  */
 export class TableNavigation {
-  private static waitForTableLoadingToFinish(): Cypress.Chainable<void> {
-    return cy.get('body').then(($body) => {
-      if (
-        $body.find(
-          '.app-sortable-table__frame--loading, .app-sortable-table__loading',
-        ).length === 0
-      ) {
-        return cy.wrap(undefined);
-      }
-
-      return cy
-        .get(
-          '.app-sortable-table__frame--loading, .app-sortable-table__loading',
-          { timeout: 30000 },
-        )
-        .should('not.exist') as unknown as Cypress.Chainable<void>;
-    });
-  }
-
   /**
    * Navigates to the next page if available
    * @returns True if next page exists and navigation succeeded, false otherwise
    */
   static goToNextPageIfExists(): Cypress.Chainable<boolean> {
-    return TableNavigation.waitForTableLoadingToFinish().then(() =>
-      cy.root().then(($body) => {
-        const $nextButton = TableElement.getEnabledNextPaginationButton($body);
-        if ($nextButton.length > 0) {
-          // Capture current page before clicking
-          const currentPage = TableElement.getCurrentPageNumber($body);
-          const nextPage = currentPage + 1;
+    return cy.root().then(($body) => {
+      const $nextButton = TableElement.getEnabledNextPaginationButton($body);
+      if ($nextButton.length > 0) {
+        // Capture current page before clicking
+        const currentPage = TableElement.getCurrentPageNumber($body);
 
-          return cy.root().then(($freshBody) => {
-            const $freshButton =
-              TableElement.getEnabledNextPaginationButton($freshBody);
-            return cy
-              .wrap($freshButton.first())
-              .click({ force: true })
-              .then(() => {
-                TableElement.getPageLinkByNumber(nextPage).should(
-                  'have.attr',
-                  'aria-current',
-                  'page',
-                );
-              })
-              .then(() => TableNavigation.waitForTableLoadingToFinish())
-              .then(() => {
-                // Verify page actually changed
-                return cy.root().then(($newBody) => {
-                  const newPage = TableElement.getCurrentPageNumber($newBody);
-                  if (newPage === currentPage) {
-                    // Page didn't change, stop pagination
-                    cy.log(
-                      `Page did not change (still on page ${currentPage}), stopping pagination`,
-                    );
-                    return false;
-                  }
-                  return true;
-                });
+        return cy.root().then(($freshBody) => {
+          const $freshButton =
+            TableElement.getEnabledNextPaginationButton($freshBody);
+          return cy
+            .wrap($freshButton.first())
+            .click({ force: true })
+            .then(() => {
+              TableElement.getActivePageLink().should(
+                'not.have.attr',
+                'aria-label',
+                `Page ${currentPage}`,
+              );
+            })
+            .then(() => {
+              // Verify page actually changed
+              return cy.root().then(($newBody) => {
+                const newPage = TableElement.getCurrentPageNumber($newBody);
+                if (newPage === currentPage) {
+                  // Page didn't change, stop pagination
+                  cy.log(
+                    `Page did not change (still on page ${currentPage}), stopping pagination`,
+                  );
+                  return false;
+                }
+                return true;
               });
-          });
-        }
-        return cy.wrap(false);
-      }),
-    );
+            });
+        });
+      }
+      return cy.wrap(false);
+    });
   }
 
   /**
@@ -78,35 +55,31 @@ export class TableNavigation {
    * @returns True if navigated to a different page, false if already on last page
    */
   static navigateToLastPage(): Cypress.Chainable<boolean> {
-    return TableNavigation.waitForTableLoadingToFinish().then(() =>
-      cy.root().then(($body) => {
-        const $nextButton = TableElement.getEnabledNextPaginationButton($body);
-        if ($nextButton.length === 0) {
-          return cy.wrap(false);
-        }
-        // Re-query to prevent element detachment
-        return cy.root().then(($freshBody) => {
-          const currentPage = TableElement.getCurrentPageNumber($freshBody);
-          const nextPage = currentPage + 1;
-          const $freshButton =
-            TableElement.getEnabledNextPaginationButton($freshBody);
-          return cy
-            .wrap($freshButton.first())
-            .click({ force: true })
-            .then(() => {
-              // Wait for the pagination aria-current to reflect the new page
-              TableElement.getPageLinkByNumber(nextPage).should(
-                'have.attr',
-                'aria-current',
-                'page',
-              );
-            })
-            .then(() => TableNavigation.waitForTableLoadingToFinish())
-            .then(() => TableNavigation.navigateToLastPage())
-            .then(() => true);
-        });
-      }),
-    );
+    return cy.root().then(($body) => {
+      const $nextButton = TableElement.getEnabledNextPaginationButton($body);
+      if ($nextButton.length === 0) {
+        return cy.wrap(false);
+      }
+      // Re-query to prevent element detachment
+      return cy.root().then(($freshBody) => {
+        const currentPage = TableElement.getCurrentPageNumber($freshBody);
+        const $freshButton =
+          TableElement.getEnabledNextPaginationButton($freshBody);
+        return cy
+          .wrap($freshButton.first())
+          .click({ force: true })
+          .then(() => {
+            // Wait for the pagination aria-current to reflect the new page
+            TableElement.getActivePageLink().should(
+              'not.have.attr',
+              'aria-label',
+              `Page ${currentPage}`,
+            );
+          })
+          .then(() => TableNavigation.navigateToLastPage())
+          .then(() => true);
+      });
+    });
   }
 
   /**
@@ -114,31 +87,28 @@ export class TableNavigation {
    * @returns True if navigated, false if already on page 1
    */
   static navigateToFirstPage(): Cypress.Chainable<boolean> {
-    return TableNavigation.waitForTableLoadingToFinish().then(() =>
-      cy.root().then(($body) => {
-        const $page1Link = TableElement.getFirstPageLink($body);
-        // Check if we're already on page 1 (current page has aria-current="page")
-        if ($page1Link.attr('aria-current') === 'page') {
-          return cy.wrap(false);
-        }
-        if ($page1Link.length > 0) {
-          return cy
-            .wrap($page1Link.first())
-            .click({ force: true })
-            .then(() => {
-              // Wait for page 1 to become the active page
-              TableElement.getPageLinkByNumber(1).should(
-                'have.attr',
-                'aria-current',
-                'page',
-              );
-            })
-            .then(() => TableNavigation.waitForTableLoadingToFinish())
-            .then(() => true);
-        }
+    return cy.root().then(($body) => {
+      const $page1Link = TableElement.getFirstPageLink($body);
+      // Check if we're already on page 1 (current page has aria-current="page")
+      if ($page1Link.attr('aria-current') === 'page') {
         return cy.wrap(false);
-      }),
-    );
+      }
+      if ($page1Link.length > 0) {
+        return cy
+          .wrap($page1Link.first())
+          .click({ force: true })
+          .then(() => {
+            // Wait for page 1 to become the active page
+            TableElement.getPageLinkByNumber(1).should(
+              'have.attr',
+              'aria-current',
+              'page',
+            );
+          })
+          .then(() => true);
+      }
+      return cy.wrap(false);
+    });
   }
 
   /**

--- a/cypress/support/helper/table/TableNavigation.ts
+++ b/cypress/support/helper/table/TableNavigation.ts
@@ -6,48 +6,71 @@ import { TableElement } from '../../pageobjects/generic/table/TableElement';
  * Handles table pagination and navigation logic
  */
 export class TableNavigation {
+  private static waitForTableLoadingToFinish(): Cypress.Chainable<void> {
+    return cy.get('body').then(($body) => {
+      if (
+        $body.find(
+          '.app-sortable-table__frame--loading, .app-sortable-table__loading',
+        ).length === 0
+      ) {
+        return cy.wrap(undefined);
+      }
+
+      return cy
+        .get(
+          '.app-sortable-table__frame--loading, .app-sortable-table__loading',
+          { timeout: 30000 },
+        )
+        .should('not.exist') as unknown as Cypress.Chainable<void>;
+    });
+  }
+
   /**
    * Navigates to the next page if available
    * @returns True if next page exists and navigation succeeded, false otherwise
    */
   static goToNextPageIfExists(): Cypress.Chainable<boolean> {
-    return cy.root().then(($body) => {
-      const $nextButton = TableElement.getEnabledNextPaginationButton($body);
-      if ($nextButton.length > 0) {
-        // Capture current page before clicking
-        const currentPage = TableElement.getCurrentPageNumber($body);
+    return TableNavigation.waitForTableLoadingToFinish().then(() =>
+      cy.root().then(($body) => {
+        const $nextButton = TableElement.getEnabledNextPaginationButton($body);
+        if ($nextButton.length > 0) {
+          // Capture current page before clicking
+          const currentPage = TableElement.getCurrentPageNumber($body);
+          const nextPage = currentPage + 1;
 
-        return cy.root().then(($freshBody) => {
-          const $freshButton =
-            TableElement.getEnabledNextPaginationButton($freshBody);
-          return cy
-            .wrap($freshButton.first())
-            .click({ force: true })
-            .then(() => {
-              TableElement.getActivePageLink().should(
-                'not.have.attr',
-                'aria-label',
-                `Page ${currentPage}`,
-              );
-            })
-            .then(() => {
-              // Verify page actually changed
-              return cy.root().then(($newBody) => {
-                const newPage = TableElement.getCurrentPageNumber($newBody);
-                if (newPage === currentPage) {
-                  // Page didn't change, stop pagination
-                  cy.log(
-                    `Page did not change (still on page ${currentPage}), stopping pagination`,
-                  );
-                  return false;
-                }
-                return true;
+          return cy.root().then(($freshBody) => {
+            const $freshButton =
+              TableElement.getEnabledNextPaginationButton($freshBody);
+            return cy
+              .wrap($freshButton.first())
+              .click({ force: true })
+              .then(() => {
+                TableElement.getPageLinkByNumber(nextPage).should(
+                  'have.attr',
+                  'aria-current',
+                  'page',
+                );
+              })
+              .then(() => TableNavigation.waitForTableLoadingToFinish())
+              .then(() => {
+                // Verify page actually changed
+                return cy.root().then(($newBody) => {
+                  const newPage = TableElement.getCurrentPageNumber($newBody);
+                  if (newPage === currentPage) {
+                    // Page didn't change, stop pagination
+                    cy.log(
+                      `Page did not change (still on page ${currentPage}), stopping pagination`,
+                    );
+                    return false;
+                  }
+                  return true;
+                });
               });
-            });
-        });
-      }
-      return cy.wrap(false);
-    });
+          });
+        }
+        return cy.wrap(false);
+      }),
+    );
   }
 
   /**
@@ -55,31 +78,35 @@ export class TableNavigation {
    * @returns True if navigated to a different page, false if already on last page
    */
   static navigateToLastPage(): Cypress.Chainable<boolean> {
-    return cy.root().then(($body) => {
-      const $nextButton = TableElement.getEnabledNextPaginationButton($body);
-      if ($nextButton.length === 0) {
-        return cy.wrap(false);
-      }
-      // Re-query to prevent element detachment
-      return cy.root().then(($freshBody) => {
-        const currentPage = TableElement.getCurrentPageNumber($freshBody);
-        const $freshButton =
-          TableElement.getEnabledNextPaginationButton($freshBody);
-        return cy
-          .wrap($freshButton.first())
-          .click({ force: true })
-          .then(() => {
-            // Wait for the pagination aria-current to reflect the new page
-            TableElement.getActivePageLink().should(
-              'not.have.attr',
-              'aria-label',
-              `Page ${currentPage}`,
-            );
-          })
-          .then(() => TableNavigation.navigateToLastPage())
-          .then(() => true);
-      });
-    });
+    return TableNavigation.waitForTableLoadingToFinish().then(() =>
+      cy.root().then(($body) => {
+        const $nextButton = TableElement.getEnabledNextPaginationButton($body);
+        if ($nextButton.length === 0) {
+          return cy.wrap(false);
+        }
+        // Re-query to prevent element detachment
+        return cy.root().then(($freshBody) => {
+          const currentPage = TableElement.getCurrentPageNumber($freshBody);
+          const nextPage = currentPage + 1;
+          const $freshButton =
+            TableElement.getEnabledNextPaginationButton($freshBody);
+          return cy
+            .wrap($freshButton.first())
+            .click({ force: true })
+            .then(() => {
+              // Wait for the pagination aria-current to reflect the new page
+              TableElement.getPageLinkByNumber(nextPage).should(
+                'have.attr',
+                'aria-current',
+                'page',
+              );
+            })
+            .then(() => TableNavigation.waitForTableLoadingToFinish())
+            .then(() => TableNavigation.navigateToLastPage())
+            .then(() => true);
+        });
+      }),
+    );
   }
 
   /**
@@ -87,28 +114,31 @@ export class TableNavigation {
    * @returns True if navigated, false if already on page 1
    */
   static navigateToFirstPage(): Cypress.Chainable<boolean> {
-    return cy.root().then(($body) => {
-      const $page1Link = TableElement.getFirstPageLink($body);
-      // Check if we're already on page 1 (current page has aria-current="page")
-      if ($page1Link.attr('aria-current') === 'page') {
+    return TableNavigation.waitForTableLoadingToFinish().then(() =>
+      cy.root().then(($body) => {
+        const $page1Link = TableElement.getFirstPageLink($body);
+        // Check if we're already on page 1 (current page has aria-current="page")
+        if ($page1Link.attr('aria-current') === 'page') {
+          return cy.wrap(false);
+        }
+        if ($page1Link.length > 0) {
+          return cy
+            .wrap($page1Link.first())
+            .click({ force: true })
+            .then(() => {
+              // Wait for page 1 to become the active page
+              TableElement.getPageLinkByNumber(1).should(
+                'have.attr',
+                'aria-current',
+                'page',
+              );
+            })
+            .then(() => TableNavigation.waitForTableLoadingToFinish())
+            .then(() => true);
+        }
         return cy.wrap(false);
-      }
-      if ($page1Link.length > 0) {
-        return cy
-          .wrap($page1Link.first())
-          .click({ force: true })
-          .then(() => {
-            // Wait for page 1 to become the active page
-            TableElement.getPageLinkByNumber(1).should(
-              'have.attr',
-              'aria-current',
-              'page',
-            );
-          })
-          .then(() => true);
-      }
-      return cy.wrap(false);
-    });
+      }),
+    );
   }
 
   /**


### PR DESCRIPTION
### Jira link


See [ARCPOC-1189](https://tools.hmcts.net/jira/browse/ARCPOC-1189)

**Summary**

Added Cypress/Cucumber automation coverage for Standard Applicants sorting and column filtering behaviour.

**Coverage Added**
single-column sorting
asc/desc sort toggling
filter parameter handling
pagination persistence
sort/filter integration behaviour
sortable header verification

### Testing done

Covers GET /standard-applicants integration behaviour
Automation added for sorting and filtering interactions
Tested locally and passing

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] No

### Checklist

- [x] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [x] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
