### PR TITLE
ARCPOC-249 Duration report changes

### DIFF
--- a/src/app/pages/reports/reports.component.html
+++ b/src/app/pages/reports/reports.component.html
@@ -119,5 +119,13 @@
     >
       Download CSV
     </button>
+    <button
+      type="button"
+      class="govuk-button govuk-button--secondary"
+      [disabled]="isReportInProgress()"
+      (click)="onClearFilters()"
+    >
+      Clear filters
+    </button>
   </div>
 }

--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -93,6 +93,15 @@ const REPORT_CSV_OPTIONS = {
   httpHeaderAccept: 'text/csv',
   transferCache: false,
 } as const;
+const REPORT_DATE_RESET_VALUE = {
+  dateFrom: null,
+  dateTo: null,
+} as const;
+const REPORT_LOCATION_RESET_VALUE = {
+  court: '',
+  otherLocation: '',
+  cja: '',
+} as const;
 
 @Component({
   selector: 'app-reports',
@@ -356,6 +365,29 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     if (this.form.controls.report.value === 'duration') {
       this.createDurationReport();
     }
+  }
+
+  onClearFilters(): void {
+    const reportId = this.form.controls.report.value as ReportId | null;
+    const selectedGroup = this.reportGroupFor(reportId);
+
+    if (!reportId || !selectedGroup || this.isReportInProgress()) {
+      return;
+    }
+
+    this.stopReportCreate();
+    this.stopReportPolling();
+    this.clearLocationSearchState();
+    selectedGroup.enable({ emitEvent: false });
+    selectedGroup.reset(this.emptyReportFormValue(reportId));
+    selectedGroup.markAsPristine();
+    selectedGroup.markAsUntouched();
+    selectedGroup.updateValueAndValidity({ emitEvent: false });
+    this.reportStatePatch({
+      submitted: false,
+      errorSummary: [],
+      reportFeedback: null,
+    });
   }
 
   /** Handy getter for the child binding */
@@ -633,6 +665,57 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     });
     this.reportGroupFor(reportId)?.markAsPristine();
     this.reportGroupFor(reportId)?.markAsUntouched();
+  }
+
+  private emptyReportFormValue(reportId: ReportId): Record<string, unknown> {
+    switch (reportId) {
+      case 'activity-audit':
+        return {
+          ...REPORT_DATE_RESET_VALUE,
+          username: '',
+          activity: [],
+        };
+      case 'fees':
+        return {
+          ...REPORT_DATE_RESET_VALUE,
+          standardApplicantCode: '',
+          surnameOrOrg: '',
+          ...REPORT_LOCATION_RESET_VALUE,
+        };
+      case 'list-maintenance':
+        return {
+          ...REPORT_DATE_RESET_VALUE,
+          description: '',
+          ...REPORT_LOCATION_RESET_VALUE,
+        };
+      case 'search-warrants':
+      case 'workload':
+      case 'duration':
+        return {
+          ...REPORT_DATE_RESET_VALUE,
+          ...REPORT_LOCATION_RESET_VALUE,
+        };
+      case 'private-prosecutors-index':
+        return {
+          ...REPORT_DATE_RESET_VALUE,
+          applicantSurnameOrOrg: '',
+          applicantFirst: '',
+          standardApplicantName: '',
+          respondentFirst: '',
+          respondentSurname: '',
+          respondentOrg: '',
+          ...REPORT_LOCATION_RESET_VALUE,
+        };
+    }
+  }
+
+  private clearLocationSearchState(): void {
+    this.patch({
+      courthouseSearch: '',
+      cjaSearch: '',
+      filteredCourthouses: [],
+      filteredCja: [],
+    });
   }
 
   private createListMaintenanceReport(): void {

--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -22,6 +22,7 @@ import {
   ReportsState,
   initialReportsState,
   mapActivityAuditGroupToActivityAuditRequestParams,
+  mapDurationGroupToDurationReportRequestParams,
   mapFeeGroupToFeesReportFilterDto,
   mapListMaintenanceGroupToListMaintenanceReportRequestParams,
   mapSearchWarrantsGroupToSearchWarrantsReportRequestParams,
@@ -50,6 +51,7 @@ import {
 import { reportOptions } from '@constants/reports/report-selector.constant';
 import {
   CreateActivityAuditReportRequestParams,
+  CreateDurationReportRequestParams,
   CreateFeesReportRequestParams,
   CreateListMaintenanceReportRequestParams,
   CreateSearchWarrantsReportRequestParams,
@@ -128,6 +130,8 @@ export class Reports extends PlaceFieldsBase implements OnInit {
   private previousReportId: ReportId | null = null;
   private reportPollingSub: Subscription | null = null;
 
+  private readonly createDurationReportRequest =
+    signal<CreateDurationReportRequestParams | null>(null);
   private readonly createFeesReportRequest =
     signal<CreateFeesReportRequestParams | null>(null);
   private readonly createListMaintenanceReportRequest =
@@ -348,6 +352,10 @@ export class Reports extends PlaceFieldsBase implements OnInit {
 
       this.startCreateActivityAuditReport(request);
     }
+
+    if (this.form.controls.report.value === 'duration') {
+      this.createDurationReport();
+    }
   }
 
   /** Handy getter for the child binding */
@@ -392,6 +400,15 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     this.createFeesReportRequest.set(request);
   }
 
+  private startCreateDurationReport(
+    request: CreateDurationReportRequestParams,
+  ): void {
+    this.stopReportCreate();
+    this.stopReportPolling();
+    this.showReportProgress();
+    this.createDurationReportRequest.set(request);
+  }
+
   private startCreateSearchWarrantsReport(
     request: CreateSearchWarrantsReportRequestParams,
   ): void {
@@ -420,6 +437,29 @@ export class Reports extends PlaceFieldsBase implements OnInit {
   }
 
   private setupEffects(): void {
+    // POST /reports/duration/jobs
+    setupLoadEffect(
+      {
+        request: this.createDurationReportRequest,
+        load: (request) =>
+          this.reportsApi.createDurationReport(
+            request,
+            'response',
+            false,
+            REPORT_JSON_OPTIONS,
+          ),
+        onSuccess: (response) => {
+          this.createDurationReportRequest.set(null);
+          this.handleReportJobCreated(response);
+        },
+        onError: (err) => {
+          this.createDurationReportRequest.set(null);
+          this.showReportError(this.toReportRequestError(err));
+        },
+      },
+      this.envInjector,
+    );
+
     // POST /reports/fees/jobs
     setupLoadEffect(
       {
@@ -606,6 +646,12 @@ export class Reports extends PlaceFieldsBase implements OnInit {
     );
   }
 
+  private createDurationReport(): void {
+    this.startCreateDurationReport(
+      mapDurationGroupToDurationReportRequestParams(this.durationGroup),
+    );
+  }
+
   private createSearchWarrantsReport(): void {
     this.startCreateSearchWarrantsReport(
       mapSearchWarrantsGroupToSearchWarrantsReportRequestParams(
@@ -660,6 +706,7 @@ export class Reports extends PlaceFieldsBase implements OnInit {
   }
 
   private stopReportCreate(): void {
+    this.createDurationReportRequest.set(null);
     this.createFeesReportRequest.set(null);
     this.createListMaintenanceReportRequest.set(null);
     this.createSearchWarrantsReportRequest.set(null);

--- a/src/app/pages/reports/util/report-request.mapper.ts
+++ b/src/app/pages/reports/util/report-request.mapper.ts
@@ -5,9 +5,11 @@ import {
   ActivityAuditFilterDto,
   ActivityType,
   CreateActivityAuditReportRequestParams,
+  CreateDurationReportRequestParams,
   CreateListMaintenanceReportRequestParams,
   CreateSearchWarrantsReportRequestParams,
   CreateWorkloadReportRequestParams,
+  DurationFilterDto,
   FeesReportFilterDto,
   LegacyReportLocation,
   ListMaintenanceFilterDto,
@@ -26,6 +28,14 @@ interface FeesReportFormValue {
 }
 
 interface ReportLocationFormValue {
+  court: string | null;
+  otherLocation: string | null;
+  cja: string | null;
+}
+
+interface DurationReportFormValue {
+  dateFrom: string;
+  dateTo: string;
   court: string | null;
   otherLocation: string | null;
   cja: string | null;
@@ -78,6 +88,14 @@ export function mapFeeGroupToFeesReportFilterDto(
   };
 }
 
+export function mapDurationGroupToDurationReportRequestParams(
+  durationGroup: FormGroup,
+): CreateDurationReportRequestParams {
+  return {
+    durationFilterDto: mapDurationGroupToDurationFilterDto(durationGroup),
+  };
+}
+
 export function mapListMaintenanceGroupToListMaintenanceReportRequestParams(
   listMaintenanceGroup: FormGroup,
 ): CreateListMaintenanceReportRequestParams {
@@ -111,6 +129,19 @@ export function mapActivityAuditGroupToActivityAuditRequestParams(
 ): CreateActivityAuditReportRequestParams {
   return {
     activityAuditFilterDto: mapActivityAuditFormToParams(activityAudit),
+  };
+}
+
+function mapDurationGroupToDurationFilterDto(
+  durationGroup: FormGroup,
+): DurationFilterDto {
+  const value = durationGroup.getRawValue() as DurationReportFormValue;
+  const location = buildLocation(value);
+
+  return {
+    dateFrom: value.dateFrom,
+    dateTo: value.dateTo,
+    ...(location ? { location } : {}),
   };
 }
 

--- a/src/app/shared/components/duration-section/duration-section.component.html
+++ b/src/app/shared/components/duration-section/duration-section.component.html
@@ -10,4 +10,5 @@
   [suggestions]="suggestions()"
   [submitted]="submitted()"
   [getError]="getError()"
+  [advancedFilters]="true"
 />

--- a/src/app/shared/components/search-warrants-section/search-warrants-section.component.html
+++ b/src/app/shared/components/search-warrants-section/search-warrants-section.component.html
@@ -9,4 +9,5 @@
   [suggestions]="suggestions()"
   [submitted]="submitted()"
   [getError]="getError()"
+  [advancedFilters]="true"
 />

--- a/src/app/shared/components/workload-section/workload-section.component.html
+++ b/src/app/shared/components/workload-section/workload-section.component.html
@@ -10,4 +10,5 @@
   [suggestions]="suggestions()"
   [submitted]="submitted()"
   [getError]="getError()"
+  [advancedFilters]="true"
 />

--- a/test/unit/app/pages/reports/reports.component.spec.ts
+++ b/test/unit/app/pages/reports/reports.component.spec.ts
@@ -9,6 +9,7 @@ import { provideRouter } from '@angular/router';
 import { Subject, of, throwError } from 'rxjs';
 
 import { DateInputComponent } from '@components/date-input/date-input.component';
+import { DurationSectionComponent } from '@components/duration-section/duration-section.component';
 import { Reports } from '@components/reports/reports.component';
 import { SearchWarrantsSectionComponent } from '@components/search-warrants-section/search-warrants-section.component';
 import { WorkloadSectionComponent } from '@components/workload-section/workload-section.component';
@@ -34,6 +35,7 @@ const refFacadeStub: Pick<ReferenceDataFacade, 'courtLocations$' | 'cja$'> = {
 };
 
 const reportsApiMock = {
+  createDurationReport: jest.fn(),
   createFeesReport: jest.fn(),
   createListMaintenanceReport: jest.fn(),
   createSearchWarrantsReport: jest.fn(),
@@ -146,6 +148,19 @@ describe('ReportsComponent', () => {
     ).componentInstance as WorkloadSectionComponent;
 
     expect(section.group()).toBe(component.workloadGroup);
+    expect(section.suggestions()).toBe(component.suggestionsFacade);
+    expect(section.getError()).toEqual(expect.any(Function));
+  });
+
+  it('passes the duration group and suggestions facade to the section', () => {
+    component.form.controls.report.setValue('duration');
+    fixture.detectChanges();
+
+    const section = fixture.debugElement.query(
+      By.directive(DurationSectionComponent),
+    ).componentInstance as DurationSectionComponent;
+
+    expect(section.group()).toBe(component.durationGroup);
     expect(section.suggestions()).toBe(component.suggestionsFacade);
     expect(section.getError()).toEqual(expect.any(Function));
   });
@@ -339,6 +354,37 @@ describe('ReportsComponent', () => {
     );
   });
 
+  it('does not require duration court, other location, or CJA', () => {
+    const createJob$ = new Subject<HttpResponse<JobAcknowledgement>>();
+    reportsApiMock.createDurationReport.mockReturnValue(createJob$);
+
+    component.form.controls.report.setValue('duration');
+    component.durationGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().errorSummary).toEqual([]);
+    expect(reportsApiMock.createDurationReport).toHaveBeenCalledWith(
+      {
+        durationFilterDto: {
+          dateFrom: '2026-01-01',
+          dateTo: '2026-01-31',
+        },
+      },
+      'response',
+      false,
+      {
+        httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+        transferCache: false,
+      },
+    );
+  });
+
   it('highlights the search warrants court suggestion when it has an error', () => {
     component.form.controls.report.setValue('search-warrants');
     component.searchWarrantsGroup.patchValue({
@@ -432,6 +478,23 @@ describe('ReportsComponent', () => {
     component.form.controls.report.setValue('workload');
 
     expect(component.workloadGroup.value).toEqual(
+      expect.objectContaining({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      }),
+    );
+  });
+
+  it('preserves date from and date to when switching to duration', () => {
+    component.form.controls.report.setValue('activity-audit');
+    component.activityAuditGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+
+    component.form.controls.report.setValue('duration');
+
+    expect(component.durationGroup.value).toEqual(
       expect.objectContaining({
         dateFrom: '2026-01-01',
         dateTo: '2026-01-31',
@@ -568,6 +631,35 @@ describe('ReportsComponent', () => {
     expect(reportsApiMock.createWorkloadReport).not.toHaveBeenCalled();
   });
 
+  it('blocks duration download when date to is before date from', () => {
+    component.form.controls.report.setValue('duration');
+    component.durationGroup.patchValue({
+      dateFrom: '2026-02-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().errorSummary).toEqual([
+      {
+        id: 'dateTo',
+        href: '#list-date-to',
+        text: 'Date to must be on or after Date from',
+      },
+    ]);
+    expect(
+      fixture.nativeElement.querySelector('#list-date-to-error')?.textContent,
+    ).toContain('Date to must be on or after Date from');
+    expect(
+      fixture.nativeElement
+        .querySelector('#list-date-to-day')
+        ?.classList.contains('govuk-input--error'),
+    ).toBe(true);
+    expect(reportsApiMock.createDurationReport).not.toHaveBeenCalled();
+  });
+
   it('enforces workload location mutual exclusivity in the form controls', () => {
     component.form.controls.report.setValue('workload');
     fixture.detectChanges();
@@ -669,6 +761,18 @@ describe('ReportsComponent', () => {
         ) as HTMLInputElement | null
       )?.disabled,
     ).toBe(true);
+  });
+
+  it('preserves legacy CJA-only duration location behaviour', () => {
+    component.form.controls.report.setValue('duration');
+    fixture.detectChanges();
+
+    component.durationGroup.get('cja')?.setValue('C1');
+    fixture.detectChanges();
+
+    expect(component.durationGroup.get('court')?.disabled).toBe(true);
+    expect(component.durationGroup.get('otherLocation')?.enabled).toBe(true);
+    expect(component.durationGroup.get('cja')?.enabled).toBe(true);
   });
 
   it('shows report progress while the list maintenance job request is pending', () => {
@@ -1112,6 +1216,74 @@ describe('ReportsComponent', () => {
     });
   });
 
+  it('creates, polls, and downloads a duration report CSV', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-22T09:30:00'));
+    reportsApiMock.createDurationReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(of(completedJob));
+    reportsApiMock.downloadReport.mockReturnValue(
+      of(
+        new HttpResponse({
+          body: new Blob(['header\n'], { type: 'text/csv' }),
+          headers: new HttpHeaders({
+            'content-disposition': 'attachment; filename="duration.csv"',
+          }),
+          status: 200,
+        }),
+      ),
+    );
+
+    component.form.controls.report.setValue('duration');
+    component.durationGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+      otherLocation: '  Annex  ',
+      cja: ' C1 ',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(reportsApiMock.createDurationReport).toHaveBeenCalledWith(
+      {
+        durationFilterDto: {
+          dateFrom: '2026-01-01',
+          dateTo: '2026-01-31',
+          location: {
+            otherLocationDescription: 'Annex',
+            cjaCode: 'C1',
+          },
+        },
+      },
+      'response',
+      false,
+      {
+        httpHeaderAccept: 'application/vnd.hmcts.appreg.v1+json',
+        transferCache: false,
+      },
+    );
+    expect(jobPollingFacadeMock.watchJob).toHaveBeenCalledWith('job-1', 2000);
+    expect(reportsApiMock.downloadReport).toHaveBeenCalledWith(
+      { jobId: 'job-1' },
+      'response',
+      false,
+      { httpHeaderAccept: 'text/csv', transferCache: false },
+    );
+    expect(createObjectUrlSpy).toHaveBeenCalledWith(expect.any(Blob));
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (anchorClickSpy.mock.contexts[0] as HTMLAnchorElement).download,
+    ).toBe('duration-report-2026-05-22.csv');
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'success',
+      heading: 'Report downloaded',
+      body: 'The duration report has downloaded.',
+    });
+  });
+
   it('shows the backend message when workload polling fails', () => {
     reportsApiMock.createWorkloadReport.mockReturnValue(
       of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
@@ -1159,6 +1331,69 @@ describe('ReportsComponent', () => {
 
       component.form.controls.report.setValue('workload');
       component.workloadGroup.patchValue({
+        dateFrom: '2026-01-01',
+        dateTo: '2026-01-31',
+      });
+      fixture.detectChanges();
+
+      component.onDownload();
+      fixture.detectChanges();
+
+      expect(component.vm().reportFeedback).toEqual({
+        kind: 'error',
+        title: 'Report generation failed',
+        items: [{ text: message }],
+      });
+    },
+  );
+
+  it('shows the backend message when duration polling fails', () => {
+    reportsApiMock.createDurationReport.mockReturnValue(
+      of(new HttpResponse({ body: jobAcknowledgement, status: 202 })),
+    );
+    jobPollingFacadeMock.watchJob.mockReturnValue(
+      of({
+        ...completedJob,
+        rawStatus: 'FAILED',
+        state: 'failed',
+        message: 'Backend failed the duration report',
+      } satisfies PolledJobStatus),
+    );
+
+    component.form.controls.report.setValue('duration');
+    component.durationGroup.patchValue({
+      dateFrom: '2026-01-01',
+      dateTo: '2026-01-31',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().reportFeedback).toEqual({
+      kind: 'error',
+      title: 'Report generation failed',
+      items: [{ text: 'Backend failed the duration report' }],
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      'Backend failed the duration report',
+    );
+    expect(reportsApiMock.downloadReport).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, 'You need to sign in to download this report.'],
+    [403, 'You do not have permission to download this report.'],
+    [500, 'There was a problem generating the report. Try again later.'],
+  ])(
+    'shows the duration request error message for HTTP %i',
+    (status, message) => {
+      reportsApiMock.createDurationReport.mockReturnValue(
+        throwError(() => ({ status })),
+      );
+
+      component.form.controls.report.setValue('duration');
+      component.durationGroup.patchValue({
         dateFrom: '2026-01-01',
         dateTo: '2026-01-31',
       });

--- a/test/unit/app/pages/reports/reports.component.spec.ts
+++ b/test/unit/app/pages/reports/reports.component.spec.ts
@@ -110,6 +110,29 @@ describe('ReportsComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('shows the clear filters button for every report type', () => {
+    const reportIds = [
+      'activity-audit',
+      'fees',
+      'list-maintenance',
+      'search-warrants',
+      'workload',
+      'duration',
+      'private-prosecutors-index',
+    ];
+
+    for (const reportId of reportIds) {
+      component.form.controls.report.setValue(reportId);
+      fixture.detectChanges();
+
+      const clearButton = Array.from<HTMLButtonElement>(
+        fixture.nativeElement.querySelectorAll('button'),
+      ).find((button) => button.textContent?.trim() === 'Clear filters');
+
+      expect(clearButton).toBeTruthy();
+    }
+  });
+
   it('filters search warrant court suggestions via the facade', () => {
     component.form.controls.report.setValue('search-warrants');
     fixture.detectChanges();
@@ -542,6 +565,53 @@ describe('ReportsComponent', () => {
         .querySelector('#date-to-day')
         ?.classList.contains('govuk-input--error'),
     ).toBe(false);
+  });
+
+  it('clears the selected report filters and validation state', () => {
+    component.form.controls.report.setValue('workload');
+    component.workloadGroup.patchValue({
+      dateFrom: '2026-02-01',
+      dateTo: '2026-01-31',
+    });
+    component.suggestionsFacade.selectCourthouse({
+      locationCode: 'A1',
+      name: 'Alpha Court',
+    });
+    fixture.detectChanges();
+
+    component.onDownload();
+    fixture.detectChanges();
+
+    expect(component.vm().submitted).toBe(true);
+    expect(component.vm().errorSummary).toHaveLength(1);
+    expect(component.suggestionsFacade.courthouseSearch()).toBe(
+      'A1 - Alpha Court',
+    );
+    expect(component.workloadGroup.get('otherLocation')?.disabled).toBe(true);
+    expect(component.workloadGroup.get('cja')?.disabled).toBe(true);
+
+    component.onClearFilters();
+    fixture.detectChanges();
+
+    expect(component.form.controls.report.value).toBe('workload');
+    expect(component.vm().submitted).toBe(false);
+    expect(component.vm().errorSummary).toEqual([]);
+    expect(component.vm().reportFeedback).toBeNull();
+    expect(component.suggestionsFacade.courthouseSearch()).toBe('');
+    expect(component.suggestionsFacade.cjaSearch()).toBe('');
+    expect(component.workloadGroup.getRawValue()).toEqual({
+      dateFrom: null,
+      dateTo: null,
+      court: '',
+      otherLocation: '',
+      cja: '',
+    });
+    expect(component.workloadGroup.get('court')?.enabled).toBe(true);
+    expect(component.workloadGroup.get('otherLocation')?.enabled).toBe(true);
+    expect(component.workloadGroup.get('cja')?.enabled).toBe(true);
+    expect(
+      fixture.nativeElement.querySelector('app-error-summary'),
+    ).toBeFalsy();
   });
 
   it('blocks list maintenance download when date to is before date from', () => {

--- a/test/unit/app/shared/components/duration-section/duration-section.component.spec.ts
+++ b/test/unit/app/shared/components/duration-section/duration-section.component.spec.ts
@@ -96,4 +96,42 @@ describe('DurationSectionComponent', () => {
     );
     expect(cjaInput).toBeTruthy();
   });
+
+  it('keeps dates and court outside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const dateInputs = fixture.nativeElement.querySelectorAll(
+      'app-date-input',
+    ) as NodeListOf<HTMLElement>;
+    const court = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="court"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(dateInputs).toHaveLength(2);
+    expect(court).toBeTruthy();
+    expect(details.contains(dateInputs[0])).toBe(false);
+    expect(details.contains(dateInputs[1])).toBe(false);
+    expect(details.contains(court)).toBe(false);
+    expect(details.textContent).toContain('Advanced filters');
+  });
+
+  it('renders CJA and other location inside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const cja = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="cja"]',
+    ) as HTMLElement;
+    const otherLocation = fixture.nativeElement.querySelector(
+      'app-text-input[formControlName="otherLocation"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(cja).toBeTruthy();
+    expect(otherLocation).toBeTruthy();
+    expect(details.contains(cja)).toBe(true);
+    expect(details.contains(otherLocation)).toBe(true);
+  });
 });

--- a/test/unit/app/shared/components/search-warrants-section/search-warrants-section.component.spec.ts
+++ b/test/unit/app/shared/components/search-warrants-section/search-warrants-section.component.spec.ts
@@ -88,4 +88,42 @@ describe('SearchWarrantsSectionComponent', () => {
 
     expect(formGroup.form).toBe(group);
   });
+
+  it('keeps dates and court outside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const dateInputs = fixture.nativeElement.querySelectorAll(
+      'app-date-input',
+    ) as NodeListOf<HTMLElement>;
+    const court = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="court"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(dateInputs).toHaveLength(2);
+    expect(court).toBeTruthy();
+    expect(details.contains(dateInputs[0])).toBe(false);
+    expect(details.contains(dateInputs[1])).toBe(false);
+    expect(details.contains(court)).toBe(false);
+    expect(details.textContent).toContain('Advanced filters');
+  });
+
+  it('renders CJA and other location inside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const cja = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="cja"]',
+    ) as HTMLElement;
+    const otherLocation = fixture.nativeElement.querySelector(
+      'app-text-input[formControlName="otherLocation"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(cja).toBeTruthy();
+    expect(otherLocation).toBeTruthy();
+    expect(details.contains(cja)).toBe(true);
+    expect(details.contains(otherLocation)).toBe(true);
+  });
 });

--- a/test/unit/app/shared/components/workload-section/workload-section.component.spec.ts
+++ b/test/unit/app/shared/components/workload-section/workload-section.component.spec.ts
@@ -96,4 +96,42 @@ describe('WorkloadSectionComponent', () => {
     );
     expect(cjaInput).toBeTruthy();
   });
+
+  it('keeps dates and court outside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const dateInputs = fixture.nativeElement.querySelectorAll(
+      'app-date-input',
+    ) as NodeListOf<HTMLElement>;
+    const court = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="court"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(dateInputs).toHaveLength(2);
+    expect(court).toBeTruthy();
+    expect(details.contains(dateInputs[0])).toBe(false);
+    expect(details.contains(dateInputs[1])).toBe(false);
+    expect(details.contains(court)).toBe(false);
+    expect(details.textContent).toContain('Advanced filters');
+  });
+
+  it('renders CJA and other location inside advanced filters', () => {
+    const details = fixture.nativeElement.querySelector(
+      'details.govuk-details',
+    ) as HTMLDetailsElement;
+    const cja = fixture.nativeElement.querySelector(
+      'app-suggestions[formControlName="cja"]',
+    ) as HTMLElement;
+    const otherLocation = fixture.nativeElement.querySelector(
+      'app-text-input[formControlName="otherLocation"]',
+    ) as HTMLElement;
+
+    expect(details).toBeTruthy();
+    expect(cja).toBeTruthy();
+    expect(otherLocation).toBeTruthy();
+    expect(details.contains(cja)).toBe(true);
+    expect(details.contains(otherLocation)).toBe(true);
+  });
 });


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-249

### Change description
- Added Duration report export support using the existing async report job flow.
- Mapped Duration form values to `durationFilterDto`.
- Wired `POST /reports/duration/jobs` via the generated OpenAPI client.
- Reused existing polling and CSV download handling.
- Preserved existing legacy location filter behaviour for Court, Other Location, and CJA.
- Added Duration success, failed polling, and request error coverage.
- Added validation coverage for Duration date range and optional location filters.
- Added coverage for preserving Date From and Date To when switching to Duration.
- Added coverage for the Duration section receiving its form group, suggestions facade, and error handler.

### Testing done
- Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
