### PR TITLE
Fix Codex runner Corepack setup

### DIFF
--- a/.github/scripts/codex-runner-preflight.sh
+++ b/.github/scripts/codex-runner-preflight.sh
@@ -11,6 +11,19 @@ require_command() {
   fi
 }
 
+enable_corepack_local() {
+  local corepack_bin="${RUNNER_TEMP:-/tmp}/corepack-bin"
+
+  mkdir -p "${corepack_bin}"
+  export PATH="${corepack_bin}:${PATH}"
+
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "${corepack_bin}" >>"${GITHUB_PATH}"
+  fi
+
+  corepack enable --install-directory "${corepack_bin}"
+}
+
 for command_name in git gh java node corepack python3 codex; do
   require_command "$command_name"
 done
@@ -24,7 +37,7 @@ corepack --version
 python3 --version
 codex --version
 
-corepack enable
+enable_corepack_local
 yarn --version
 
 if command -v docker >/dev/null 2>&1; then

--- a/bin/codex-local-pipeline.sh
+++ b/bin/codex-local-pipeline.sh
@@ -47,6 +47,14 @@ require_command() {
   fi
 }
 
+enable_corepack_local() {
+  local corepack_bin="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/corepack-bin"
+
+  mkdir -p "${corepack_bin}"
+  export PATH="${corepack_bin}:${PATH}"
+  corepack enable --install-directory "${corepack_bin}"
+}
+
 repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 
@@ -143,7 +151,7 @@ if [[ "${mode}" == "checks-only" ]]; then
 fi
 
 log "Preparing Yarn"
-corepack enable
+enable_corepack_local
 yarn --version
 
 log "Installing dependencies"

--- a/bin/codex-local-pipeline.sh
+++ b/bin/codex-local-pipeline.sh
@@ -159,12 +159,12 @@ yarn install --immutable
 
 fast_command="${FRONTEND_FAST_COMMAND:-yarn cichecks}"
 log "Running frontend verification: ${fast_command}"
-bash -lc "${fast_command}"
+bash -c "${fast_command}"
 
 if [[ "${mode}" == "full" ]]; then
   full_command="${FRONTEND_FULL_COMMAND:-yarn test:functional}"
   log "Running frontend full verification: ${full_command}"
-  bash -lc "${full_command}"
+  bash -c "${full_command}"
 fi
 
 log "Local pipeline completed"


### PR DESCRIPTION
### Jira link

N/A - Codex runner support fix.

### Change description

Fixes the Codex frontend runner preflight failure caused by `corepack enable` trying to create Yarn/PNPM shims under `/usr/bin` on the AKS ARC runner container.

The failed runner log showed:

```text
EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/bin/pnpm'
```

This change configures Corepack to install shims into a runner-writable temporary directory instead, then prepends that directory to `PATH`. The same helper is used by the Codex local pipeline so preflight and verification use consistent Yarn setup behaviour.

### Testing done

- Ran shell syntax validation:

```bash
bash -n .github/scripts/codex-runner-preflight.sh bin/codex-local-pipeline.sh
```

- Verified Corepack can enable Yarn using a temporary install directory without writing to `/usr/bin`:

```bash
tmp=$(mktemp -d)
RUNNER_TEMP="$tmp" bash -c 'set -euo pipefail; corepack_bin="${RUNNER_TEMP}/corepack-bin"; mkdir -p "$corepack_bin"; export PATH="$corepack_bin:$PATH"; corepack enable --install-directory "$corepack_bin"; command -v yarn; yarn --version'
rm -rf "$tmp"
```

Observed `yarn` resolving from the temp shim directory and reporting `4.10.3`.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
