### PR TITLE
ARCPOC-1405 set current page to 0 on sort change

### DIFF
--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -939,6 +939,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
         key: sort.key,
         direction: sort.direction,
       },
+      currentPage: 0,
     });
 
     this.loadListDetailsInfo();

--- a/src/app/pages/applications-list-detail/applications-list-entry-move/applications-list-entry-move.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-entry-move/applications-list-entry-move.component.ts
@@ -239,6 +239,7 @@ export class ApplicationsListEntryMoveComponent
         direction: sort.direction,
       },
     });
+    this.storedRecordsState.patch({ currentPage: 0 });
     this.loadApplicationsLists();
   }
 

--- a/src/app/pages/applications-list/applications-list.component.ts
+++ b/src/app/pages/applications-list/applications-list.component.ts
@@ -425,6 +425,7 @@ export class ApplicationsList extends PlaceFieldsBase implements OnInit {
         direction: sort.direction,
       },
     });
+    this.storedRecordsState.patch({ currentPage: 0 });
 
     const hasAny = hasAnyParams(this.form);
     this.loadApplicationsLists(hasAny);

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -146,8 +146,8 @@ export class StandardApplicants implements OnInit {
       return;
     }
 
-    this.signalState.patch({ sortField: sort });
-    this.loadStandardApplicants(this.vm().currentPage);
+    this.signalState.patch({ sortField: sort, currentPage: 0 });
+    this.loadStandardApplicants(0);
   }
 
   onPageChange(page: number): void {

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.ts
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.ts
@@ -247,6 +247,7 @@ export class ApplicationCodeSearchComponent implements OnInit {
     }
 
     this.sortField.set(sort);
+    this.currentPage.set(0);
     this.search();
   }
 

--- a/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
+++ b/src/app/shared/components/standard-applicant-select/standard-applicant-select.component.ts
@@ -158,8 +158,8 @@ export class StandardApplicantSelectComponent implements OnInit, OnChanges {
     if (!this.saState().hasSearched) {
       return;
     }
-    this.saSignalState.patch({ sortField: sort });
-    this.loadPage(this.vm().pageIndex);
+    this.saSignalState.patch({ sortField: sort, pageIndex: 0 });
+    this.loadPage(0);
   }
 
   onSubmit(event: SubmitEvent): void {

--- a/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
@@ -1294,10 +1294,11 @@ describe('ApplicationsListDetail', () => {
     expect(loadSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('onSortChange stores the UI sort key and reloads data', () => {
+  it('onSortChange stores the UI sort key, resets to page 0, and reloads data', () => {
     const loadSpy = jest
       .spyOn(component, 'loadListDetailsInfo')
       .mockImplementation(() => undefined);
+    patchDetailState({ currentPage: 5 });
 
     component.onSortChange({ key: 'title', direction: 'desc' });
 
@@ -1305,6 +1306,7 @@ describe('ApplicationsListDetail', () => {
       key: 'title',
       direction: 'desc',
     });
+    expect(vm().currentPage).toBe(0);
     expect(loadSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/test/unit/app/pages/applications-list-detail/applications-list-entry-move/applications-list-entry-move.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-entry-move/applications-list-entry-move.component.spec.ts
@@ -436,12 +436,19 @@ describe('ApplicationsListEntryMoveComponent', () => {
   });
 
   it('maps known sort keys and preserves unknown ones', () => {
+    (
+      component as unknown as {
+        storedRecordsState: { patch: (patch: { currentPage: number }) => void };
+      }
+    ).storedRecordsState.patch({ currentPage: 4 });
+
     component.onSortChange({ key: 'entries', direction: 'asc' });
 
     expect(component.vm().sortField).toEqual({
       key: 'entriesCount',
       direction: 'asc',
     });
+    expect(component.storedRecordsVm().currentPage).toBe(0);
 
     component.onSortChange({ key: 'customSort', direction: 'desc' });
 

--- a/test/unit/app/pages/applications-list/applications-list.component.spec.ts
+++ b/test/unit/app/pages/applications-list/applications-list.component.spec.ts
@@ -477,10 +477,11 @@ describe('ApplicationsList – search', () => {
     expect(args.filter).toEqual({ status: 'CLOSED' });
   });
 
-  it('onSortChange stores the UI sort key and reloads data', () => {
+  it('onSortChange stores the UI sort key, resets to page 0, and reloads data', () => {
     const loadSpy = jest
       .spyOn(component, 'loadApplicationsLists')
       .mockImplementation(() => undefined);
+    patchRecordsState(component, { currentPage: 4 });
 
     component.onSortChange({ key: 'entries', direction: 'desc' });
 
@@ -488,6 +489,7 @@ describe('ApplicationsList – search', () => {
       key: 'entries',
       direction: 'desc',
     });
+    expect(getRecordsState(component).currentPage).toBe(0);
     expect(loadSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
+++ b/test/unit/app/pages/standard-applicants/standard-applicants.component.spec.ts
@@ -325,13 +325,13 @@ describe('StandardApplicantsComponent', () => {
     );
   });
 
-  it('keeps the current page number when sorting after paging', async () => {
+  it('resets to the first page when sorting after paging', async () => {
     component.onSubmit(new SubmitEvent('submit'));
     await flushSignalEffects(fixture);
 
     getStandardApplicantsMock.mockReturnValueOnce(
       of({
-        pageNumber: 1,
+        pageNumber: 0,
         pageSize: 10,
         totalElements: 11,
         content: [
@@ -386,7 +386,7 @@ describe('StandardApplicantsComponent', () => {
       {
         code: undefined,
         name: undefined,
-        pageNumber: 1,
+        pageNumber: 0,
         pageSize: 10,
         sort: ['from,desc'],
       },
@@ -396,7 +396,7 @@ describe('StandardApplicantsComponent', () => {
         transferCache: true,
       },
     );
-    expect(component.vm().currentPage).toBe(1);
+    expect(component.vm().currentPage).toBe(0);
   });
 
   it('sorts using the last applied filters when the current form is invalid', async () => {

--- a/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
+++ b/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
@@ -327,7 +327,7 @@ describe('ApplicationCodeSearchComponent', () => {
     ]);
   });
 
-  it('onSortChange() should keep the current page and search with mapped API sort', () => {
+  it('onSortChange() should reset to page 0 and search with mapped API sort', () => {
     const fetchSpy = jest
       .spyOn(helpers, 'fetchCodeRows$')
       .mockReturnValue(of(mockRows));
@@ -337,14 +337,14 @@ describe('ApplicationCodeSearchComponent', () => {
 
     component.onSortChange({ key: 'title', direction: 'desc' });
 
-    expect(component.currentPage()).toBe(4);
+    expect(component.currentPage()).toBe(0);
     expect(component.sortField()).toEqual({ key: 'title', direction: 'desc' });
     expect(fetchSpy).toHaveBeenCalledWith(
       apiMock,
       {
         code: 'MS99004',
         title: undefined,
-        pageNumber: 4,
+        pageNumber: 0,
         pageSize: 10,
         sort: ['title,desc'],
       },

--- a/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
+++ b/test/unit/app/shared/components/standard-applicant-select/standard-applicant-select.component.spec.ts
@@ -287,7 +287,7 @@ describe('StandardApplicantSelectComponent', () => {
     expect(component.vm().pageIndex).toBe(0);
   });
 
-  it('keeps the current page number when sorting after paging', () => {
+  it('resets to the first page when sorting after paging', () => {
     fixture.detectChanges();
     fixture.detectChanges();
 
@@ -307,7 +307,7 @@ describe('StandardApplicantSelectComponent', () => {
     mockGetStandardApplicants.mockReturnValueOnce(
       of({
         content: [makeSummary({ code: 'SA-1' })],
-        pageNumber: 1,
+        pageNumber: 0,
         pageSize: 10,
         totalElements: 11,
         totalPages: 2,
@@ -321,7 +321,7 @@ describe('StandardApplicantSelectComponent', () => {
       {
         code: undefined,
         name: undefined,
-        pageNumber: 1,
+        pageNumber: 0,
         pageSize: 10,
         sort: ['to,desc'],
       },
@@ -329,7 +329,7 @@ describe('StandardApplicantSelectComponent', () => {
       false,
       expect.objectContaining({ transferCache: true }),
     );
-    expect(component.vm().pageIndex).toBe(1);
+    expect(component.vm().pageIndex).toBe(0);
   });
 
   it('keeps the table mounted while a sort request is in flight when rows already exist', () => {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1405

### Change description

- Reset paginated results to the first page whenever a server-side table sort changes.
- Applied the pagination reset consistently across applications lists, list detail entries, move-entry list search, standard applicants, application code search, and standard applicant select.

<!-- Describe what changed and why. -->

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
