### PR TITLE
Preserve frontend Codex verification command

### DIFF
--- a/.github/scripts/codex-jira-verify.sh
+++ b/.github/scripts/codex-jira-verify.sh
@@ -58,6 +58,8 @@ run_sanitized() {
     "CI=${CI:-true}" \
     "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}" \
     "COREPACK_HOME=${sanitized_home}/.cache/corepack" \
+    "FRONTEND_FAST_COMMAND=${FRONTEND_FAST_COMMAND:-}" \
+    "FRONTEND_FULL_COMMAND=${FRONTEND_FULL_COMMAND:-}" \
     "GIT_CONFIG_GLOBAL=/dev/null" \
     "GIT_CONFIG_NOSYSTEM=1" \
     "GIT_TERMINAL_PROMPT=0" \

--- a/.github/scripts/codex-pr-review-verify.sh
+++ b/.github/scripts/codex-pr-review-verify.sh
@@ -58,6 +58,8 @@ run_sanitized() {
     "CI=${CI:-true}" \
     "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}" \
     "COREPACK_HOME=${sanitized_home}/.cache/corepack" \
+    "FRONTEND_FAST_COMMAND=${FRONTEND_FAST_COMMAND:-}" \
+    "FRONTEND_FULL_COMMAND=${FRONTEND_FULL_COMMAND:-}" \
     "GIT_CONFIG_GLOBAL=/dev/null" \
     "GIT_CONFIG_NOSYSTEM=1" \
     "GIT_TERMINAL_PROMPT=0" \


### PR DESCRIPTION
### Jira link

Not applicable. This is a Codex workflow verification fix.

### Change description

Fixes the frontend Codex verification scripts so `FRONTEND_FAST_COMMAND` and `FRONTEND_FULL_COMMAND` survive the sanitized environment used to run the trusted local pipeline.

Without this, the workflow-level override `FRONTEND_FAST_COMMAND: yarn lint` is stripped by `env -i`, causing `bin/codex-local-pipeline.sh fast` to fall back to `yarn cichecks`. That unintentionally runs accessibility tests in the GitHub-hosted verification job, where Chromium cannot launch because no usable browser sandbox is available.

This keeps the security boundary intact: GitHub tokens and webhook secrets are still not passed into the branch-controlled verification process; only the intended command-selection environment variables are preserved.

### Testing done

- `bash -n .github/scripts/codex-jira-verify.sh .github/scripts/codex-pr-review-verify.sh`
- `git diff --check`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful
- [x] documentation has been updated (if needed)
- [x] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
