### PR TITLE
ARCPOC-247 Search warrant report

### DIFF
--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -23,6 +23,7 @@ import {
   initialReportsState,
   mapFeeGroupToFeesReportFilterDto,
   mapListMaintenanceGroupToListMaintenanceReportRequestParams,
+  mapSearchWarrantsGroupToSearchWarrantsReportRequestParams,
   mapWorkloadGroupToWorkloadReportRequestParams,
 } from './util';
 
@@ -49,6 +50,7 @@ import { reportOptions } from '@constants/reports/report-selector.constant';
 import {
   CreateFeesReportRequestParams,
   CreateListMaintenanceReportRequestParams,
+  CreateSearchWarrantsReportRequestParams,
   CreateWorkloadReportRequestParams,
   JobAcknowledgement,
   ReportsApi,
@@ -71,6 +73,10 @@ import { dateToOnOrAfterDateFromValidator } from '@validators/date-range.validat
 const REPORT_ERROR_PRIORITY_KEYS: Record<string, string[]> = {
   dateFrom: ['dateInvalid', 'required'],
   dateTo: ['dateInvalid', 'dateRange', 'required'],
+};
+const REPORT_DATE_LABELS: Record<'dateFrom' | 'dateTo', string> = {
+  dateFrom: 'Date from',
+  dateTo: 'Date to',
 };
 
 const REPORT_POLL_INTERVAL_MS = 2_000;
@@ -124,6 +130,8 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     signal<CreateFeesReportRequestParams | null>(null);
   private readonly createListMaintenanceReportRequest =
     signal<CreateListMaintenanceReportRequestParams | null>(null);
+  private readonly createSearchWarrantsReportRequest =
+    signal<CreateSearchWarrantsReportRequestParams | null>(null);
   private readonly createWorkloadReportRequest =
     signal<CreateWorkloadReportRequestParams | null>(null);
 
@@ -310,6 +318,10 @@ export class Reports extends PlaceFieldsBase implements OnInit {
       this.createListMaintenanceReport();
     }
 
+    if (this.form.controls.report.value === 'search-warrants') {
+      this.createSearchWarrantsReport();
+    }
+
     if (this.form.controls.report.value === 'fees') {
       const request: CreateFeesReportRequestParams = {
         feesReportFilterDto: mapFeeGroupToFeesReportFilterDto(this.feesGroup),
@@ -365,6 +377,15 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     this.createFeesReportRequest.set(request);
   }
 
+  private startCreateSearchWarrantsReport(
+    request: CreateSearchWarrantsReportRequestParams,
+  ): void {
+    this.stopReportCreate();
+    this.stopReportPolling();
+    this.showReportProgress();
+    this.createSearchWarrantsReportRequest.set(request);
+  }
+
   private startCreateWorkloadReport(
     request: CreateWorkloadReportRequestParams,
   ): void {
@@ -399,6 +420,29 @@ export class Reports extends PlaceFieldsBase implements OnInit {
         onError: (err) => {
           this.handleReportCreateError(err);
           this.createFeesReportRequest.set(null);
+        },
+      },
+      this.envInjector,
+    );
+
+    // POST /reports/search-warrants/jobs
+    setupLoadEffect(
+      {
+        request: this.createSearchWarrantsReportRequest,
+        load: (request) =>
+          this.reportsApi.createSearchWarrantsReport(
+            request,
+            'response',
+            false,
+            REPORT_JSON_OPTIONS,
+          ),
+        onSuccess: (response) => {
+          this.createSearchWarrantsReportRequest.set(null);
+          this.handleReportJobCreated(response);
+        },
+        onError: (err) => {
+          this.createSearchWarrantsReportRequest.set(null);
+          this.showReportError(this.toReportRequestError(err));
         },
       },
       this.envInjector,
@@ -512,6 +556,14 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     );
   }
 
+  private createSearchWarrantsReport(): void {
+    this.startCreateSearchWarrantsReport(
+      mapSearchWarrantsGroupToSearchWarrantsReportRequestParams(
+        this.searchWarrantsGroup,
+      ),
+    );
+  }
+
   private createWorkloadReport(): void {
     this.startCreateWorkloadReport(
       mapWorkloadGroupToWorkloadReportRequestParams(this.workloadGroup),
@@ -560,6 +612,7 @@ export class Reports extends PlaceFieldsBase implements OnInit {
   private stopReportCreate(): void {
     this.createFeesReportRequest.set(null);
     this.createListMaintenanceReportRequest.set(null);
+    this.createSearchWarrantsReportRequest.set(null);
     this.createWorkloadReportRequest.set(null);
   }
 
@@ -738,12 +791,44 @@ export class Reports extends PlaceFieldsBase implements OnInit {
         'dateErrorText'
       ] as string;
 
-      if (typeof dateErrorText !== 'string') {
-        return error;
-      }
+      const text =
+        typeof dateErrorText === 'string' ? dateErrorText : error.text;
 
-      return { ...error, text: dateErrorText };
+      return { ...error, text: this.toDateSummaryText(error.id, text) };
     });
+  }
+
+  private toDateSummaryText(id: 'dateFrom' | 'dateTo', text: string): string {
+    const label = REPORT_DATE_LABELS[id];
+    const lowerLabel = label.toLowerCase();
+    const trimmedText = text.trim();
+
+    if (trimmedText === 'Enter day, month and year') {
+      return `Enter ${lowerLabel}`;
+    }
+
+    if (trimmedText === 'Enter a valid date') {
+      return `${label} must be a valid date`;
+    }
+
+    if (trimmedText.startsWith('Enter ')) {
+      return `${label} must include ${this.addDatePartArticles(
+        trimmedText.slice('Enter '.length),
+      )}`;
+    }
+
+    if (trimmedText.startsWith('Date must')) {
+      return `${label}${trimmedText.slice('Date'.length)}`;
+    }
+
+    return text;
+  }
+
+  private addDatePartArticles(text: string): string {
+    return text
+      .replace(/\bday\b/g, 'a day')
+      .replace(/\bmonth\b/g, 'a month')
+      .replace(/\byear\b/g, 'a year');
   }
 
   private selectedReportGroup(): FormGroup | null {

--- a/src/app/pages/reports/util/report-request.mapper.ts
+++ b/src/app/pages/reports/util/report-request.mapper.ts
@@ -3,10 +3,12 @@ import { FormGroup } from '@angular/forms';
 import { toOptionalTrimmed } from '@components/applications-list-entry-create/util';
 import {
   CreateListMaintenanceReportRequestParams,
+  CreateSearchWarrantsReportRequestParams,
   CreateWorkloadReportRequestParams,
   FeesReportFilterDto,
   LegacyReportLocation,
   ListMaintenanceFilterDto,
+  SearchWarrantsReportFilterDto,
   WorkloadFilterDto,
 } from '@openapi';
 
@@ -30,6 +32,14 @@ interface ListMaintenanceReportFormValue {
   dateFrom: string;
   dateTo: string;
   description: string | null;
+  court: string | null;
+  otherLocation: string | null;
+  cja: string | null;
+}
+
+interface SearchWarrantsReportFormValue {
+  dateFrom: string;
+  dateTo: string;
   court: string | null;
   otherLocation: string | null;
   cja: string | null;
@@ -67,6 +77,17 @@ export function mapListMaintenanceGroupToListMaintenanceReportRequestParams(
   };
 }
 
+export function mapSearchWarrantsGroupToSearchWarrantsReportRequestParams(
+  searchWarrantsGroup: FormGroup,
+): CreateSearchWarrantsReportRequestParams {
+  return {
+    searchWarrantsReportFilterDto:
+      mapSearchWarrantsGroupToSearchWarrantsReportFilterDto(
+        searchWarrantsGroup,
+      ),
+  };
+}
+
 export function mapWorkloadGroupToWorkloadReportRequestParams(
   workloadGroup: FormGroup,
 ): CreateWorkloadReportRequestParams {
@@ -87,6 +108,20 @@ function mapListMaintenanceGroupToListMaintenanceFilterDto(
     dateFrom: value.dateFrom,
     dateTo: value.dateTo,
     ...(listDescription ? { listDescription } : {}),
+    ...(location ? { location } : {}),
+  };
+}
+
+function mapSearchWarrantsGroupToSearchWarrantsReportFilterDto(
+  searchWarrantsGroup: FormGroup,
+): SearchWarrantsReportFilterDto {
+  const value =
+    searchWarrantsGroup.getRawValue() as SearchWarrantsReportFormValue;
+  const location = buildLocation(value);
+
+  return {
+    dateFrom: value.dateFrom,
+    dateTo: value.dateTo,
     ...(location ? { location } : {}),
   };
 }

--- a/test/unit/app/pages/reports/reports.component.spec.ts
+++ b/test/unit/app/pages/reports/reports.component.spec.ts
@@ -36,6 +36,7 @@ const refFacadeStub: Pick<ReferenceDataFacade, 'courtLocations$' | 'cja$'> = {
 const reportsApiMock = {
   createFeesReport: jest.fn(),
   createListMaintenanceReport: jest.fn(),
+  createSearchWarrantsReport: jest.fn(),
   createWorkloadReport: jest.fn(),
   downloadReport: jest.fn(),
 };
@@ -168,8 +169,8 @@ describe('ReportsComponent', () => {
     fixture.detectChanges();
 
     expect(component.vm().errorSummary).toEqual([
-      { id: 'dateFrom', href: '#date-from', text: 'Enter day, month and year' },
-      { id: 'dateTo', href: '#date-to', text: 'Enter day, month and year' },
+      { id: 'dateFrom', href: '#date-from', text: 'Enter date from' },
+      { id: 'dateTo', href: '#date-to', text: 'Enter date to' },
     ]);
     expect(
       fixture.nativeElement.querySelector('app-error-summary'),
@@ -195,8 +196,12 @@ describe('ReportsComponent', () => {
     component.onDownload();
 
     expect(component.vm().errorSummary).toEqual([
-      { id: 'dateFrom', href: '#date-from', text: 'Enter month' },
-      { id: 'dateTo', href: '#date-to', text: 'Enter day, month and year' },
+      {
+        id: 'dateFrom',
+        href: '#date-from',
+        text: 'Date from must include a month',
+      },
+      { id: 'dateTo', href: '#date-to', text: 'Enter date to' },
     ]);
   });
 
@@ -262,6 +267,9 @@ describe('ReportsComponent', () => {
   });
 
   it('does not require search warrants court, other location, or CJA', () => {
+    const createJob$ = new Subject<HttpResponse<JobAcknowledgement>>();
+    reportsApiMock.createSearchWarrantsReport.mockReturnValue(createJob$);
+
     component.form.controls.report.setValue('search-warrants');
     component.searchWarrantsGroup.patchValue({
       dateFrom: '2026-01-01',
@@ -270,8 +278,23 @@ describe('ReportsComponent', () => {
     fixture.detectChanges();
 
     component.onDownload();
+    fixture.detectChanges();
 
     expect(component.vm().errorSummary).toEqual([]);
+    expect(reportsApiMock.createSearchWarrantsReport).toHaveBeenCalledWith(
+      {
+        searchWarrantsReportFilterDto: {
+          dateFrom: '2026-01-01',
+          dateTo: '2026-01-31',
+        },
+      },
+      'response',
+      false,
+      {
+        httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+        transferCache: false,
+      },
+    );
   });
 
   it('highlights the search warrants court suggestion when it has an error', () => {
@@ -333,6 +356,23 @@ describe('ReportsComponent', () => {
     component.form.controls.report.setValue('list-maintenance');
 
     expect(component.listMaintenanceGroup.value).toEqual(
+      expect.objectContaining({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      }),
+    );
+  });
+
+  it('preserves date from and date to when switching to search warrants', () => {
+    component.form.controls.report.setValue('activity-audit');
+    component.activityAuditGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+
+    component.form.controls.report.setValue('search-warrants');
+
+    expect(component.searchWarrantsGroup.value).toEqual(
       expect.objectContaining({
         dateFrom: '2026-01-01',
         dateTo: '2026-01-31',
@@ -428,6 +468,35 @@ describe('ReportsComponent', () => {
     expect(reportsApiMock.createListMaintenanceReport).not.toHaveBeenCalled();
   });
 
+  it('blocks search warrants download when date to is before date from', () => {
+    component.form.controls.report.setValue('search-warrants');
+    component.searchWarrantsGroup.patchValue({
+      dateFrom: '2026-02-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().errorSummary).toEqual([
+      {
+        id: 'dateTo',
+        href: '#list-date-to',
+        text: 'Date to must be on or after Date from',
+      },
+    ]);
+    expect(
+      fixture.nativeElement.querySelector('#list-date-to-error')?.textContent,
+    ).toContain('Date to must be on or after Date from');
+    expect(
+      fixture.nativeElement
+        .querySelector('#list-date-to-day')
+        ?.classList.contains('govuk-input--error'),
+    ).toBe(true);
+    expect(reportsApiMock.createSearchWarrantsReport).not.toHaveBeenCalled();
+  });
+
   it('blocks workload download when date to is before date from', () => {
     component.form.controls.report.setValue('workload');
     component.workloadGroup.patchValue({
@@ -480,6 +549,20 @@ describe('ReportsComponent', () => {
 
     expect(component.workloadGroup.get('court')?.disabled).toBe(true);
     expect(component.workloadGroup.get('cja')?.enabled).toBe(true);
+  });
+
+  it('preserves legacy CJA-only search warrants location behaviour', () => {
+    component.form.controls.report.setValue('search-warrants');
+    fixture.detectChanges();
+
+    component.searchWarrantsGroup.get('cja')?.setValue('C1');
+    fixture.detectChanges();
+
+    expect(component.searchWarrantsGroup.get('court')?.disabled).toBe(true);
+    expect(component.searchWarrantsGroup.get('otherLocation')?.enabled).toBe(
+      true,
+    );
+    expect(component.searchWarrantsGroup.get('cja')?.enabled).toBe(true);
   });
 
   it('shows report progress while the list maintenance job request is pending', () => {
@@ -723,6 +806,72 @@ describe('ReportsComponent', () => {
     ).toContain('Report downloaded');
   });
 
+  it('creates, polls, and downloads a search warrants report CSV', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-22T09:30:00'));
+    reportsApiMock.createSearchWarrantsReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(of(completedJob));
+    reportsApiMock.downloadReport.mockReturnValue(
+      of(
+        new HttpResponse({
+          body: new Blob(['header\n'], { type: 'text/csv' }),
+          headers: new HttpHeaders({
+            'content-disposition': 'attachment; filename="search-warrants.csv"',
+          }),
+          status: 200,
+        }),
+      ),
+    );
+
+    component.form.controls.report.setValue('search-warrants');
+    component.searchWarrantsGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+      cja: ' C1 ',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(reportsApiMock.createSearchWarrantsReport).toHaveBeenCalledWith(
+      {
+        searchWarrantsReportFilterDto: {
+          dateFrom: '2026-01-01',
+          dateTo: '2026-01-31',
+          location: {
+            cjaCode: 'C1',
+          },
+        },
+      },
+      'response',
+      false,
+      {
+        httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+        transferCache: false,
+      },
+    );
+    expect(jobPollingFacadeMock.watchJob).toHaveBeenCalledWith('job-1', 2000);
+    expect(reportsApiMock.downloadReport).toHaveBeenCalledWith(
+      { jobId: 'job-1' },
+      'response',
+      false,
+      { httpHeaderAccept: 'text/csv', transferCache: false },
+    );
+    expect(createObjectUrlSpy).toHaveBeenCalledWith(expect.any(Blob));
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (anchorClickSpy.mock.contexts[0] as HTMLAnchorElement).download,
+    ).toBe('search-warrants-report-2026-05-22.csv');
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'success',
+      heading: 'Report downloaded',
+      body: 'The search warrants report has downloaded.',
+    });
+  });
+
   it('creates, polls, and downloads a workload report CSV', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-05-22T09:30:00'));
@@ -838,6 +987,69 @@ describe('ReportsComponent', () => {
 
       component.form.controls.report.setValue('workload');
       component.workloadGroup.patchValue({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      });
+      fixture.detectChanges();
+
+      component.onDownload();
+      fixture.detectChanges();
+
+      expect(component.vm().reportFeedback).toEqual({
+        kind: 'error',
+        title: 'Report generation failed',
+        items: [{ text: message }],
+      });
+    },
+  );
+
+  it('shows the backend message when search warrants polling fails', () => {
+    reportsApiMock.createSearchWarrantsReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(
+      of({
+        ...completedJob,
+        rawStatus: 'FAILED',
+        state: 'failed',
+        message: 'Backend failed the search warrants report',
+      } satisfies PolledJobStatus),
+    );
+
+    component.form.controls.report.setValue('search-warrants');
+    component.searchWarrantsGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'error',
+      title: 'Report generation failed',
+      items: [{ text: 'Backend failed the search warrants report' }],
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      'Backend failed the search warrants report',
+    );
+    expect(reportsApiMock.downloadReport).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, 'You need to sign in to download this report.'],
+    [403, 'You do not have permission to download this report.'],
+    [500, 'There was a problem generating the report. Try again later.'],
+  ])(
+    'shows the search warrants request error message for HTTP %i',
+    (status, message) => {
+      reportsApiMock.createSearchWarrantsReport.mockReturnValue(
+        throwError(() => ({ status })),
+      );
+
+      component.form.controls.report.setValue('search-warrants');
+      component.searchWarrantsGroup.patchValue({
         dateFrom: '2026-01-01',
         dateTo: '2026-01-31',
       });


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-247

### Change description
- Added Search Warrants report export support using the async report job flow.
- Mapped Search Warrants form values to `searchWarrantsReportFilterDto`.
- Wired `POST /reports/search-warrants/jobs` via the generated OpenAPI client.
- Reused existing report polling and CSV download handling.
- Preserved existing/legacy location filter behaviour, including CJA being available independently of Other Location.
- Added Search Warrants success, failed polling, and request error coverage.
- Added validation coverage for Search Warrants date range and optional location filters.
- Improved Reports date error summary text so Date From and Date To errors are distinct.
- Added/updated unit tests for Search Warrants async report generation and date error summary wording.

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
