### PR TITLE
ARCPOC-631 BULK UPDATE ALE - Officials

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -118,6 +118,20 @@ export const routes: Routes = [
           ),
       },
       {
+        path: ':id/update-officials',
+        loadComponent: () =>
+          import('@components/applications-list-detail/update-officials/update-officials.component').then(
+            (m) => m.UpdateOfficialsComponent,
+          ),
+      },
+      {
+        path: ':id/update-officials/confirm',
+        loadComponent: () =>
+          import('@components/applications-list-detail/update-officials/confirm/update-officials-confirm.component').then(
+            (m) => m.UpdateOfficialsConfirmComponent,
+          ),
+      },
+      {
         path: ':id/move',
         loadComponent: () =>
           import('@components/applications-list-detail/applications-list-entry-move/applications-list-entry-move.component').then(

--- a/src/app/core/components/review-confirm/review-confirm.component.html
+++ b/src/app/core/components/review-confirm/review-confirm.component.html
@@ -20,7 +20,7 @@
             <button
               class="govuk-button"
               [class.govuk-button--warning]="isRedButton()"
-              [disabled]="isConfirmed()"
+              [disabled]="buttonDisabled()"
               (click)="onConfirm()"
             >
               {{ confirmButtonTxt() }}

--- a/src/app/core/components/review-confirm/review-confirm.component.ts
+++ b/src/app/core/components/review-confirm/review-confirm.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  computed,
   inject,
   input,
   output,
@@ -22,11 +23,13 @@ export class ReviewConfirmComponent implements OnInit, OnDestroy {
   confirmButtonTxt = input<string>('Continue');
   cancelButtonTxt = input<string>('Cancel');
   isRedButton = input<boolean>(true);
+  disabled = input<boolean | null>(null);
 
   confirm = output<void>();
   cancelled = output<void>();
 
   isConfirmed = signal(false);
+  buttonDisabled = computed(() => this.disabled() ?? this.isConfirmed());
 
   headerService = inject(HeaderService);
 
@@ -39,7 +42,14 @@ export class ReviewConfirmComponent implements OnInit, OnDestroy {
   }
 
   onConfirm(): void {
-    this.isConfirmed.set(true);
+    if (this.buttonDisabled()) {
+      return;
+    }
+
+    if (this.disabled() === null) {
+      this.isConfirmed.set(true);
+    }
+
     this.confirm.emit();
   }
 

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -45,6 +45,13 @@
   />
 }
 
+@if (vm().updateOfficialsDone) {
+  <app-success-banner
+    heading="Officials updated"
+    linkText="The officials have been successfully updated"
+  />
+}
+
 @if (vm().bulkUploadFeedback?.kind === 'progress') {
   <app-async-job-progress
     [heading]="vm().bulkUploadFeedback?.heading ?? ''"
@@ -207,6 +214,14 @@
                   (click)="onMoveButtonClick()"
                 >
                   Move entries
+                </button>
+
+                <button
+                  type="button"
+                  class="govuk-button moj-button-menu__item govuk-button--secondary"
+                  (click)="onUpdateOfficialsButtonClick()"
+                >
+                  Update officials
                 </button>
 
                 <button

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -226,7 +226,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
 
     if (vm.errorSummary.length > 0 || vm.updateInvalid) {
       this.resetErrorSummary();
-    } else if (vm.updateDone) {
+    } else if (vm.updateDone || vm.updateOfficialsDone) {
       this.resetSuccessBanner();
     }
   }
@@ -243,6 +243,7 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
   private resetSuccessBanner(): void {
     this.detailSignalState.patch({
       updateDone: false,
+      updateOfficialsDone: false,
     });
   }
 
@@ -382,6 +383,13 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       this.route.snapshot.queryParamMap.get('moveEntriesSuccessful') === 'true'
     ) {
       this.vm().moveDone = true;
+    }
+
+    if (
+      this.route.snapshot.queryParamMap.get('updateOfficialsSuccessful') ===
+      'true'
+    ) {
+      this.vm().updateOfficialsDone = true;
     }
   }
 
@@ -823,6 +831,32 @@ export class ApplicationsListDetail extends PlaceFieldsBase implements OnInit {
       selectedRows: [],
       isSelectingAll: false,
       allMatchingSelected: false,
+    });
+  }
+
+  async onUpdateOfficialsButtonClick(): Promise<void> {
+    const selected = (await this.resolveSelectedRows()) as selectedRow[];
+
+    if (selected.length === 0) {
+      return;
+    }
+
+    // clear any prior messages
+    this.detailSignalState.patch({ errorSummary: [], errorHint: '' });
+
+    const updateOfficialsApplications = selected.map((r) => ({
+      id: r.id,
+      sequenceNumber: r.sequenceNumber,
+      applicant: r.applicant,
+      respondent: r.respondent,
+      title: r.title,
+    }));
+
+    await this.router.navigate(['update-officials'], {
+      relativeTo: this.route,
+      state: {
+        updateOfficialsApplications,
+      },
     });
   }
 

--- a/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.html
+++ b/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.html
@@ -3,6 +3,7 @@
   confirmButtonTxt="Confirm and update officials"
   cancelButtonTxt="Back"
   [isRedButton]="false"
+  [disabled]="isSubmitting()"
   (confirm)="onConfirm()"
   (cancelled)="goBack()"
 >

--- a/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.html
+++ b/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.html
@@ -1,0 +1,34 @@
+<app-review-confirm
+  title="Check officials before updating"
+  confirmButtonTxt="Confirm and update officials"
+  cancelButtonTxt="Back"
+  [isRedButton]="false"
+  (confirm)="onConfirm()"
+  (cancelled)="goBack()"
+>
+  @if (errorSummary().length) {
+    <app-error-summary
+      [title]="'There is a problem'"
+      [items]="errorSummary()"
+      (itemSelect)="onCreateErrorClick($event)"
+    />
+  }
+
+  <app-sortable-table
+    id="update-officials-confirm-applications-table"
+    [caption]="'Application(s) to update'"
+    [columns]="columns"
+    [data]="rows"
+  />
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-6">Officials</h2>
+
+  <dl class="govuk-summary-list">
+    @for (official of officialRows; track official.label) {
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">{{ official.label }}</dt>
+        <dd class="govuk-summary-list__value">{{ official.value }}</dd>
+      </div>
+    }
+  </dl>
+</app-review-confirm>

--- a/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
+++ b/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
@@ -18,12 +18,7 @@ import {
 } from '@components/error-summary/error-summary.component';
 import { ReviewConfirmComponent } from '@components/review-confirm/review-confirm.component';
 import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
-import {
-  ApplicationListEntriesApi,
-  BulkOfficialsUpdateDto,
-  Official,
-  OfficialType,
-} from '@openapi';
+import { ApplicationListEntriesApi, Official, OfficialType } from '@openapi';
 import {
   focusErrorSummary,
   onCreateErrorClick as onCreateErrorClickFn,
@@ -37,6 +32,7 @@ type OfficialSummaryRow = {
 
 @Component({
   selector: 'app-update-officials-confirm',
+  standalone: true,
   imports: [
     ErrorSummaryComponent,
     ReviewConfirmComponent,
@@ -100,7 +96,7 @@ export class UpdateOfficialsConfirmComponent implements OnInit {
       .replaceApplicationListEntryOfficials({
         listId: this.listId,
         bulkOfficialsUpdateDto: {
-          entryIds: entryIds as unknown as BulkOfficialsUpdateDto['entryIds'],
+          entryIds,
           officials: this.officials,
         },
       })

--- a/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
+++ b/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
@@ -18,7 +18,12 @@ import {
 } from '@components/error-summary/error-summary.component';
 import { ReviewConfirmComponent } from '@components/review-confirm/review-confirm.component';
 import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
-import { ApplicationListEntriesApi, Official, OfficialType } from '@openapi';
+import {
+  ApplicationListEntriesApi,
+  BulkOfficialsUpdateDto,
+  Official,
+  OfficialType,
+} from '@openapi';
 import {
   focusErrorSummary,
   onCreateErrorClick as onCreateErrorClickFn,
@@ -95,7 +100,7 @@ export class UpdateOfficialsConfirmComponent implements OnInit {
       .replaceApplicationListEntryOfficials({
         listId: this.listId,
         bulkOfficialsUpdateDto: {
-          entryIds: entryIds as unknown as Set<string>,
+          entryIds: entryIds as unknown as BulkOfficialsUpdateDto['entryIds'],
           officials: this.officials,
         },
       })

--- a/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
+++ b/src/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.ts
@@ -1,0 +1,161 @@
+import { Location, isPlatformBrowser } from '@angular/common';
+import { Component, OnInit, PLATFORM_ID, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { finalize } from 'rxjs';
+
+import {
+  UpdateOfficialsApplication,
+  UpdateOfficialsNavState,
+} from '../update-officials.types';
+
+import {
+  APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS,
+  PERSON_TITLE_OPTIONS,
+} from '@components/applications-list-entry-detail/util/entry-detail.constants';
+import {
+  ErrorItem,
+  ErrorSummaryComponent,
+} from '@components/error-summary/error-summary.component';
+import { ReviewConfirmComponent } from '@components/review-confirm/review-confirm.component';
+import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
+import { ApplicationListEntriesApi, Official, OfficialType } from '@openapi';
+import {
+  focusErrorSummary,
+  onCreateErrorClick as onCreateErrorClickFn,
+} from '@util/error-click';
+import { getProblemText } from '@util/http-error-to-text';
+
+type OfficialSummaryRow = {
+  label: string;
+  value: string;
+};
+
+@Component({
+  selector: 'app-update-officials-confirm',
+  imports: [
+    ErrorSummaryComponent,
+    ReviewConfirmComponent,
+    SortableTableComponent,
+  ],
+  templateUrl: './update-officials-confirm.component.html',
+})
+export class UpdateOfficialsConfirmComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly entriesApi = inject(ApplicationListEntriesApi);
+
+  readonly columns = APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS;
+  readonly errorSummary = signal<ErrorItem[]>([]);
+  readonly isSubmitting = signal(false);
+  readonly onCreateErrorClick = onCreateErrorClickFn;
+
+  private readonly titleLabels = new Map(
+    PERSON_TITLE_OPTIONS.map((option) => [option.value, option.label]),
+  );
+
+  listId = this.route.snapshot.paramMap.get('id') ?? '';
+  rows: UpdateOfficialsApplication[] = [];
+  officials: Official[] = [];
+  officialRows: OfficialSummaryRow[] = [];
+  officialFormValue: UpdateOfficialsNavState['officialFormValue'];
+
+  ngOnInit(): void {
+    const navState = isPlatformBrowser(this.platformId)
+      ? (this.location.getState() as UpdateOfficialsNavState)
+      : undefined;
+
+    this.rows = navState?.updateOfficialsApplications ?? [];
+    this.officials = navState?.officials ?? [];
+    this.officialFormValue = navState?.officialFormValue;
+    this.officialRows = this.buildOfficialRows(this.officials);
+
+    if (!this.listId || !this.rows.length || !this.officials.length) {
+      this.goBack();
+    }
+  }
+
+  onConfirm(): void {
+    if (this.isSubmitting()) {
+      return;
+    }
+
+    if (!this.listId || !this.rows.length || !this.officials.length) {
+      this.goBack();
+      return;
+    }
+
+    this.errorSummary.set([]);
+    this.isSubmitting.set(true);
+
+    const entryIds = [...new Set(this.rows.map((row) => row.id))];
+
+    this.entriesApi
+      .replaceApplicationListEntryOfficials({
+        listId: this.listId,
+        bulkOfficialsUpdateDto: {
+          entryIds: entryIds as unknown as Set<string>,
+          officials: this.officials,
+        },
+      })
+      .pipe(finalize(() => this.isSubmitting.set(false)))
+      .subscribe({
+        next: () => {
+          void this.router.navigate(['/applications-list', this.listId], {
+            queryParams: { updateOfficialsSuccessful: true },
+          });
+        },
+        error: (err: unknown) => {
+          this.errorSummary.set([{ text: getProblemText(err) }]);
+          focusErrorSummary(this.platformId);
+        },
+      });
+  }
+
+  goBack(): void {
+    if (!this.listId) {
+      void this.router.navigate(['/applications-list']);
+      return;
+    }
+
+    void this.router.navigate(
+      ['/applications-list', this.listId, 'update-officials'],
+      {
+        state: {
+          updateOfficialsApplications: this.rows,
+          officialFormValue: this.officialFormValue,
+        } satisfies UpdateOfficialsNavState,
+      },
+    );
+  }
+
+  private buildOfficialRows(officials: Official[]): OfficialSummaryRow[] {
+    let magistrateCount = 0;
+
+    return officials.map((official) => {
+      if (official.type === OfficialType.MAGISTRATE) {
+        magistrateCount += 1;
+        return {
+          label: `Magistrate ${magistrateCount}`,
+          value: this.formatOfficialName(official),
+        };
+      }
+
+      return {
+        label: 'Court official',
+        value: this.formatOfficialName(official),
+      };
+    });
+  }
+
+  private formatOfficialName(official: Official): string {
+    const title = official.title
+      ? (this.titleLabels.get(official.title) ?? official.title)
+      : undefined;
+
+    return [title, official.forename, official.surname]
+      .filter((part): part is string => !!part?.trim())
+      .join(' ');
+  }
+}

--- a/src/app/pages/applications-list-detail/update-officials/update-officials.component.html
+++ b/src/app/pages/applications-list-detail/update-officials/update-officials.component.html
@@ -1,0 +1,34 @@
+<app-breadcrumbs
+  [items]="[
+    { label: 'Applications list', link: '/applications-list' },
+    {
+      label: 'Applications list details',
+      link: '/applications-list/' + listId,
+    },
+  ]"
+/>
+
+@if (errorSummary().length) {
+  <app-error-summary
+    [title]="'There is a problem'"
+    [items]="errorSummary()"
+    (itemSelect)="onCreateErrorClick($event)"
+  />
+}
+
+<h1 class="govuk-heading-xl">Update officials</h1>
+
+<app-sortable-table
+  id="update-officials-applications-table"
+  [caption]="'Application(s) to update'"
+  [columns]="columns"
+  [data]="rows"
+/>
+
+<div class="govuk-!-margin-top-6">
+  <app-officials-section
+    [group]="form"
+    [errors]="errorSummary()"
+    (saveOfficialsClicked)="onSaveOfficials()"
+  />
+</div>

--- a/src/app/pages/applications-list-detail/update-officials/update-officials.component.ts
+++ b/src/app/pages/applications-list-detail/update-officials/update-officials.component.ts
@@ -27,6 +27,7 @@ import { buildFormErrorSummary } from '@util/error-summary';
 
 @Component({
   selector: 'app-update-officials',
+  standalone: true,
   imports: [
     BreadcrumbsComponent,
     ErrorSummaryComponent,

--- a/src/app/pages/applications-list-detail/update-officials/update-officials.component.ts
+++ b/src/app/pages/applications-list-detail/update-officials/update-officials.component.ts
@@ -1,0 +1,130 @@
+import { Location, isPlatformBrowser } from '@angular/common';
+import { Component, OnInit, PLATFORM_ID, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import {
+  UpdateOfficialsApplication,
+  UpdateOfficialsNavState,
+} from './update-officials.types';
+
+import { APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS } from '@components/applications-list-entry-detail/util/entry-detail.constants';
+import { buildOfficialsFromFormValue } from '@components/applications-list-entry-detail/util/entry-detail.form';
+import { BreadcrumbsComponent } from '@components/breadcrumbs/breadcrumbs.component';
+import {
+  ErrorItem,
+  ErrorSummaryComponent,
+} from '@components/error-summary/error-summary.component';
+import { OfficialsSectionComponent } from '@components/officials-section/officials-section.component';
+import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
+import { OFFICIAL_FIELD_MESSAGES } from '@constants/application-list-entry/error-messages';
+import { OFFICIALS_ERROR_HREFS } from '@constants/application-list-entry/respondent/error-hrefs';
+import { ApplicationListEntryFormService } from '@services/applications-list-entry/application-list-entry-form.service';
+import {
+  focusErrorSummary,
+  onCreateErrorClick as onCreateErrorClickFn,
+} from '@util/error-click';
+import { buildFormErrorSummary } from '@util/error-summary';
+
+@Component({
+  selector: 'app-update-officials',
+  imports: [
+    BreadcrumbsComponent,
+    ErrorSummaryComponent,
+    OfficialsSectionComponent,
+    SortableTableComponent,
+  ],
+  templateUrl: './update-officials.component.html',
+})
+export class UpdateOfficialsComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly formService = inject(ApplicationListEntryFormService);
+
+  readonly form = this.formService.createForms().form;
+  readonly columns = APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS;
+  readonly errorSummary = signal<ErrorItem[]>([]);
+
+  readonly onCreateErrorClick = onCreateErrorClickFn;
+
+  listId = this.route.snapshot.paramMap.get('id') ?? '';
+  rows: UpdateOfficialsApplication[] = [];
+
+  constructor() {
+    this.form.controls.applicationCode.disable({ emitEvent: false });
+    this.form.controls.lodgementDate.disable({ emitEvent: false });
+  }
+
+  ngOnInit(): void {
+    const navState = isPlatformBrowser(this.platformId)
+      ? (this.location.getState() as UpdateOfficialsNavState)
+      : undefined;
+
+    this.rows = navState?.updateOfficialsApplications ?? [];
+
+    if (navState?.officialFormValue) {
+      this.form.patchValue(navState.officialFormValue, { emitEvent: false });
+    }
+
+    if (!this.listId || !this.rows.length) {
+      this.goBack();
+    }
+  }
+
+  onSaveOfficials(): void {
+    this.form.markAllAsTouched();
+    this.form.updateValueAndValidity({ emitEvent: false });
+
+    const errors = this.buildOfficialsErrorSummary();
+    if (errors.length) {
+      this.errorSummary.set(errors);
+      focusErrorSummary(this.platformId);
+      return;
+    }
+
+    const officials =
+      buildOfficialsFromFormValue(this.form.getRawValue()).officials ?? [];
+
+    if (!officials.length) {
+      this.errorSummary.set([
+        {
+          id: 'mags1FirstName',
+          href: OFFICIALS_ERROR_HREFS.mags1FirstName,
+          text: 'Enter at least one official',
+        },
+      ]);
+      focusErrorSummary(this.platformId);
+      return;
+    }
+
+    if (!this.listId || !this.rows.length) {
+      this.goBack();
+      return;
+    }
+
+    void this.router.navigate(['confirm'], {
+      relativeTo: this.route,
+      state: {
+        updateOfficialsApplications: this.rows,
+        officialFormValue: this.form.getRawValue(),
+        officials,
+      } satisfies UpdateOfficialsNavState,
+    });
+  }
+
+  goBack(): void {
+    if (this.listId) {
+      void this.router.navigate(['/applications-list', this.listId]);
+      return;
+    }
+
+    void this.router.navigate(['/applications-list']);
+  }
+
+  private buildOfficialsErrorSummary(): ErrorItem[] {
+    return buildFormErrorSummary(this.form, OFFICIAL_FIELD_MESSAGES, {
+      hrefs: OFFICIALS_ERROR_HREFS,
+    });
+  }
+}

--- a/src/app/pages/applications-list-detail/update-officials/update-officials.types.ts
+++ b/src/app/pages/applications-list-detail/update-officials/update-officials.types.ts
@@ -1,0 +1,17 @@
+import { Row } from '@core-types/table/row.types';
+import { Official } from '@openapi';
+import { ApplicationsListEntryFormValue } from '@shared-types/applications-list-entry-create/application-list-entry-form';
+
+export type UpdateOfficialsApplication = Row & {
+  id: string;
+  sequenceNumber?: number | string;
+  applicant?: string | null;
+  respondent?: string | null;
+  title?: string | null;
+};
+
+export type UpdateOfficialsNavState = {
+  updateOfficialsApplications?: UpdateOfficialsApplication[];
+  officials?: Official[];
+  officialFormValue?: ApplicationsListEntryFormValue;
+};

--- a/src/app/pages/applications-list-detail/util/applications-list-detail.state.ts
+++ b/src/app/pages/applications-list-detail/util/applications-list-detail.state.ts
@@ -35,6 +35,7 @@ export interface ApplicationsListDetailState {
   isLoading: boolean;
   isSelectingAll: boolean;
   updateDone: boolean;
+  updateOfficialsDone?: boolean;
   updateInvalid: boolean;
   moveDone: boolean;
 
@@ -69,6 +70,7 @@ export const initialApplicationsListDetailState: ApplicationsListDetailState = {
   isLoading: true,
   isSelectingAll: false,
   updateDone: false,
+  updateOfficialsDone: false,
   updateInvalid: false,
   moveDone: false,
 
@@ -85,6 +87,7 @@ export const initialApplicationsListDetailState: ApplicationsListDetailState = {
 export const clearUpdateNotificationsPatch = (): Pick<
   ApplicationsListDetailState,
   | 'updateDone'
+  | 'updateOfficialsDone'
   | 'updateInvalid'
   | 'errorHint'
   | 'errorSummary'
@@ -93,6 +96,7 @@ export const clearUpdateNotificationsPatch = (): Pick<
   | 'moveDone'
 > => ({
   updateDone: false,
+  updateOfficialsDone: false,
   updateInvalid: false,
   errorHint: '',
   errorSummary: [],

--- a/src/app/shared/constants/application-list-entry/error-messages.ts
+++ b/src/app/shared/constants/application-list-entry/error-messages.ts
@@ -115,7 +115,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'First name contains invalid characters',
   },
   mags1Surname: {
-    required: 'Magistrates 1 Last name is required',
+    required: 'Magistrates 1 last name is required',
     maxlength: 'Last name must be 100 characters or fewer',
     pattern: 'Last name contains invalid characters',
   },
@@ -124,7 +124,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'First name contains invalid characters',
   },
   mags2Surname: {
-    required: 'Magistrates 2 Last name is required',
+    required: 'Magistrates 2 last name is required',
     maxlength: 'Last name must be 100 characters or fewer',
     pattern: 'Last name contains invalid characters',
   },
@@ -133,7 +133,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'First name contains invalid characters',
   },
   mags3Surname: {
-    required: 'Magistrates 3 Last name is required',
+    required: 'Magistrates 3 last name is required',
     maxlength: 'Last name must be 100 characters or fewer',
     pattern: 'Last name contains invalid characters',
   },
@@ -142,7 +142,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'First name contains invalid characters',
   },
   officialSurname: {
-    required: "Official's Last name is required",
+    required: "Official's last name is required",
     maxlength: 'Last name must be 100 characters or fewer',
     pattern: 'Last name contains invalid characters',
   },

--- a/test/unit/app/core/components/review-confirm/review-confirm.component.spec.ts
+++ b/test/unit/app/core/components/review-confirm/review-confirm.component.spec.ts
@@ -57,6 +57,29 @@ describe('ReviewConfirmComponent', () => {
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('onConfirm uses parent-controlled disabled state when disabled input is provided', () => {
+    const emitSpy = jest.spyOn(component.confirm, 'emit');
+    fixture.componentRef.setInput('disabled', false);
+    fixture.detectChanges();
+
+    component.onConfirm();
+
+    expect(component.isConfirmed()).toBe(false);
+    expect(component.buttonDisabled()).toBe(false);
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onConfirm does not emit when parent-controlled disabled state is true', () => {
+    const emitSpy = jest.spyOn(component.confirm, 'emit');
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    component.onConfirm();
+
+    expect(component.buttonDisabled()).toBe(true);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
   it('onCancel sets isConfirmed=false and emits cancelled', () => {
     const emitSpy = jest.spyOn(component.cancelled, 'emit');
 

--- a/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/applications-list-detail.component.spec.ts
@@ -828,6 +828,7 @@ describe('ApplicationsListDetail', () => {
         createDone: false,
         preserveErrorSummaryOnLoad: false,
         moveDone: false,
+        updateOfficialsDone: false,
       });
       expect(setSpy).toHaveBeenCalledWith({
         id: 'list-123',
@@ -871,6 +872,7 @@ describe('ApplicationsListDetail', () => {
         createDone: false,
         preserveErrorSummaryOnLoad: false,
         moveDone: false,
+        updateOfficialsDone: false,
       });
       expect(setSpy).toHaveBeenCalledWith({
         id: 'list-123',
@@ -1245,7 +1247,7 @@ describe('ApplicationsListDetail', () => {
     });
   });
 
-  it('ResetSuccessBanner should reset success banner by setting updateDone to false', () => {
+  it('ResetSuccessBanner should reset success banners', () => {
     const patchSpy = jest.spyOn(component['detailSignalState'], 'patch');
 
     (
@@ -1254,6 +1256,7 @@ describe('ApplicationsListDetail', () => {
 
     expect(patchSpy).toHaveBeenCalledWith({
       updateDone: false,
+      updateOfficialsDone: false,
     });
   });
 
@@ -1460,6 +1463,19 @@ describe('ApplicationsListDetail', () => {
 
     expect(routeSpy).toHaveBeenCalledWith('listCreated');
     expect(component.vm().createDone).toBe(false);
+  });
+
+  it('setSuccessBanner: sets updateOfficialsDone when updateOfficialsSuccessful=true', () => {
+    const route = TestBed.inject(ActivatedRoute);
+    jest
+      .spyOn(route.snapshot.queryParamMap, 'get')
+      .mockImplementation((key: string) =>
+        key === 'updateOfficialsSuccessful' ? 'true' : null,
+      );
+
+    component.setSuccessBanner();
+
+    expect(component.vm().updateOfficialsDone).toBe(true);
   });
 
   it('openUpdate: navigates with state & queryParams', async () => {

--- a/test/unit/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.spec.ts
@@ -168,6 +168,7 @@ describe('UpdateOfficialsConfirmComponent', () => {
     expect(component.errorSummary()).toEqual([
       { text: 'Officials could not be updated' },
     ]);
+    expect(component.isSubmitting()).toBe(false);
   });
 
   it('goes back to the update officials page with state', () => {

--- a/test/unit/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/update-officials/confirm/update-officials-confirm.component.spec.ts
@@ -1,0 +1,204 @@
+import { Location } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { UpdateOfficialsConfirmComponent } from '@components/applications-list-detail/update-officials/confirm/update-officials-confirm.component';
+import {
+  UpdateOfficialsApplication,
+  UpdateOfficialsNavState,
+} from '@components/applications-list-detail/update-officials/update-officials.types';
+import { ApplicationListEntriesApi, Official, OfficialType } from '@openapi';
+
+describe('UpdateOfficialsConfirmComponent', () => {
+  let component: UpdateOfficialsConfirmComponent;
+  let fixture: ComponentFixture<UpdateOfficialsConfirmComponent>;
+  let locationState: UpdateOfficialsNavState;
+
+  const rows: UpdateOfficialsApplication[] = [
+    {
+      id: 'entry-1',
+      sequenceNumber: 1,
+      applicant: 'Applicant A',
+      respondent: 'Respondent A',
+      title: 'Application A',
+    },
+    {
+      id: 'entry-2',
+      sequenceNumber: 2,
+      applicant: 'Applicant B',
+      respondent: 'Respondent B',
+      title: 'Application B',
+    },
+  ];
+
+  const officials: Official[] = [
+    {
+      type: OfficialType.MAGISTRATE,
+      title: 'mr',
+      forename: 'John',
+      surname: 'Smith',
+    },
+    {
+      type: OfficialType.CLERK,
+      title: 'mrs',
+      forename: 'Clara',
+      surname: 'Jones',
+    },
+  ];
+
+  const officialFormValue = {
+    mags1FirstName: 'John',
+    mags1Surname: 'Smith',
+    officialFirstName: 'Clara',
+    officialSurname: 'Jones',
+  } as UpdateOfficialsNavState['officialFormValue'];
+
+  const routerMock = {
+    navigate: jest.fn().mockResolvedValue(true),
+  };
+
+  const locationMock = {
+    getState: jest.fn(() => locationState),
+  };
+
+  const entriesApiMock = {
+    replaceApplicationListEntryOfficials: jest.fn(),
+  };
+
+  const activatedRouteMock = {
+    snapshot: {
+      paramMap: convertToParamMap({ id: 'list-1' }),
+    },
+  };
+
+  beforeEach(async () => {
+    locationState = {
+      updateOfficialsApplications: rows,
+      officials,
+      officialFormValue,
+    };
+    routerMock.navigate.mockReset();
+    routerMock.navigate.mockResolvedValue(true);
+    locationMock.getState.mockClear();
+    entriesApiMock.replaceApplicationListEntryOfficials.mockReset();
+    entriesApiMock.replaceApplicationListEntryOfficials.mockReturnValue(of({}));
+
+    await TestBed.configureTestingModule({
+      imports: [UpdateOfficialsConfirmComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        { provide: Router, useValue: routerMock },
+        { provide: Location, useValue: locationMock },
+        { provide: ApplicationListEntriesApi, useValue: entriesApiMock },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    }).compileComponents();
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(UpdateOfficialsConfirmComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads applications and officials from navigation state', () => {
+    createComponent();
+
+    expect(component.listId).toBe('list-1');
+    expect(component.rows).toEqual(rows);
+    expect(component.officials).toEqual(officials);
+    expect(component.officialRows).toEqual([
+      { label: 'Magistrate 1', value: 'Mr John Smith' },
+      { label: 'Court official', value: 'Mrs Clara Jones' },
+    ]);
+  });
+
+  it('submits the bulk officials update and navigates back to the detail page', () => {
+    createComponent();
+
+    component.onConfirm();
+
+    expect(
+      entriesApiMock.replaceApplicationListEntryOfficials,
+    ).toHaveBeenCalledWith({
+      listId: 'list-1',
+      bulkOfficialsUpdateDto: {
+        entryIds: ['entry-1', 'entry-2'],
+        officials,
+      },
+    });
+    expect(routerMock.navigate).toHaveBeenCalledWith(
+      ['/applications-list', 'list-1'],
+      {
+        queryParams: { updateOfficialsSuccessful: true },
+      },
+    );
+  });
+
+  it('deduplicates entry ids before submitting', () => {
+    locationState = {
+      updateOfficialsApplications: [...rows, rows[0]],
+      officials,
+      officialFormValue,
+    };
+    createComponent();
+
+    component.onConfirm();
+
+    const request = entriesApiMock.replaceApplicationListEntryOfficials.mock
+      .calls[0][0] as {
+      bulkOfficialsUpdateDto: { entryIds: string[] };
+    };
+    expect(request.bulkOfficialsUpdateDto.entryIds).toEqual([
+      'entry-1',
+      'entry-2',
+    ]);
+  });
+
+  it('shows an API error when the update fails', () => {
+    entriesApiMock.replaceApplicationListEntryOfficials.mockReturnValue(
+      throwError(() => ({ detail: 'Officials could not be updated' })),
+    );
+    createComponent();
+
+    component.onConfirm();
+
+    expect(component.errorSummary()).toEqual([
+      { text: 'Officials could not be updated' },
+    ]);
+  });
+
+  it('goes back to the update officials page with state', () => {
+    createComponent();
+
+    component.goBack();
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(
+      ['/applications-list', 'list-1', 'update-officials'],
+      {
+        state: {
+          updateOfficialsApplications: rows,
+          officialFormValue,
+        },
+      },
+    );
+  });
+
+  it('redirects back when confirm state is incomplete', () => {
+    locationState = { updateOfficialsApplications: rows };
+
+    createComponent();
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(
+      ['/applications-list', 'list-1', 'update-officials'],
+      {
+        state: {
+          updateOfficialsApplications: rows,
+          officialFormValue: undefined,
+        },
+      },
+    );
+  });
+});

--- a/test/unit/app/pages/applications-list-detail/update-officials/update-officials.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/update-officials/update-officials.component.spec.ts
@@ -1,0 +1,186 @@
+import { Location } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+
+import { UpdateOfficialsComponent } from '@components/applications-list-detail/update-officials/update-officials.component';
+import {
+  UpdateOfficialsApplication,
+  UpdateOfficialsNavState,
+} from '@components/applications-list-detail/update-officials/update-officials.types';
+import { OfficialType } from '@openapi';
+
+describe('UpdateOfficialsComponent', () => {
+  let component: UpdateOfficialsComponent;
+  let fixture: ComponentFixture<UpdateOfficialsComponent>;
+  let locationState: UpdateOfficialsNavState;
+
+  const rows: UpdateOfficialsApplication[] = [
+    {
+      id: 'entry-1',
+      sequenceNumber: 1,
+      applicant: 'Applicant A',
+      respondent: 'Respondent A',
+      title: 'Application A',
+    },
+    {
+      id: 'entry-2',
+      sequenceNumber: 2,
+      applicant: 'Applicant B',
+      respondent: 'Respondent B',
+      title: 'Application B',
+    },
+  ];
+
+  const routerMock = {
+    navigate: jest.fn(),
+  };
+
+  const locationMock = {
+    getState: jest.fn(() => locationState),
+  };
+
+  const activatedRouteMock = {
+    snapshot: {
+      paramMap: convertToParamMap({ id: 'list-1' }),
+    },
+  };
+
+  beforeEach(async () => {
+    locationState = { updateOfficialsApplications: rows };
+    routerMock.navigate.mockReset();
+    locationMock.getState.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [UpdateOfficialsComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        { provide: Router, useValue: routerMock },
+        { provide: Location, useValue: locationMock },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    }).compileComponents();
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(UpdateOfficialsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads selected applications from route state', () => {
+    createComponent();
+
+    expect(component.listId).toBe('list-1');
+    expect(component.rows).toEqual(rows);
+  });
+
+  it('hydrates official form values from route state when returning from confirm', () => {
+    locationState = {
+      updateOfficialsApplications: rows,
+      officialFormValue: {
+        mags1FirstName: 'John',
+        mags1Surname: 'Smith',
+      },
+    } as UpdateOfficialsNavState;
+
+    createComponent();
+
+    expect(component.form.controls.mags1FirstName.value).toBe('John');
+    expect(component.form.controls.mags1Surname.value).toBe('Smith');
+  });
+
+  it('navigates back to the list detail page when no applications are provided', () => {
+    locationState = { updateOfficialsApplications: [] };
+
+    createComponent();
+
+    expect(routerMock.navigate).toHaveBeenCalledWith([
+      '/applications-list',
+      'list-1',
+    ]);
+  });
+
+  it('navigates to confirm with selected applications, officials and form state', () => {
+    createComponent();
+
+    component.form.patchValue({
+      mags1Title: 'mr',
+      mags1FirstName: 'John',
+      mags1Surname: 'Smith',
+      officialTitle: 'mrs',
+      officialFirstName: 'Clara',
+      officialSurname: 'Jones',
+    });
+
+    component.onSaveOfficials();
+
+    expect(routerMock.navigate).toHaveBeenCalledWith(['confirm'], {
+      relativeTo: activatedRouteMock,
+      state: {
+        updateOfficialsApplications: rows,
+        officialFormValue: expect.objectContaining({
+          mags1FirstName: 'John',
+          mags1Surname: 'Smith',
+          officialFirstName: 'Clara',
+          officialSurname: 'Jones',
+        }),
+        officials: [
+          {
+            type: OfficialType.MAGISTRATE,
+            title: 'mr',
+            forename: 'John',
+            surname: 'Smith',
+          },
+          {
+            type: OfficialType.CLERK,
+            title: 'mrs',
+            forename: 'Clara',
+            surname: 'Jones',
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not post when official validation fails', () => {
+    createComponent();
+
+    component.form.patchValue({
+      mags1FirstName: 'John',
+      mags1Surname: null,
+    });
+
+    component.onSaveOfficials();
+
+    expect(routerMock.navigate).not.toHaveBeenCalledWith(
+      ['confirm'],
+      expect.anything(),
+    );
+    expect(component.errorSummary()).toEqual([
+      {
+        id: 'mags1Surname',
+        href: '#officials-mags1-surname',
+        text: 'Magistrates 1 Last name is required',
+      },
+    ]);
+  });
+
+  it('does not continue when no official is entered', () => {
+    createComponent();
+
+    component.onSaveOfficials();
+
+    expect(component.errorSummary()).toEqual([
+      {
+        id: 'mags1FirstName',
+        href: '#officials-mags1-first-name',
+        text: 'Enter at least one official',
+      },
+    ]);
+    expect(routerMock.navigate).not.toHaveBeenCalledWith(
+      ['confirm'],
+      expect.anything(),
+    );
+  });
+});

--- a/test/unit/app/pages/applications-list-detail/update-officials/update-officials.component.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/update-officials/update-officials.component.spec.ts
@@ -161,7 +161,7 @@ describe('UpdateOfficialsComponent', () => {
       {
         id: 'mags1Surname',
         href: '#officials-mags1-surname',
-        text: 'Magistrates 1 Last name is required',
+        text: 'Magistrates 1 last name is required',
       },
     ]);
   });


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-631

### Change description

- Adds an **Update officials** bulk action from the applications list detail page.
- Adds a new `update-officials` page where users can enter officials for selected applications.
- Adds a review/confirm step before applying the bulk officials update.
- Calls the generated `replaceApplicationListEntryOfficials` API on confirmation.
- Shows a success banner on return to the applications list detail page.
- Updates `ReviewConfirmComponent` so parent pages can control the confirm button disabled state during async submission.
- Adds unit coverage for the update officials flow, confirm page, shared confirm component behavior, and success banner state.

<!-- Describe what changed and why. -->

### Testing done
Manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
