### PR TITLE
Run frontend Codex cichecks before publishing

### DIFF
--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -93,7 +93,7 @@ jobs:
       EXPECTED_BRANCH_NAME: ${{ needs.codex-generate.outputs.branch_name }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-jira-output
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-0
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-0
@@ -240,7 +240,7 @@ jobs:
       EXPECTED_BRANCH_NAME: ${{ needs.codex-generate.outputs.branch_name }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-1
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-1
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-1
@@ -387,7 +387,7 @@ jobs:
       EXPECTED_BRANCH_NAME: ${{ needs.codex-generate.outputs.branch_name }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-2
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-2
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-2
@@ -534,7 +534,7 @@ jobs:
       EXPECTED_BRANCH_NAME: ${{ needs.codex-generate.outputs.branch_name }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-3
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-3
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-3

--- a/.github/workflows/codex_pr_review_feedback.yml
+++ b/.github/workflows/codex_pr_review_feedback.yml
@@ -193,7 +193,7 @@ jobs:
       EXPECTED_HEAD_REF: ${{ needs.detect-codex-pr.outputs.head_ref }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-review-output
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-0
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-0
@@ -337,7 +337,7 @@ jobs:
       EXPECTED_HEAD_REF: ${{ needs.detect-codex-pr.outputs.head_ref }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-1
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-1
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-1
@@ -481,7 +481,7 @@ jobs:
       EXPECTED_HEAD_REF: ${{ needs.detect-codex-pr.outputs.head_ref }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-2
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-2
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-2
@@ -625,7 +625,7 @@ jobs:
       EXPECTED_HEAD_REF: ${{ needs.detect-codex-pr.outputs.head_ref }}
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
-      FRONTEND_FAST_COMMAND: yarn lint
+      FRONTEND_FAST_COMMAND: yarn cichecks
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-3
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-3
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-3


### PR DESCRIPTION
### Jira link

Not applicable.

### Change description

Updates the frontend Codex Jira and PR review feedback verification jobs to run `yarn cichecks` instead of `yarn lint`.

This means Codex-generated frontend patches must pass the same local CI command used by the normal GitHub workflow before the trusted publish job opens or updates a PR. Unit test failures like the one seen on PR #1013 will now be caught during Codex verification and fed back into the repair loop.

### Testing done

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codex_jira_dispatch.yml"); YAML.load_file(".github/workflows/codex_pr_review_feedback.yml"); puts "workflow yaml ok"'`\n- `node .yarn/releases/yarn-4.10.3.cjs prettier --check .github/workflows/codex_jira_dispatch.yml .github/workflows/codex_pr_review_feedback.yml`\n- `git diff --check`\n\n### Security Vulnerability Assessment ###\n\n**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?\n  * [ ] Yes\n  * [x] No\n\n### Checklist\n\n- [x] commit messages are meaningful and follow good commit message guidelines\n- [x] README and other documentation has been updated / added (if needed)\n- [x] tests have been updated / new tests has been added (if needed)\n- [ ] Does this PR introduce a breaking change\n