### PR TITLE
Fix Codex usage token parsing

### DIFF
--- a/.github/scripts/codex-usage-metrics.sh
+++ b/.github/scripts/codex-usage-metrics.sh
@@ -26,6 +26,7 @@ token_keys = {
     "cached_input_tokens",
     "cached_output_tokens",
     "reasoning_tokens",
+    "reasoning_output_tokens",
     "total_tokens",
     "prompt_tokens",
     "completion_tokens",
@@ -36,6 +37,7 @@ aliases = {
     "prompt_tokens": "input_tokens",
     "completion_tokens": "output_tokens",
     "cached_tokens": "cached_input_tokens",
+    "reasoning_output_tokens": "reasoning_tokens",
 }
 
 event_count = 0
@@ -89,6 +91,12 @@ for usage in usage_objects:
 
 last_usage = usage_objects[-1] if usage_objects else {}
 preferred_usage = last_usage or max_usage
+if preferred_usage and "total_tokens" not in preferred_usage:
+    input_tokens = preferred_usage.get("input_tokens")
+    output_tokens = preferred_usage.get("output_tokens")
+    if input_tokens is not None and output_tokens is not None:
+        preferred_usage = dict(preferred_usage)
+        preferred_usage["total_tokens"] = input_tokens + output_tokens
 
 summary = {
     "schemaVersion": 1,


### PR DESCRIPTION
### Jira link

Not applicable.

### Change description

Fixes Codex usage metric parsing to match the usage payload emitted by `codex exec --json`.

A local smoke run emitted usage on `turn.completed` with `reasoning_output_tokens`. The helper now normalises that field to `reasoning_tokens` and derives `total_tokens` from `input_tokens + output_tokens` when Codex does not emit a total.

### Testing done

- `bash -n .github/scripts/codex-usage-metrics.sh`
- `git diff --check`
- Parser smoke test using the observed Codex JSON payload shape:
  - `input_tokens`
  - `cached_input_tokens`
  - `output_tokens`
  - `reasoning_output_tokens`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
