### PR TITLE
ARCPOC-248 Add workload report

### DIFF
--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -23,6 +23,7 @@ import {
   initialReportsState,
   mapFeeGroupToFeesReportFilterDto,
   mapListMaintenanceGroupToListMaintenanceReportRequestParams,
+  mapWorkloadGroupToWorkloadReportRequestParams,
 } from './util';
 
 import { ActivityAuditSectionComponent } from '@components/activity-audit-section/activity-audit-section.component';
@@ -48,6 +49,7 @@ import { reportOptions } from '@constants/reports/report-selector.constant';
 import {
   CreateFeesReportRequestParams,
   CreateListMaintenanceReportRequestParams,
+  CreateWorkloadReportRequestParams,
   JobAcknowledgement,
   ReportsApi,
 } from '@openapi';
@@ -73,6 +75,14 @@ const REPORT_ERROR_PRIORITY_KEYS: Record<string, string[]> = {
 
 const REPORT_POLL_INTERVAL_MS = 2_000;
 const REPORT_DATE_RANGE_VALIDATORS = [dateToOnOrAfterDateFromValidator()];
+const REPORT_JSON_OPTIONS = {
+  httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+  transferCache: false,
+} as const;
+const REPORT_CSV_OPTIONS = {
+  httpHeaderAccept: 'text/csv',
+  transferCache: false,
+} as const;
 
 @Component({
   selector: 'app-reports',
@@ -114,6 +124,8 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     signal<CreateFeesReportRequestParams | null>(null);
   private readonly createListMaintenanceReportRequest =
     signal<CreateListMaintenanceReportRequestParams | null>(null);
+  private readonly createWorkloadReportRequest =
+    signal<CreateWorkloadReportRequestParams | null>(null);
 
   onCreateErrorClick = onCreateErrorClickFn;
 
@@ -305,6 +317,10 @@ export class Reports extends PlaceFieldsBase implements OnInit {
 
       this.startCreateFeesReport(request);
     }
+
+    if (this.form.controls.report.value === 'workload') {
+      this.createWorkloadReport();
+    }
   }
 
   /** Handy getter for the child binding */
@@ -349,6 +365,15 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     this.createFeesReportRequest.set(request);
   }
 
+  private startCreateWorkloadReport(
+    request: CreateWorkloadReportRequestParams,
+  ): void {
+    this.stopReportCreate();
+    this.stopReportPolling();
+    this.showReportProgress();
+    this.createWorkloadReportRequest.set(request);
+  }
+
   private setupEffects(): void {
     // POST /reports/fees/jobs
     setupLoadEffect(
@@ -374,6 +399,29 @@ export class Reports extends PlaceFieldsBase implements OnInit {
         onError: (err) => {
           this.handleReportCreateError(err);
           this.createFeesReportRequest.set(null);
+        },
+      },
+      this.envInjector,
+    );
+
+    // POST /reports/workload/jobs
+    setupLoadEffect(
+      {
+        request: this.createWorkloadReportRequest,
+        load: (request) =>
+          this.reportsApi.createWorkloadReport(
+            request,
+            'response',
+            false,
+            REPORT_JSON_OPTIONS,
+          ),
+        onSuccess: (response) => {
+          this.createWorkloadReportRequest.set(null);
+          this.handleReportJobCreated(response);
+        },
+        onError: (err) => {
+          this.createWorkloadReportRequest.set(null);
+          this.showReportError(this.toReportRequestError(err));
         },
       },
       this.envInjector,
@@ -464,6 +512,12 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     );
   }
 
+  private createWorkloadReport(): void {
+    this.startCreateWorkloadReport(
+      mapWorkloadGroupToWorkloadReportRequestParams(this.workloadGroup),
+    );
+  }
+
   private handleReportJobCreated(
     response: HttpResponse<JobAcknowledgement>,
   ): void {
@@ -506,6 +560,7 @@ export class Reports extends PlaceFieldsBase implements OnInit {
   private stopReportCreate(): void {
     this.createFeesReportRequest.set(null);
     this.createListMaintenanceReportRequest.set(null);
+    this.createWorkloadReportRequest.set(null);
   }
 
   private handleReportJobStatus(job: PolledJobStatus): void {
@@ -527,10 +582,7 @@ export class Reports extends PlaceFieldsBase implements OnInit {
 
   private downloadReport(jobId: string): void {
     this.reportsApi
-      .downloadReport({ jobId }, 'response', false, {
-        httpHeaderAccept: 'text/csv',
-        transferCache: false,
-      })
+      .downloadReport({ jobId }, 'response', false, REPORT_CSV_OPTIONS)
       .pipe(take(1), takeUntilDestroyed(this.componentDestroyRef))
       .subscribe({
         next: (response) => {

--- a/src/app/pages/reports/util/report-request.mapper.ts
+++ b/src/app/pages/reports/util/report-request.mapper.ts
@@ -3,9 +3,11 @@ import { FormGroup } from '@angular/forms';
 import { toOptionalTrimmed } from '@components/applications-list-entry-create/util';
 import {
   CreateListMaintenanceReportRequestParams,
+  CreateWorkloadReportRequestParams,
   FeesReportFilterDto,
   LegacyReportLocation,
   ListMaintenanceFilterDto,
+  WorkloadFilterDto,
 } from '@openapi';
 
 interface FeesReportFormValue {
@@ -28,6 +30,14 @@ interface ListMaintenanceReportFormValue {
   dateFrom: string;
   dateTo: string;
   description: string | null;
+  court: string | null;
+  otherLocation: string | null;
+  cja: string | null;
+}
+
+interface WorkloadReportFormValue {
+  dateFrom: string;
+  dateTo: string;
   court: string | null;
   otherLocation: string | null;
   cja: string | null;
@@ -57,6 +67,14 @@ export function mapListMaintenanceGroupToListMaintenanceReportRequestParams(
   };
 }
 
+export function mapWorkloadGroupToWorkloadReportRequestParams(
+  workloadGroup: FormGroup,
+): CreateWorkloadReportRequestParams {
+  return {
+    workloadFilterDto: mapWorkloadGroupToWorkloadFilterDto(workloadGroup),
+  };
+}
+
 function mapListMaintenanceGroupToListMaintenanceFilterDto(
   listMaintenanceGroup: FormGroup,
 ): ListMaintenanceFilterDto {
@@ -69,6 +87,19 @@ function mapListMaintenanceGroupToListMaintenanceFilterDto(
     dateFrom: value.dateFrom,
     dateTo: value.dateTo,
     ...(listDescription ? { listDescription } : {}),
+    ...(location ? { location } : {}),
+  };
+}
+
+function mapWorkloadGroupToWorkloadFilterDto(
+  workloadGroup: FormGroup,
+): WorkloadFilterDto {
+  const value = workloadGroup.getRawValue() as WorkloadReportFormValue;
+  const location = buildLocation(value);
+
+  return {
+    dateFrom: value.dateFrom,
+    dateTo: value.dateTo,
     ...(location ? { location } : {}),
   };
 }

--- a/test/unit/app/pages/reports/reports.component.spec.ts
+++ b/test/unit/app/pages/reports/reports.component.spec.ts
@@ -11,6 +11,7 @@ import { Subject, of, throwError } from 'rxjs';
 import { DateInputComponent } from '@components/date-input/date-input.component';
 import { Reports } from '@components/reports/reports.component';
 import { SearchWarrantsSectionComponent } from '@components/search-warrants-section/search-warrants-section.component';
+import { WorkloadSectionComponent } from '@components/workload-section/workload-section.component';
 import {
   CourtLocationGetSummaryDto,
   CriminalJusticeAreaGetDto,
@@ -35,6 +36,7 @@ const refFacadeStub: Pick<ReferenceDataFacade, 'courtLocations$' | 'cja$'> = {
 const reportsApiMock = {
   createFeesReport: jest.fn(),
   createListMaintenanceReport: jest.fn(),
+  createWorkloadReport: jest.fn(),
   downloadReport: jest.fn(),
 };
 
@@ -129,6 +131,19 @@ describe('ReportsComponent', () => {
     ).componentInstance as SearchWarrantsSectionComponent;
 
     expect(section.group()).toBe(component.searchWarrantsGroup);
+    expect(section.suggestions()).toBe(component.suggestionsFacade);
+    expect(section.getError()).toEqual(expect.any(Function));
+  });
+
+  it('passes the workload group and suggestions facade to the section', () => {
+    component.form.controls.report.setValue('workload');
+    fixture.detectChanges();
+
+    const section = fixture.debugElement.query(
+      By.directive(WorkloadSectionComponent),
+    ).componentInstance as WorkloadSectionComponent;
+
+    expect(section.group()).toBe(component.workloadGroup);
     expect(section.suggestions()).toBe(component.suggestionsFacade);
     expect(section.getError()).toEqual(expect.any(Function));
   });
@@ -325,6 +340,23 @@ describe('ReportsComponent', () => {
     );
   });
 
+  it('preserves date from and date to when switching to workload', () => {
+    component.form.controls.report.setValue('activity-audit');
+    component.activityAuditGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+
+    component.form.controls.report.setValue('workload');
+
+    expect(component.workloadGroup.value).toEqual(
+      expect.objectContaining({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      }),
+    );
+  });
+
   it('clears validation state when switching report type', () => {
     component.form.controls.report.setValue('list-maintenance');
     component.listMaintenanceGroup.patchValue({
@@ -394,6 +426,60 @@ describe('ReportsComponent', () => {
         ?.classList.contains('govuk-input--error'),
     ).toBe(true);
     expect(reportsApiMock.createListMaintenanceReport).not.toHaveBeenCalled();
+  });
+
+  it('blocks workload download when date to is before date from', () => {
+    component.form.controls.report.setValue('workload');
+    component.workloadGroup.patchValue({
+      dateFrom: '2026-02-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().errorSummary).toEqual([
+      {
+        id: 'dateTo',
+        href: '#list-date-to',
+        text: 'Date to must be on or after Date from',
+      },
+    ]);
+    expect(
+      fixture.nativeElement.querySelector('#list-date-to-error')?.textContent,
+    ).toContain('Date to must be on or after Date from');
+    expect(
+      fixture.nativeElement
+        .querySelector('#list-date-to-day')
+        ?.classList.contains('govuk-input--error'),
+    ).toBe(true);
+    expect(reportsApiMock.createWorkloadReport).not.toHaveBeenCalled();
+  });
+
+  it('enforces workload location mutual exclusivity in the form controls', () => {
+    component.form.controls.report.setValue('workload');
+    fixture.detectChanges();
+
+    component.workloadGroup.get('court')?.setValue('A1');
+    fixture.detectChanges();
+
+    expect(component.workloadGroup.get('otherLocation')?.disabled).toBe(true);
+    expect(component.workloadGroup.get('cja')?.disabled).toBe(true);
+    expect(
+      (
+        fixture.nativeElement.querySelector(
+          '#other-location',
+        ) as HTMLInputElement | null
+      )?.disabled,
+    ).toBe(true);
+
+    component.workloadGroup.get('court')?.setValue('');
+    component.workloadGroup.get('otherLocation')?.setValue('Annex');
+    fixture.detectChanges();
+
+    expect(component.workloadGroup.get('court')?.disabled).toBe(true);
+    expect(component.workloadGroup.get('cja')?.enabled).toBe(true);
   });
 
   it('shows report progress while the list maintenance job request is pending', () => {
@@ -636,6 +722,137 @@ describe('ReportsComponent', () => {
       fixture.nativeElement.querySelector('app-success-banner')?.textContent,
     ).toContain('Report downloaded');
   });
+
+  it('creates, polls, and downloads a workload report CSV', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-22T09:30:00'));
+    reportsApiMock.createWorkloadReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(of(completedJob));
+    reportsApiMock.downloadReport.mockReturnValue(
+      of(
+        new HttpResponse({
+          body: new Blob(['header\n'], { type: 'text/csv' }),
+          headers: new HttpHeaders({
+            'content-disposition': 'attachment; filename="workload.csv"',
+          }),
+          status: 200,
+        }),
+      ),
+    );
+
+    component.form.controls.report.setValue('workload');
+    component.workloadGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+      otherLocation: '  Annex  ',
+      cja: ' C1 ',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(reportsApiMock.createWorkloadReport).toHaveBeenCalledWith(
+      {
+        workloadFilterDto: {
+          dateFrom: '2026-01-01',
+          dateTo: '2026-01-31',
+          location: {
+            otherLocationDescription: 'Annex',
+            cjaCode: 'C1',
+          },
+        },
+      },
+      'response',
+      false,
+      {
+        httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+        transferCache: false,
+      },
+    );
+    expect(jobPollingFacadeMock.watchJob).toHaveBeenCalledWith('job-1', 2000);
+    expect(reportsApiMock.downloadReport).toHaveBeenCalledWith(
+      { jobId: 'job-1' },
+      'response',
+      false,
+      { httpHeaderAccept: 'text/csv', transferCache: false },
+    );
+    expect(createObjectUrlSpy).toHaveBeenCalledWith(expect.any(Blob));
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (anchorClickSpy.mock.contexts[0] as HTMLAnchorElement).download,
+    ).toBe('workload-report-2026-05-22.csv');
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'success',
+      heading: 'Report downloaded',
+      body: 'The workload report has downloaded.',
+    });
+  });
+
+  it('shows the backend message when workload polling fails', () => {
+    reportsApiMock.createWorkloadReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(
+      of({
+        ...completedJob,
+        rawStatus: 'FAILED',
+        state: 'failed',
+        message: 'Backend failed the workload report',
+      } satisfies PolledJobStatus),
+    );
+
+    component.form.controls.report.setValue('workload');
+    component.workloadGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'error',
+      title: 'Report generation failed',
+      items: [{ text: 'Backend failed the workload report' }],
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      'Backend failed the workload report',
+    );
+    expect(reportsApiMock.downloadReport).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, 'You need to sign in to download this report.'],
+    [403, 'You do not have permission to download this report.'],
+    [500, 'There was a problem generating the report. Try again later.'],
+  ])(
+    'shows the workload request error message for HTTP %i',
+    (status, message) => {
+      reportsApiMock.createWorkloadReport.mockReturnValue(
+        throwError(() => ({ status })),
+      );
+
+      component.form.controls.report.setValue('workload');
+      component.workloadGroup.patchValue({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      });
+      fixture.detectChanges();
+
+      component.onDownload();
+      fixture.detectChanges();
+
+      expect(component.vm().reportFeedback).toEqual({
+        kind: 'error',
+        title: 'Report generation failed',
+        items: [{ text: message }],
+      });
+    },
+  );
 
   it('shows the backend message when list maintenance polling fails', () => {
     reportsApiMock.createListMaintenanceReport.mockReturnValue(


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-248

### Change description
- Added Workload report async export support from the Reports page.
- Reused the existing report job flow for creating jobs, polling status, downloading CSVs, and showing progress/success/error feedback.
- Added Workload payload mapping using date range and optional legacy location filters.
- Shared report request/download options to reduce duplication between List Maintenance and Workload.
- Added unit coverage for Workload section wiring, date preservation, date range validation, location mutual exclusivity, successful CSV download, failed polling, and 401/403/500 error handling.

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
