### PR TITLE
Add Codex merge conflict resolution workflow

### DIFF
--- a/.github/scripts/codex-merge-conflict-implement.sh
+++ b/.github/scripts/codex-merge-conflict-implement.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+required_env "GH_TOKEN"
+required_env "GITHUB_REPOSITORY"
+required_env "PR_NUMBER"
+required_env "HEAD_REF"
+required_env "BASE_REF"
+required_env "HEAD_SHA"
+required_env "BASE_SHA"
+required_env "CONFLICTED_FILES"
+required_env "OUTPUT_DIR"
+
+artifact_dir="${RUNNER_TEMP:-/tmp}/codex-conflict-generate-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
+output_dir="${OUTPUT_DIR}"
+pr_json_path="${artifact_dir}/pull-request.json"
+prompt_path="${artifact_dir}/codex-merge-conflict-prompt.md"
+conflicted_files_path="${output_dir}/conflicted-files.txt"
+final_message_path="${output_dir}/codex-final-message.md"
+comment_body_path="${output_dir}/codex-conflict-comment.md"
+patch_path="${output_dir}/changes.patch"
+metadata_path="${output_dir}/metadata.env"
+runner_home="${HOME:-/home/runner}"
+codex_home="${artifact_dir}/codex-home"
+codex_tmp="${artifact_dir}/codex-tmp"
+codex_runner_temp="${artifact_dir}/codex-runner-temp"
+sanitized_home="${artifact_dir}/sanitized-home"
+sanitized_tmp="${artifact_dir}/sanitized-tmp"
+
+prepare_codex_home() {
+  mkdir -p "${codex_home}/.codex" "${codex_home}/.cache" "${codex_home}/.config" "${codex_tmp}" "${codex_runner_temp}"
+
+  if [[ -f "${runner_home}/.codex/auth.json" ]]; then
+    cp "${runner_home}/.codex/auth.json" "${codex_home}/.codex/auth.json"
+    chmod 600 "${codex_home}/.codex/auth.json"
+  fi
+
+  if [[ -f "${runner_home}/.codex/config.toml" ]]; then
+    cp "${runner_home}/.codex/config.toml" "${codex_home}/.codex/config.toml"
+    chmod 600 "${codex_home}/.codex/config.toml"
+  fi
+}
+
+run_sanitized() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "RUNNER_TEMP=${RUNNER_TEMP:-/tmp}" \
+    "CI=${CI:-true}" \
+    "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}" \
+    "COREPACK_HOME=${sanitized_home}/.cache/corepack" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "$@"
+}
+
+run_codex() {
+  env -i \
+    "HOME=${codex_home}" \
+    "CODEX_HOME=${codex_home}/.codex" \
+    "XDG_CACHE_HOME=${codex_home}/.cache" \
+    "XDG_CONFIG_HOME=${codex_home}/.config" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${codex_tmp}" \
+    "RUNNER_TEMP=${codex_runner_temp}" \
+    "CI=${CI:-true}" \
+    "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "$@"
+}
+
+git_sanitized() {
+  run_sanitized git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+git_read_authenticated() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c credential.helper='!f() { test "$1" = get && echo username=x-access-token && echo "password=$GH_TOKEN"; }; f' \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+gh_read_authenticated() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    gh "$@"
+}
+
+read_conflicted_files() {
+  mapfile -t conflicted_files < <(printf '%s\n' "${CONFLICTED_FILES}" | sed '/^[[:space:]]*$/d' | sort -u)
+
+  if [[ "${#conflicted_files[@]}" -eq 0 ]]; then
+    echo "No conflicted files were provided." >&2
+    exit 1
+  fi
+
+  for path in "${conflicted_files[@]}"; do
+    if [[ "${path}" == /* || "${path}" == *..* || "${path}" == *$'\n'* || "${path}" == *$'\r'* ]]; then
+      echo "Unsafe conflicted file path: ${path}" >&2
+      exit 1
+    fi
+  done
+}
+
+write_prompt() {
+  PROMPT_PATH="${prompt_path}" PR_JSON_PATH="${pr_json_path}" CONFLICTED_FILES_PATH="${conflicted_files_path}" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+with open(os.environ["PR_JSON_PATH"], encoding="utf-8") as pr_file:
+    pull_request = json.load(pr_file)
+
+conflicted_files = Path(os.environ["CONFLICTED_FILES_PATH"]).read_text(encoding="utf-8").strip()
+
+prompt = f"""You are Codex running non-interactively in GitHub Actions on a self-hosted runner.
+
+Resolve the actual merge conflicts in this Angular/Node frontend pull request.
+
+Operational rules:
+- The working tree is already in a conflicted merge state.
+- Resolve only the merge conflicts between the PR branch and the base branch.
+- Do not make unrelated product changes, do not refactor unrelated code, and do not alter this automation.
+- Do not include secrets, tokens, credentials, PII, runner file contents, environment variables, or auth material in patches, PR bodies, comments, logs, or artifacts.
+- Preserve existing Angular, TypeScript, HMCTS design-system, test, route, accessibility, and formatting patterns.
+- Leave the working tree with no conflict markers and no unmerged files.
+- Do not push branches, open pull requests, or comment on GitHub. The workflow handles publishing in a separate trusted job.
+
+Pull request:
+- Number: {os.environ["PR_NUMBER"]}
+- URL: {pull_request["html_url"]}
+- Title: {pull_request["title"]}
+- Branch: {os.environ["HEAD_REF"]}
+- Base branch: {os.environ["BASE_REF"]}
+
+Conflicted files:
+{conflicted_files}
+"""
+
+Path(os.environ["PROMPT_PATH"]).write_text(prompt, encoding="utf-8")
+PY
+}
+
+mkdir -p "${artifact_dir}" "${sanitized_home}" "${sanitized_tmp}" "${output_dir}"
+prepare_codex_home
+read_conflicted_files
+printf '%s\n' "${conflicted_files[@]}" >"${conflicted_files_path}"
+
+gh_read_authenticated api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" >"${pr_json_path}"
+
+git_read_authenticated fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+git_read_authenticated fetch origin "${HEAD_REF}:refs/remotes/origin/${HEAD_REF}"
+
+actual_head_sha="$(git_sanitized rev-parse "refs/remotes/origin/${HEAD_REF}")"
+actual_base_sha="$(git_sanitized rev-parse "refs/remotes/origin/${BASE_REF}")"
+if [[ "${actual_head_sha}" != "${HEAD_SHA}" || "${actual_base_sha}" != "${BASE_SHA}" ]]; then
+  echo "PR branch or base branch moved after conflict detection; rerun /codex-resolve-conflicts." >&2
+  exit 1
+fi
+
+git_sanitized checkout -B "${HEAD_REF}" "refs/remotes/origin/${HEAD_REF}"
+
+set +e
+git_sanitized merge --no-commit --no-ff "refs/remotes/origin/${BASE_REF}"
+merge_status=$?
+set -e
+
+actual_conflicts="$(git_sanitized diff --name-only --diff-filter=U | sort -u)"
+if [[ "${merge_status}" -eq 0 || -z "${actual_conflicts}" ]]; then
+  echo "PR #${PR_NUMBER} no longer has merge conflicts with ${BASE_REF}." >&2
+  exit 1
+fi
+
+write_prompt
+unset GH_TOKEN
+
+echo "Running Codex merge-conflict resolution for PR #${PR_NUMBER} on ${HEAD_REF}"
+run_codex codex exec \
+  --cd "${PWD}" \
+  --sandbox workspace-write \
+  --ephemeral \
+  --output-last-message "${final_message_path}" \
+  - <"${prompt_path}"
+
+if [[ ! -s "${final_message_path}" ]]; then
+  echo "Codex completed without writing a final message." >"${final_message_path}"
+fi
+
+remaining_conflicts="$(git_sanitized diff --name-only --diff-filter=U | sort -u)"
+if [[ -n "${remaining_conflicts}" ]]; then
+  echo "Codex left unresolved merge conflicts:" >&2
+  printf '%s\n' "${remaining_conflicts}" >&2
+  exit 1
+fi
+
+if grep -R -n -E '^(<<<<<<<|=======|>>>>>>>)' -- "${conflicted_files[@]}" >/tmp/codex-conflict-markers.txt 2>/dev/null; then
+  echo "Conflict markers remain in resolved files:" >&2
+  cat /tmp/codex-conflict-markers.txt >&2
+  exit 1
+fi
+
+git_sanitized diff --binary HEAD -- "${conflicted_files[@]}" >"${patch_path}"
+if [[ ! -s "${patch_path}" ]]; then
+  echo "Codex did not produce a conflict-resolution patch." >&2
+  exit 1
+fi
+
+{
+  echo "Codex resolved merge conflicts for this PR."
+  echo
+  echo "Base branch: ${BASE_REF}"
+  echo
+  echo "Conflicted files resolved:"
+  sed 's/^/- /' "${conflicted_files_path}"
+  echo
+  echo "Codex final message:"
+  echo
+  sed -n '1,200p' "${final_message_path}"
+} >"${comment_body_path}"
+
+{
+  echo "has_changes=true"
+  echo "pr_number=${PR_NUMBER}"
+  echo "head_ref=${HEAD_REF}"
+  echo "base_ref=${BASE_REF}"
+  echo "head_sha=${HEAD_SHA}"
+  echo "base_sha=${BASE_SHA}"
+} >"${metadata_path}"

--- a/.github/scripts/codex-merge-conflict-implement.sh
+++ b/.github/scripts/codex-merge-conflict-implement.sh
@@ -172,6 +172,15 @@ Resolve the actual merge conflicts in this Angular/Node frontend pull request.
 Operational rules:
 - The working tree is already in a conflicted merge state.
 - Resolve only the merge conflicts between the PR branch and the base branch.
+- Resolve conflicts conservatively. Treat the base branch as the source of truth.
+- Prefer base branch behavior by default.
+- Re-apply PR branch changes only where they are clearly compatible with the base branch
+  and necessary for the PR's stated intent.
+- Do not introduce new behavior beyond what is necessary to resolve the conflict.
+- If a PR-side change cannot be safely reconciled, prefer the base branch and call this
+  out in your final message for human review.
+- For each conflicted file, briefly explain in your final message whether you chose the
+  base branch version, the PR branch version, or a combined resolution, and why.
 - Do not make unrelated product changes, do not refactor unrelated code, and do not alter this automation.
 - Do not include secrets, tokens, credentials, PII, runner file contents, environment variables, or auth material in patches, PR bodies, comments, logs, or artifacts.
 - Preserve existing Angular, TypeScript, HMCTS design-system, test, route, accessibility, and formatting patterns.

--- a/.github/scripts/codex-merge-conflict-publish.sh
+++ b/.github/scripts/codex-merge-conflict-publish.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+required_env "GH_TOKEN"
+required_env "GITHUB_REPOSITORY"
+required_env "OUTPUT_DIR"
+required_env "VERIFICATION_DIR"
+required_env "EXPECTED_PR_NUMBER"
+required_env "EXPECTED_HEAD_REF"
+required_env "EXPECTED_BASE_REF"
+required_env "EXPECTED_HEAD_SHA"
+required_env "EXPECTED_BASE_SHA"
+
+output_dir="${OUTPUT_DIR}"
+verification_dir="${VERIFICATION_DIR}"
+metadata_path="${output_dir}/metadata.env"
+conflicted_files_path="${output_dir}/conflicted-files.txt"
+final_message_path="${output_dir}/codex-final-message.md"
+verification_path="${verification_dir}/verification.env"
+patch_path="${verification_dir}/changes.patch"
+comment_body_path="${verification_dir}/codex-conflict-comment.md"
+sanitized_home="${RUNNER_TEMP:-/tmp}/codex-conflict-publish-home"
+sanitized_tmp="${RUNNER_TEMP:-/tmp}/codex-conflict-publish-tmp"
+
+metadata_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "${metadata_path}"
+}
+
+verification_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "${verification_path}"
+}
+
+file_sha256() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  else
+    shasum -a 256 "${path}" | awk '{print $1}'
+  fi
+}
+
+git_authenticated() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c credential.helper='!f() { test "$1" = get && echo username=x-access-token && echo "password=$GH_TOKEN"; }; f' \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+git_local() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+gh_authenticated() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    gh "$@"
+}
+
+read_conflicted_files() {
+  mapfile -t conflicted_files < <(sed '/^[[:space:]]*$/d' "${conflicted_files_path}" | sort -u)
+
+  if [[ "${#conflicted_files[@]}" -eq 0 ]]; then
+    echo "Missing conflicted files artifact." >&2
+    exit 1
+  fi
+
+  for path in "${conflicted_files[@]}"; do
+    if [[ "${path}" == /* || "${path}" == *..* || "${path}" == *$'\n'* || "${path}" == *$'\r'* ]]; then
+      echo "Unsafe conflicted file path: ${path}" >&2
+      exit 1
+    fi
+  done
+}
+
+restore_ours_for_patch() {
+  local path
+
+  for path in "${conflicted_files[@]}"; do
+    if git_local cat-file -e "HEAD:${path}" 2>/dev/null; then
+      git_local checkout --ours -- "${path}" 2>/dev/null || git_local restore --source=HEAD --worktree --staged -- "${path}"
+      git_local add -- "${path}"
+    else
+      git_local rm -f --ignore-unmatch -- "${path}" >/dev/null 2>&1 || true
+      rm -rf -- "${path}"
+    fi
+  done
+}
+
+mkdir -p "${sanitized_home}" "${sanitized_tmp}"
+
+has_changes="$(metadata_value has_changes)"
+pr_number="$(metadata_value pr_number)"
+head_ref="$(metadata_value head_ref)"
+base_ref="$(metadata_value base_ref)"
+head_sha="$(metadata_value head_sha)"
+base_sha="$(metadata_value base_sha)"
+verified_has_changes="$(verification_value has_changes)"
+verified_pr_number="$(verification_value pr_number)"
+verified_head_ref="$(verification_value head_ref)"
+verified_base_ref="$(verification_value base_ref)"
+verified_head_sha="$(verification_value head_sha)"
+verified_base_sha="$(verification_value base_sha)"
+
+if [[ "${has_changes}" != "true" || "${verified_has_changes}" != "true" ]]; then
+  echo "Refusing to publish missing conflict-resolution changes." >&2
+  exit 1
+fi
+
+if [[ "${pr_number}" != "${EXPECTED_PR_NUMBER}" || "${head_ref}" != "${EXPECTED_HEAD_REF}" || "${base_ref}" != "${EXPECTED_BASE_REF}" || "${head_sha}" != "${EXPECTED_HEAD_SHA}" || "${base_sha}" != "${EXPECTED_BASE_SHA}" ]]; then
+  echo "Refusing to publish unexpected conflict-resolution artifact metadata." >&2
+  exit 1
+fi
+
+if [[ "${verified_pr_number}" != "${pr_number}" || "${verified_head_ref}" != "${head_ref}" || "${verified_base_ref}" != "${base_ref}" || "${verified_head_sha}" != "${head_sha}" || "${verified_base_sha}" != "${base_sha}" ]]; then
+  echo "Refusing to publish unverified conflict-resolution artifact metadata." >&2
+  exit 1
+fi
+
+if [[ ! -s "${patch_path}" ]]; then
+  echo "Missing or empty verified conflict-resolution patch artifact: ${patch_path}" >&2
+  exit 1
+fi
+
+verified_patch_sha="$(verification_value patch_sha)"
+actual_patch_sha="$(file_sha256 "${patch_path}")"
+if [[ -z "${verified_patch_sha}" || "${actual_patch_sha}" != "${verified_patch_sha}" ]]; then
+  echo "Refusing to publish conflict-resolution patch because it does not match the verified patch hash." >&2
+  exit 1
+fi
+
+read_conflicted_files
+
+git_authenticated fetch origin "${base_ref}:refs/remotes/origin/${base_ref}"
+git_authenticated fetch origin "${head_ref}:refs/remotes/origin/${head_ref}"
+
+actual_head_sha="$(git_local rev-parse "refs/remotes/origin/${head_ref}")"
+actual_base_sha="$(git_local rev-parse "refs/remotes/origin/${base_ref}")"
+if [[ "${actual_head_sha}" != "${head_sha}" || "${actual_base_sha}" != "${base_sha}" ]]; then
+  gh_authenticated pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" --body "Codex conflict-resolution publishing stopped because the PR branch or \`${base_ref}\` moved after verification. Re-run \`/codex-resolve-conflicts\` to resolve the current conflicts."
+  echo "PR branch or base branch moved after verification; refusing to publish stale conflict resolution." >&2
+  exit 1
+fi
+
+git_authenticated checkout -B "${head_ref}" "refs/remotes/origin/${head_ref}"
+
+set +e
+git_local merge --no-commit --no-ff "refs/remotes/origin/${base_ref}"
+merge_status=$?
+set -e
+
+actual_conflicts="$(git_local diff --name-only --diff-filter=U | sort -u)"
+if [[ "${merge_status}" -eq 0 || -z "${actual_conflicts}" ]]; then
+  git_local merge --abort >/dev/null 2>&1 || true
+  gh_authenticated pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" --body "Codex conflict-resolution publishing stopped because this PR no longer has merge conflicts with \`${base_ref}\`."
+  echo "PR #${pr_number} no longer has conflicts with ${base_ref}; no commit pushed."
+  exit 0
+fi
+
+restore_ours_for_patch
+git_local apply --binary "${patch_path}"
+git_local add -A -- "${conflicted_files[@]}"
+
+remaining_conflicts="$(git_local diff --name-only --diff-filter=U | sort -u)"
+if [[ -n "${remaining_conflicts}" ]]; then
+  echo "Verified conflict-resolution patch left unresolved files:" >&2
+  printf '%s\n' "${remaining_conflicts}" >&2
+  exit 1
+fi
+
+git_authenticated \
+  -c user.name="github-actions[bot]" \
+  -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+  commit \
+  -m "Resolve merge conflicts for PR #${pr_number}" \
+  -m "Generated by Codex self-hosted runner."
+
+git_authenticated push origin "${head_ref}"
+commit_sha="$(git_local rev-parse HEAD)"
+
+{
+  echo "Codex resolved merge conflicts with \`${base_ref}\` and pushed an update."
+  echo
+  echo "Commit: ${commit_sha}"
+  echo
+  echo "Resolved files:"
+  sed 's/^/- /' "${conflicted_files_path}"
+  echo
+  echo "Codex final message:"
+  echo
+  sed -n '1,200p' "${final_message_path}"
+} >"${comment_body_path}"
+
+gh_authenticated pr comment "${pr_number}" --repo "${GITHUB_REPOSITORY}" --body-file "${comment_body_path}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "pr_number=${pr_number}"
+    echo "branch_name=${head_ref}"
+    echo "commit_sha=${commit_sha}"
+  } >>"${GITHUB_OUTPUT}"
+fi

--- a/.github/scripts/codex-merge-conflict-verify.sh
+++ b/.github/scripts/codex-merge-conflict-verify.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+required_env "OUTPUT_DIR"
+required_env "EXPECTED_PR_NUMBER"
+required_env "EXPECTED_HEAD_REF"
+required_env "EXPECTED_BASE_REF"
+required_env "EXPECTED_HEAD_SHA"
+required_env "EXPECTED_BASE_SHA"
+required_env "GH_TOKEN"
+
+output_dir="${OUTPUT_DIR}"
+metadata_path="${output_dir}/metadata.env"
+conflicted_files_path="${output_dir}/conflicted-files.txt"
+patch_path="${output_dir}/changes.patch"
+verification_path="${output_dir}/verification.env"
+artifact_dir="${RUNNER_TEMP:-/tmp}/codex-conflict-verify-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
+sanitized_home="${artifact_dir}/sanitized-home"
+sanitized_tmp="${artifact_dir}/sanitized-tmp"
+trusted_pipeline_path="${artifact_dir}/trusted-codex-local-pipeline.sh"
+trusted_pipeline_sha=""
+
+metadata_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "${metadata_path}"
+}
+
+run_sanitized() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "RUNNER_TEMP=${RUNNER_TEMP:-/tmp}" \
+    "CI=${CI:-true}" \
+    "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}" \
+    "COREPACK_HOME=${sanitized_home}/.cache/corepack" \
+    "FRONTEND_FAST_COMMAND=${FRONTEND_FAST_COMMAND:-}" \
+    "FRONTEND_FULL_COMMAND=${FRONTEND_FULL_COMMAND:-}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "$@"
+}
+
+git_sanitized() {
+  run_sanitized git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+git_read_authenticated() {
+  env -i \
+    "HOME=${sanitized_home}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "SHELL=${SHELL:-/bin/bash}" \
+    "USER=${USER:-runner}" \
+    "LOGNAME=${LOGNAME:-${USER:-runner}}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "TMPDIR=${sanitized_tmp}" \
+    "GIT_CONFIG_GLOBAL=/dev/null" \
+    "GIT_CONFIG_NOSYSTEM=1" \
+    "GIT_TERMINAL_PROMPT=0" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    git \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c credential.helper='!f() { test "$1" = get && echo username=x-access-token && echo "password=$GH_TOKEN"; }; f' \
+    -c protocol.file.allow=never \
+    "$@"
+}
+
+file_sha256() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  else
+    shasum -a 256 "${path}" | awk '{print $1}'
+  fi
+}
+
+verify_trusted_file() {
+  local path="$1"
+  local expected_sha="$2"
+  local label="$3"
+  local actual_sha
+
+  actual_sha="$(file_sha256 "${path}")"
+  if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+    echo "::error::Trusted ${label} changed after capture; refusing to execute it." >&2
+    exit 1
+  fi
+}
+
+read_conflicted_files() {
+  mapfile -t conflicted_files < <(sed '/^[[:space:]]*$/d' "${conflicted_files_path}" | sort -u)
+
+  if [[ "${#conflicted_files[@]}" -eq 0 ]]; then
+    echo "Missing conflicted files artifact." >&2
+    exit 1
+  fi
+
+  for path in "${conflicted_files[@]}"; do
+    if [[ "${path}" == /* || "${path}" == *..* || "${path}" == *$'\n'* || "${path}" == *$'\r'* ]]; then
+      echo "Unsafe conflicted file path: ${path}" >&2
+      exit 1
+    fi
+  done
+}
+
+restore_ours_for_patch() {
+  local path
+
+  for path in "${conflicted_files[@]}"; do
+    if git_sanitized cat-file -e "HEAD:${path}" 2>/dev/null; then
+      git_sanitized checkout --ours -- "${path}" 2>/dev/null || git_sanitized restore --source=HEAD --worktree --staged -- "${path}"
+      git_sanitized add -- "${path}"
+    else
+      git_sanitized rm -f --ignore-unmatch -- "${path}" >/dev/null 2>&1 || true
+      rm -rf -- "${path}"
+    fi
+  done
+}
+
+ensure_frontend_formatter() {
+  if [[ -x "node_modules/.bin/prettier" ]]; then
+    return
+  fi
+
+  echo "Installing frontend dependencies for pre-verification formatting."
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs install --immutable --mode=skip-build
+}
+
+format_conflicted_files() {
+  local existing_files=()
+  local path
+
+  for path in "${conflicted_files[@]}"; do
+    if [[ -f "${path}" ]]; then
+      existing_files+=("${path}")
+    fi
+  done
+
+  if [[ "${#existing_files[@]}" -eq 0 ]]; then
+    return
+  fi
+
+  ensure_frontend_formatter
+  echo "Applying Prettier before verifying and publishing the conflict-resolution patch."
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs prettier --write --ignore-unknown "${existing_files[@]}"
+  git_sanitized add -A -- "${conflicted_files[@]}"
+}
+
+mkdir -p "${artifact_dir}" "${sanitized_home}" "${sanitized_tmp}"
+
+has_changes="$(metadata_value has_changes)"
+pr_number="$(metadata_value pr_number)"
+head_ref="$(metadata_value head_ref)"
+base_ref="$(metadata_value base_ref)"
+head_sha="$(metadata_value head_sha)"
+base_sha="$(metadata_value base_sha)"
+
+if [[ "${has_changes}" != "true" || "${pr_number}" != "${EXPECTED_PR_NUMBER}" || "${head_ref}" != "${EXPECTED_HEAD_REF}" || "${base_ref}" != "${EXPECTED_BASE_REF}" || "${head_sha}" != "${EXPECTED_HEAD_SHA}" || "${base_sha}" != "${EXPECTED_BASE_SHA}" ]]; then
+  echo "Refusing to verify unexpected conflict-resolution artifact metadata." >&2
+  exit 1
+fi
+
+if [[ ! -s "${patch_path}" ]]; then
+  echo "Missing or empty conflict-resolution patch artifact: ${patch_path}" >&2
+  exit 1
+fi
+
+read_conflicted_files
+cp bin/codex-local-pipeline.sh "${trusted_pipeline_path}"
+chmod +x "${trusted_pipeline_path}"
+trusted_pipeline_sha="$(file_sha256 "${trusted_pipeline_path}")"
+
+git_read_authenticated fetch origin "${base_ref}:refs/remotes/origin/${base_ref}"
+git_read_authenticated fetch origin "${head_ref}:refs/remotes/origin/${head_ref}"
+unset GH_TOKEN
+
+actual_head_sha="$(git_sanitized rev-parse "refs/remotes/origin/${head_ref}")"
+actual_base_sha="$(git_sanitized rev-parse "refs/remotes/origin/${base_ref}")"
+if [[ "${actual_head_sha}" != "${head_sha}" || "${actual_base_sha}" != "${base_sha}" ]]; then
+  echo "PR branch or base branch moved after conflict generation; rerun /codex-resolve-conflicts." >&2
+  exit 1
+fi
+
+git_sanitized checkout -B "${head_ref}" "refs/remotes/origin/${head_ref}"
+
+set +e
+git_sanitized merge --no-commit --no-ff "refs/remotes/origin/${base_ref}"
+merge_status=$?
+set -e
+
+actual_conflicts="$(git_sanitized diff --name-only --diff-filter=U | sort -u)"
+if [[ "${merge_status}" -eq 0 || -z "${actual_conflicts}" ]]; then
+  echo "PR #${pr_number} no longer has merge conflicts with ${base_ref}." >&2
+  exit 1
+fi
+
+restore_ours_for_patch
+git_sanitized apply --binary "${patch_path}"
+git_sanitized add -A -- "${conflicted_files[@]}"
+
+remaining_conflicts="$(git_sanitized diff --name-only --diff-filter=U | sort -u)"
+if [[ -n "${remaining_conflicts}" ]]; then
+  echo "Conflict-resolution patch left unresolved files:" >&2
+  printf '%s\n' "${remaining_conflicts}" >&2
+  exit 1
+fi
+
+format_conflicted_files
+
+if grep -R -n -E '^(<<<<<<<|=======|>>>>>>>)' -- "${conflicted_files[@]}" >/tmp/codex-conflict-markers.txt 2>/dev/null; then
+  echo "Conflict markers remain in resolved files:" >&2
+  cat /tmp/codex-conflict-markers.txt >&2
+  exit 1
+fi
+
+git_sanitized diff --binary HEAD -- "${conflicted_files[@]}" >"${patch_path}"
+patch_sha="$(file_sha256 "${patch_path}")"
+
+local_pipeline_mode="${LOCAL_PIPELINE_MODE:-fast}"
+verify_trusted_file "${trusted_pipeline_path}" "${trusted_pipeline_sha}" "pipeline wrapper"
+run_sanitized "${trusted_pipeline_path}" "${local_pipeline_mode}" --base "${base_ref}" --no-fetch
+
+{
+  echo "has_changes=true"
+  echo "pr_number=${pr_number}"
+  echo "head_ref=${head_ref}"
+  echo "base_ref=${base_ref}"
+  echo "head_sha=${head_sha}"
+  echo "base_sha=${base_sha}"
+  echo "patch_sha=${patch_sha}"
+} >"${verification_path}"

--- a/.github/workflows/codex_merge_conflict_resolution.yml
+++ b/.github/workflows/codex_merge_conflict_resolution.yml
@@ -1,0 +1,363 @@
+name: Codex Merge Conflict Resolution
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  detect-conflicted-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+      pr_number: ${{ steps.detect.outputs.pr_number }}
+      head_ref: ${{ steps.detect.outputs.head_ref }}
+      base_ref: ${{ steps.detect.outputs.base_ref }}
+      head_sha: ${{ steps.detect.outputs.head_sha }}
+      base_sha: ${{ steps.detect.outputs.base_sha }}
+      conflicted_files: ${{ steps.detect.outputs.conflicted_files }}
+    steps:
+      - name: Detect authorised conflicted PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          pr_number=""
+          head_ref=""
+          base_ref="${DEFAULT_BRANCH}"
+
+          write_skip() {
+            local reason="$1"
+            echo "Skipping Codex merge-conflict resolution: ${reason}"
+            {
+              echo "should_run=false"
+              echo "pr_number=${pr_number}"
+              echo "head_ref=${head_ref}"
+              echo "base_ref=${base_ref}"
+            } >>"$GITHUB_OUTPUT"
+          }
+
+          comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+          actor_login="$(jq -r '.comment.user.login // ""' "$GITHUB_EVENT_PATH")"
+          is_pr="$(jq -r '.issue | has("pull_request")' "$GITHUB_EVENT_PATH")"
+
+          if [[ "$is_pr" != "true" ]]; then
+            write_skip "comment is not on a pull request"
+            exit 0
+          fi
+
+          if ! grep -Eiq '(^|[[:space:]])/(codex-resolve-conflicts|codex resolve conflicts)([[:space:]]|$)' <<<"$comment_body"; then
+            write_skip "missing explicit /codex-resolve-conflicts command"
+            exit 0
+          fi
+
+          pr_number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+
+          if [[ -z "$actor_login" || "$actor_login" == "null" ]]; then
+            write_skip "comment author could not be determined"
+            exit 0
+          fi
+
+          case "$actor_login" in
+            github-actions[bot]|app/github-actions)
+              write_skip "ignoring GitHub Actions bot comment"
+              exit 0
+              ;;
+          esac
+
+          actor_permission="$(
+            gh api "repos/${GITHUB_REPOSITORY}/collaborators/${actor_login}/permission" \
+              --jq '.permission' 2>/dev/null || true
+          )"
+
+          case "$actor_permission" in
+            write|maintain|admin)
+              ;;
+            *)
+              write_skip "actor ${actor_login} does not have repository write permission"
+              exit 0
+              ;;
+          esac
+
+          pull_request_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
+          pr_state="$(jq -r '.state' <<<"$pull_request_json")"
+          head_ref="$(jq -r '.head.ref' <<<"$pull_request_json")"
+          head_repo="$(jq -r '.head.repo.full_name' <<<"$pull_request_json")"
+          pr_base_ref="$(jq -r '.base.ref' <<<"$pull_request_json")"
+
+          if [[ "$pr_state" != "open" ]]; then
+            write_skip "PR #${pr_number} is not open"
+            exit 0
+          fi
+
+          if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+            write_skip "forked PR branches are not supported"
+            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR branch is from a fork. Only branches in this repository are supported."
+            exit 0
+          fi
+
+          if [[ "$pr_base_ref" != "$DEFAULT_BRANCH" ]]; then
+            write_skip "PR base is ${pr_base_ref}, not ${DEFAULT_BRANCH}"
+            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR targets \`${pr_base_ref}\`, not \`${DEFAULT_BRANCH}\`."
+            exit 0
+          fi
+
+          if [[ "$head_ref" == -* || "$head_ref" == *..* || "$head_ref" == *$'\n'* || "$head_ref" == *$'\r'* ]]; then
+            write_skip "unsafe PR branch name"
+            exit 0
+          fi
+
+          work_dir="$(mktemp -d)"
+          cleanup() {
+            rm -rf "$work_dir"
+          }
+          trap cleanup EXIT
+
+          cd "$work_dir"
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -c credential.helper= \
+            -c credential.helper='!f() { test "$1" = get && echo username=x-access-token && echo "password=$GH_TOKEN"; }; f' \
+            fetch --no-tags --prune origin \
+            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}" \
+            "refs/heads/${head_ref}:refs/remotes/origin/pr-head"
+          git checkout --quiet -B pr-head refs/remotes/origin/pr-head
+
+          set +e
+          git merge --no-commit --no-ff "refs/remotes/origin/${DEFAULT_BRANCH}" >/tmp/codex-merge-check.log 2>&1
+          merge_status=$?
+          set -e
+
+          conflicted_files="$(git diff --name-only --diff-filter=U | sort -u)"
+          if [[ "$merge_status" -eq 0 || -z "$conflicted_files" ]]; then
+            git merge --abort >/dev/null 2>&1 || true
+            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR does not currently have merge conflicts with \`${DEFAULT_BRANCH}\`."
+            write_skip "PR #${pr_number} has no actual merge conflicts with ${DEFAULT_BRANCH}"
+            exit 0
+          fi
+
+          head_sha="$(git rev-parse refs/remotes/origin/pr-head)"
+          base_sha="$(git rev-parse "refs/remotes/origin/${DEFAULT_BRANCH}")"
+
+          {
+            echo "should_run=true"
+            echo "pr_number=${pr_number}"
+            echo "head_ref=${head_ref}"
+            echo "base_ref=${DEFAULT_BRANCH}"
+            echo "head_sha=${head_sha}"
+            echo "base_sha=${base_sha}"
+            echo "conflicted_files<<EOF"
+            printf '%s\n' "$conflicted_files"
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
+
+  codex-conflict-generate:
+    needs: detect-conflicted-pr
+    if: needs.detect-conflicted-pr.outputs.should_run == 'true'
+    runs-on: codex-frontend-azure-aks
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ needs.detect-conflicted-pr.outputs.pr_number }}
+      HEAD_REF: ${{ needs.detect-conflicted-pr.outputs.head_ref }}
+      BASE_REF: ${{ needs.detect-conflicted-pr.outputs.base_ref }}
+      HEAD_SHA: ${{ needs.detect-conflicted-pr.outputs.head_sha }}
+      BASE_SHA: ${{ needs.detect-conflicted-pr.outputs.base_sha }}
+      CONFLICTED_FILES: ${{ needs.detect-conflicted-pr.outputs.conflicted_files }}
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify runner toolchain and Codex auth
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: ./.github/scripts/codex-runner-preflight.sh
+
+      - name: Run Codex and create conflict-resolution patch
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/codex-conflict-output
+        run: ./.github/scripts/codex-merge-conflict-implement.sh
+
+      - name: Upload Codex conflict-resolution output
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-conflict-output
+          path: ${{ runner.temp }}/codex-conflict-output
+          if-no-files-found: error
+          retention-days: 1
+
+  verify-conflict-resolution:
+    needs: [detect-conflicted-pr, codex-conflict-generate]
+    if: needs.detect-conflicted-pr.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      passed: ${{ steps.verify.outputs.passed }}
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      GH_TOKEN: ${{ github.token }}
+      EXPECTED_PR_NUMBER: ${{ needs.detect-conflicted-pr.outputs.pr_number }}
+      EXPECTED_HEAD_REF: ${{ needs.detect-conflicted-pr.outputs.head_ref }}
+      EXPECTED_BASE_REF: ${{ needs.detect-conflicted-pr.outputs.base_ref }}
+      EXPECTED_HEAD_SHA: ${{ needs.detect-conflicted-pr.outputs.head_sha }}
+      EXPECTED_BASE_SHA: ${{ needs.detect-conflicted-pr.outputs.base_sha }}
+      LOCAL_PIPELINE_MODE: fast
+      FRONTEND_FAST_COMMAND: yarn cichecks
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download Codex conflict-resolution output
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-conflict-output
+          path: ${{ runner.temp }}/codex-conflict-output
+
+      - name: Verify Codex conflict-resolution patch
+        id: verify
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/codex-conflict-output
+        run: |
+          set +e
+          ./.github/scripts/codex-merge-conflict-verify.sh >"$RUNNER_TEMP/codex-conflict-verification.log" 2>&1
+          status=$?
+          cat "$RUNNER_TEMP/codex-conflict-verification.log"
+          if [[ "${status}" -eq 0 ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Upload verified conflict-resolution output
+        if: steps.verify.outputs.passed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-conflict-verified
+          path: |
+            ${{ runner.temp }}/codex-conflict-output/changes.patch
+            ${{ runner.temp }}/codex-conflict-output/codex-conflict-comment.md
+            ${{ runner.temp }}/codex-conflict-output/verification.env
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-conflict-resolution:
+    needs: [detect-conflicted-pr, verify-conflict-resolution]
+    if: needs.detect-conflicted-pr.outputs.should_run == 'true' && needs.verify-conflict-resolution.outputs.passed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      GH_TOKEN: ${{ github.token }}
+      EXPECTED_PR_NUMBER: ${{ needs.detect-conflicted-pr.outputs.pr_number }}
+      EXPECTED_HEAD_REF: ${{ needs.detect-conflicted-pr.outputs.head_ref }}
+      EXPECTED_BASE_REF: ${{ needs.detect-conflicted-pr.outputs.base_ref }}
+      EXPECTED_HEAD_SHA: ${{ needs.detect-conflicted-pr.outputs.head_sha }}
+      EXPECTED_BASE_SHA: ${{ needs.detect-conflicted-pr.outputs.base_sha }}
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download Codex conflict-resolution output
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-conflict-output
+          path: ${{ runner.temp }}/codex-conflict-output
+
+      - name: Download verified conflict-resolution output
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-conflict-verified
+          path: ${{ runner.temp }}/codex-conflict-verified
+
+      - name: Copy trusted publish script
+        run: |
+          cp .github/scripts/codex-merge-conflict-publish.sh "$RUNNER_TEMP/codex-merge-conflict-publish.sh"
+          chmod +x "$RUNNER_TEMP/codex-merge-conflict-publish.sh"
+
+      - name: Publish conflict-resolution commit
+        id: publish
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/codex-conflict-output
+          VERIFICATION_DIR: ${{ runner.temp }}/codex-conflict-verified
+        run: '$RUNNER_TEMP/codex-merge-conflict-publish.sh'
+
+      - name: Write workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Codex Merge Conflict Resolution"
+            echo
+            echo "- Pull request: #${{ steps.publish.outputs.pr_number }}"
+            echo "- Branch: ${{ steps.publish.outputs.branch_name }}"
+            echo "- Commit: ${{ steps.publish.outputs.commit_sha }}"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+  conflict-resolution-failed:
+    needs:
+      - detect-conflicted-pr
+      - codex-conflict-generate
+      - verify-conflict-resolution
+      - publish-conflict-resolution
+    if: |
+      always() &&
+      needs.detect-conflicted-pr.outputs.should_run == 'true' &&
+      (
+        needs.codex-conflict-generate.result == 'failure' ||
+        needs.verify-conflict-resolution.outputs.passed != 'true' ||
+        needs.publish-conflict-resolution.result == 'failure'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ needs.detect-conflicted-pr.outputs.pr_number }}
+    steps:
+      - name: Comment with failure result
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Codex attempted to resolve merge conflicts for this PR, but the workflow failed before a verified resolution could be pushed. See ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."

--- a/.github/workflows/codex_merge_conflict_resolution.yml
+++ b/.github/workflows/codex_merge_conflict_resolution.yml
@@ -48,6 +48,14 @@ jobs:
             } >>"$GITHUB_OUTPUT"
           }
 
+          post_pr_comment() {
+            local body="$1"
+
+            if ! gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "$body"; then
+              echo "::warning::Failed to add PR comment; continuing without blocking detection."
+            fi
+          }
+
           comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
           actor_login="$(jq -r '.comment.user.login // ""' "$GITHUB_EVENT_PATH")"
           is_pr="$(jq -r '.issue | has("pull_request")' "$GITHUB_EVENT_PATH")"
@@ -103,13 +111,13 @@ jobs:
 
           if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
             write_skip "forked PR branches are not supported"
-            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR branch is from a fork. Only branches in this repository are supported."
+            post_pr_comment "Codex merge-conflict resolution was not started because this PR branch is from a fork. Only branches in this repository are supported."
             exit 0
           fi
 
           if [[ "$pr_base_ref" != "$DEFAULT_BRANCH" ]]; then
             write_skip "PR base is ${pr_base_ref}, not ${DEFAULT_BRANCH}"
-            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR targets \`${pr_base_ref}\`, not \`${DEFAULT_BRANCH}\`."
+            post_pr_comment "Codex merge-conflict resolution was not started because this PR targets \`${pr_base_ref}\`, not \`${DEFAULT_BRANCH}\`."
             exit 0
           fi
 
@@ -139,10 +147,25 @@ jobs:
           merge_status=$?
           set -e
 
-          conflicted_files="$(git diff --name-only --diff-filter=U | sort -u)"
+          echo "Merge status: ${merge_status}"
+          echo "Merge check output:"
+          sed -n '1,160p' /tmp/codex-merge-check.log
+
+          conflicted_files="$(git diff --name-only --diff-filter=U --relative | sort -u)"
+          if [[ -z "$conflicted_files" ]]; then
+            conflicted_files="$(git ls-files -u | awk '{print $4}' | sort -u)"
+          fi
+
+          echo "Conflicted files:"
+          if [[ -n "$conflicted_files" ]]; then
+            printf '%s\n' "$conflicted_files"
+          else
+            echo "(none)"
+          fi
+
           if [[ "$merge_status" -eq 0 || -z "$conflicted_files" ]]; then
             git merge --abort >/dev/null 2>&1 || true
-            gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" --body "Codex merge-conflict resolution was not started because this PR does not currently have merge conflicts with \`${DEFAULT_BRANCH}\`."
+            post_pr_comment "Codex merge-conflict resolution was not started because this PR does not currently have merge conflicts with \`${DEFAULT_BRANCH}\`."
             write_skip "PR #${pr_number} has no actual merge conflicts with ${DEFAULT_BRANCH}"
             exit 0
           fi

--- a/.github/workflows/codex_merge_conflict_resolution.yml
+++ b/.github/workflows/codex_merge_conflict_resolution.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
           case "$actor_login" in
-            github-actions[bot]|app/github-actions)
+            github-actions\[bot\]|app/github-actions)
               write_skip "ignoring GitHub Actions bot comment"
               exit 0
               ;;

--- a/.github/workflows/codex_pr_review_feedback.yml
+++ b/.github/workflows/codex_pr_review_feedback.yml
@@ -109,7 +109,7 @@ jobs:
           fi
 
           case "$actor_login" in
-            github-actions[bot]|app/github-actions)
+            github-actions\[bot\]|app/github-actions)
               write_skip "ignoring GitHub Actions bot comment"
               exit 0
               ;;


### PR DESCRIPTION
### Jira link

See [JAC-301](https://justice-ai-coe.atlassian.net/browse/JAC-301)

### Change description

Adds a `/codex-resolve-conflicts` PR comment workflow for Apps Reg frontend pull requests.

The workflow allows an authorised repository developer to ask Codex to resolve merge conflicts on an open PR. Before Codex is invoked, the workflow verifies that:

- the comment is on a PR
- the comment contains `/codex-resolve-conflicts`
- the commenter has `write`, `maintain`, or `admin` repository permission
- the PR branch is in this repository, not a fork
- the PR targets `master`
- the PR has actual merge conflicts with `master`

If those checks pass, Codex resolves the conflicted files in a no-write runner job. A separate no-write verification job applies the generated conflict-resolution patch, runs Prettier on the resolved files, and runs the local frontend verification pipeline using `yarn cichecks`. A trusted publish job then recreates the merge, applies the verified patch, pushes the merge-conflict resolution commit, and comments on the PR.

The workflow pins the detected PR branch SHA and base branch SHA so stale conflict-resolution artifacts are refused if either branch moves before verification or publish.

### Testing done

- `node .yarn/releases/yarn-4.10.3.cjs prettier --write .github/workflows/codex_merge_conflict_resolution.yml`
- `bash -n .github/scripts/codex-merge-conflict-implement.sh .github/scripts/codex-merge-conflict-verify.sh .github/scripts/codex-merge-conflict-publish.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codex_merge_conflict_resolution.yml"); puts "workflow yaml ok"'`
- `git diff --cached --check`
- `./bin/codex-local-pipeline.sh checks-only --no-fetch`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful
- [x] documentation has been updated (if needed)
- [x] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
