### PR TITLE
Fix Codex PR setup workflow dispatch

### DIFF
--- a/.github/scripts/codex-jira-publish.sh
+++ b/.github/scripts/codex-jira-publish.sh
@@ -126,6 +126,22 @@ run_notify() {
     python3 -I "${trusted_notify_path}" "$@"
 }
 
+dispatch_pr_tasks() {
+  local pr_url="$1"
+  local pr_number
+
+  pr_number="$(gh_authenticated pr view "${pr_url}" --repo "${GITHUB_REPOSITORY}" --json number --jq '.number')"
+  if [[ -z "${pr_number}" ]]; then
+    echo "Unable to determine PR number for ${pr_url}" >&2
+    exit 1
+  fi
+
+  gh_authenticated workflow run on-pr.yml \
+    --repo "${GITHUB_REPOSITORY}" \
+    --ref "${default_branch}" \
+    -f "pr_number=${pr_number}"
+}
+
 mkdir -p "${sanitized_home}" "${sanitized_tmp}"
 
 cp .github/scripts/notify-jira-automation.py "${trusted_notify_path}"
@@ -192,6 +208,8 @@ if [[ -z "${pr_url}" ]]; then
       --body-file "${pr_body_path}"
   )"
 fi
+
+dispatch_pr_tasks "${pr_url}"
 
 commit_sha="$(git_local rev-parse HEAD)"
 run_notify \

--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -618,6 +618,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       issues: write

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -3,6 +3,12 @@ name: PR Tasks
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to configure
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -30,7 +36,7 @@ jobs:
 
       - name: Add redirect URIs for PR environment
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.number }}
           OBJECT_ID: ${{ secrets.APPREG_OBJECT_ID }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
### Jira link

N/A - Codex platform workflow fix.

### Change description

Allows the PR setup workflow to be run explicitly for Codex-created pull requests.

Codex currently opens PRs using the built-in `GITHUB_TOKEN`, which means GitHub suppresses normal `pull_request` workflow triggers. As a result, `.github/workflows/on-pr.yml` does not run automatically for Codex PRs and the PR redirect URI setup can be missed.

This change:

- adds a `workflow_dispatch` entry point to `on-pr.yml` with a `pr_number` input
- updates the Codex Jira publish script to dispatch `on-pr.yml` after creating or finding the PR
- grants the Codex publish job `actions: write` so it can trigger the setup workflow
- keeps the dispatched setup workflow running from `master`, with only the PR number passed as input

### Testing done

- `node .yarn/releases/yarn-4.10.3.cjs prettier --write .github/workflows/on-pr.yml .github/workflows/codex_jira_dispatch.yml`
- `bash -n .github/scripts/codex-jira-publish.sh`
- `git diff --check`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful
- [x] documentation has been updated (if needed)
- [x] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
