### PR TITLE
Fix Codex frontend Yarn install mode

### DIFF
--- a/.github/scripts/codex-jira-verify.sh
+++ b/.github/scripts/codex-jira-verify.sh
@@ -161,7 +161,7 @@ ensure_frontend_formatter() {
   fi
 
   echo "Installing frontend dependencies for pre-verification formatting."
-  run_sanitized node .yarn/releases/yarn-4.10.3.cjs install --immutable --mode=skip-builds
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs install --immutable --mode=skip-build
 }
 
 format_verified_patch() {

--- a/.github/scripts/codex-pr-review-verify.sh
+++ b/.github/scripts/codex-pr-review-verify.sh
@@ -161,7 +161,7 @@ ensure_frontend_formatter() {
   fi
 
   echo "Installing frontend dependencies for pre-verification formatting."
-  run_sanitized node .yarn/releases/yarn-4.10.3.cjs install --immutable --mode=skip-builds
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs install --immutable --mode=skip-build
 }
 
 format_verified_patch() {


### PR DESCRIPTION
### Jira link

Not applicable.

### Change description

Fixes the Codex frontend verification scripts to use Yarn 4's valid install mode `--mode=skip-build` instead of `--mode=skip-builds`.

The previous value caused Codex verification to fail before linting or publishing, which meant every repair attempt retried the same workflow-script error.

### Testing done

- `node .yarn/releases/yarn-4.10.3.cjs install --help | rg -n -- "skip-build|skip-builds|--mode"`
- `bash -n .github/scripts/codex-jira-verify.sh .github/scripts/codex-pr-review-verify.sh`
- `git diff --check`
- `rg -n "skip-builds" .github/scripts .github/workflows bin package.json || true`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
