### PR TITLE
Capture Codex usage metrics

### DIFF
--- a/.github/scripts/codex-jira-implement.sh
+++ b/.github/scripts/codex-jira-implement.sh
@@ -32,6 +32,12 @@ final_message_path="${output_dir}/codex-final-message.md"
 pr_body_path="${output_dir}/codex-pr-body.md"
 patch_path="${output_dir}/changes.patch"
 metadata_path="${output_dir}/metadata.env"
+usage_events_path="${artifact_dir}/codex-events.jsonl"
+usage_summary_path="${output_dir}/codex-usage-summary.json"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=.github/scripts/codex-usage-metrics.sh
+source "${script_dir}/codex-usage-metrics.sh"
 
 prepare_codex_home() {
   mkdir -p "${codex_home}/.codex" "${codex_home}/.cache" "${codex_home}/.config" "${codex_tmp}" "${codex_runner_temp}"
@@ -183,7 +189,9 @@ Path(os.environ["PR_BODY_PATH"]).write_text(pr_body, encoding="utf-8")
 PY
 
 echo "Running Codex for ${ISSUE_KEY}; publish will use ${branch_name}"
-run_codex codex exec \
+run_codex_exec_with_usage "jira-generate" "${usage_events_path}" "${usage_summary_path}" \
+  run_codex codex exec \
+  --json \
   --cd "${PWD}" \
   --sandbox workspace-write \
   --ephemeral \

--- a/.github/scripts/codex-jira-repair.sh
+++ b/.github/scripts/codex-jira-repair.sh
@@ -42,6 +42,12 @@ final_message_path="${output_dir}/codex-repair-${REPAIR_ATTEMPT}-final-message.m
 pr_body_path="${output_dir}/codex-pr-body.md"
 patch_path="${output_dir}/changes.patch"
 metadata_path="${output_dir}/metadata.env"
+usage_events_path="${artifact_dir}/codex-events.jsonl"
+usage_summary_path="${output_dir}/codex-usage-summary.json"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=.github/scripts/codex-usage-metrics.sh
+source "${script_dir}/codex-usage-metrics.sh"
 
 metadata_value() {
   local key="$1"
@@ -183,7 +189,9 @@ Path(os.environ["PROMPT_PATH"]).write_text(prompt, encoding="utf-8")
 PY
 
 echo "Running Codex repair attempt ${REPAIR_ATTEMPT} for ${ISSUE_KEY}; publish will use ${branch_name}"
-run_codex codex exec \
+run_codex_exec_with_usage "jira-repair-${REPAIR_ATTEMPT}" "${usage_events_path}" "${usage_summary_path}" \
+  run_codex codex exec \
+  --json \
   --cd "${PWD}" \
   --sandbox workspace-write \
   --ephemeral \

--- a/.github/scripts/codex-pr-review-feedback.sh
+++ b/.github/scripts/codex-pr-review-feedback.sh
@@ -40,6 +40,12 @@ sanitized_home="${artifact_dir}/sanitized-home"
 sanitized_tmp="${artifact_dir}/sanitized-tmp"
 guardrail_changes_path="${output_dir}/guardrail-changes.txt"
 guardrail_review_required="false"
+usage_events_path="${artifact_dir}/codex-events.jsonl"
+usage_summary_path="${output_dir}/codex-usage-summary.json"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=.github/scripts/codex-usage-metrics.sh
+source "${script_dir}/codex-usage-metrics.sh"
 guardrail_pathspecs=(
   "bin/codex-local-pipeline.sh"
   ".github/scripts"
@@ -435,7 +441,9 @@ trusted_pipeline_sha="$(file_sha256 "${trusted_pipeline_path}")"
 unset GH_TOKEN
 
 echo "Running Codex review feedback for PR #${PR_NUMBER} on ${HEAD_REF}"
-run_codex codex exec \
+run_codex_exec_with_usage "pr-review-feedback" "${usage_events_path}" "${usage_summary_path}" \
+  run_codex codex exec \
+  --json \
   --cd "${PWD}" \
   --sandbox workspace-write \
   --ephemeral \

--- a/.github/scripts/codex-pr-review-repair.sh
+++ b/.github/scripts/codex-pr-review-repair.sh
@@ -40,6 +40,12 @@ final_message_path="${output_dir}/codex-final-message.md"
 comment_body_path="${output_dir}/codex-review-comment.md"
 patch_path="${output_dir}/changes.patch"
 metadata_path="${output_dir}/metadata.env"
+usage_events_path="${artifact_dir}/codex-events.jsonl"
+usage_summary_path="${output_dir}/codex-usage-summary.json"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=.github/scripts/codex-usage-metrics.sh
+source "${script_dir}/codex-usage-metrics.sh"
 
 metadata_value() {
   local key="$1"
@@ -225,7 +231,9 @@ Path(os.environ["PROMPT_PATH"]).write_text(prompt, encoding="utf-8")
 PY
 
 echo "Running Codex review repair attempt ${REPAIR_ATTEMPT} for PR #${pr_number} on ${head_ref}"
-run_codex codex exec \
+run_codex_exec_with_usage "pr-review-repair-${REPAIR_ATTEMPT}" "${usage_events_path}" "${usage_summary_path}" \
+  run_codex codex exec \
+  --json \
   --cd "${PWD}" \
   --sandbox workspace-write \
   --ephemeral \

--- a/.github/scripts/codex-usage-metrics.sh
+++ b/.github/scripts/codex-usage-metrics.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+write_codex_usage_summary() {
+  local events_path="$1"
+  local summary_path="$2"
+  local invocation="$3"
+  local exit_status="$4"
+
+  CODEX_EVENTS_PATH="${events_path}" \
+    CODEX_USAGE_SUMMARY_PATH="${summary_path}" \
+    CODEX_INVOCATION="${invocation}" \
+    CODEX_EXIT_STATUS="${exit_status}" \
+    python3 -I - <<'PY'
+import json
+import os
+from pathlib import Path
+
+events_path = Path(os.environ["CODEX_EVENTS_PATH"])
+summary_path = Path(os.environ["CODEX_USAGE_SUMMARY_PATH"])
+
+token_keys = {
+    "input_tokens",
+    "output_tokens",
+    "cached_input_tokens",
+    "cached_output_tokens",
+    "reasoning_tokens",
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "cached_tokens",
+}
+
+aliases = {
+    "prompt_tokens": "input_tokens",
+    "completion_tokens": "output_tokens",
+    "cached_tokens": "cached_input_tokens",
+}
+
+event_count = 0
+invalid_json_lines = 0
+usage_objects = []
+observed_token_fields = {}
+
+
+def normalize_key(key):
+    return aliases.get(key, key)
+
+
+def walk(value, path=""):
+    global observed_token_fields
+
+    if isinstance(value, dict):
+        usage = {}
+        for key, item in value.items():
+            child_path = f"{path}.{key}" if path else key
+            if key in token_keys and isinstance(item, (int, float)) and not isinstance(item, bool):
+                normalized_key = normalize_key(key)
+                usage[normalized_key] = int(item)
+                observed_token_fields[child_path] = int(item)
+            walk(item, child_path)
+
+        if usage:
+            usage_objects.append(usage)
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            walk(item, f"{path}[{index}]")
+
+
+if events_path.exists():
+    with events_path.open(encoding="utf-8", errors="replace") as events:
+        for line in events:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_json_lines += 1
+                continue
+            event_count += 1
+            walk(event)
+
+max_usage = {}
+for usage in usage_objects:
+    for key, value in usage.items():
+        max_usage[key] = max(max_usage.get(key, 0), value)
+
+last_usage = usage_objects[-1] if usage_objects else {}
+preferred_usage = last_usage or max_usage
+
+summary = {
+    "schemaVersion": 1,
+    "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+    "runId": os.environ.get("GITHUB_RUN_ID", ""),
+    "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+    "invocation": os.environ.get("CODEX_INVOCATION", ""),
+    "issueKey": os.environ.get("ISSUE_KEY", ""),
+    "prNumber": os.environ.get("PR_NUMBER", ""),
+    "codexExitStatus": int(os.environ.get("CODEX_EXIT_STATUS", "0")),
+    "usageAvailable": bool(preferred_usage),
+    "usage": preferred_usage,
+    "maxObservedUsage": max_usage,
+    "usageEventCount": len(usage_objects),
+    "jsonEventCount": event_count,
+    "invalidJsonLineCount": invalid_json_lines,
+    "observedTokenFields": observed_token_fields,
+    "note": (
+        "Usage is parsed from `codex exec --json` events. If usageAvailable is false, "
+        "this Codex CLI/auth mode did not emit token usage in the JSON event stream."
+    ),
+}
+
+summary_path.parent.mkdir(parents=True, exist_ok=True)
+summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+PY
+}
+
+run_codex_exec_with_usage() {
+  local invocation="$1"
+  local events_path="$2"
+  local summary_path="$3"
+  shift 3
+
+  set +e
+  "$@" 2>&1 | tee "${events_path}"
+  local codex_status="${PIPESTATUS[0]}"
+  set -e
+
+  write_codex_usage_summary "${events_path}" "${summary_path}" "${invocation}" "${codex_status}"
+  rm -f "${events_path}"
+
+  return "${codex_status}"
+}


### PR DESCRIPTION
### Jira link

Not applicable.

### Change description

Adds Codex usage metric capture for the autonomous developer workflows.

The Codex generation, repair, PR review feedback, and PR review repair scripts now run `codex exec --json`, parse the JSON event stream, and write a derived `codex-usage-summary.json` file into the existing workflow output artifact. The raw Codex JSON event stream stays in runner temp storage and is deleted after parsing so Jira prompt content and tool output are not uploaded as artifacts.

If the Codex CLI/auth mode emits usage data, the summary records input, output, cached, reasoning, and total token counts. If it does not emit usage data, the artifact records `usageAvailable: false` so this can be tracked explicitly per run.

### Testing done

- `bash -n` against the changed Codex scripts
- `git diff --check`
- Synthetic parser smoke test for `codex-usage-summary.json` generation

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
