### PR TITLE
ARCPOC-1293 Remove loop for result selected

### DIFF
--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -41,6 +41,12 @@ const subscribedEndpoints: EndpointRule[] = [
   },
   {
     endpoint: new RegExp(
+      `^/application-lists/${regexIdPlaceholder}/entries/results$`,
+    ),
+    responses: [400, 403, 404, 409, 500, 504],
+  },
+  {
+    endpoint: new RegExp(
       `^/application-lists/${regexIdPlaceholder}/entries/${regexIdPlaceholder}$`,
     ),
     responses: [400, 403, 404, 409, 500, 504],

--- a/src/app/pages/result-selected/result-selected.component.html
+++ b/src/app/pages/result-selected/result-selected.component.html
@@ -32,6 +32,7 @@
   [clearPendingToken]="resultsFacade.clearPendingToken()"
   [wordingByCode]="resultsFacade.resultCodeWordingByCode()"
   [resultCodeTemplateByCode]="resultsFacade.resultCodeTemplateByCode()"
+  [submitting]="isSubmitting()"
   (pendingChange)="onPendingChange($event)"
   (submitResults)="onSubmitResults($event)"
   (removeExisting)="onRemoveResult($event)"

--- a/src/app/pages/result-selected/result-selected.component.ts
+++ b/src/app/pages/result-selected/result-selected.component.ts
@@ -23,10 +23,7 @@ import { SuccessBannerComponent } from '@components/success-banner/success-banne
 import { ENTRY_SUCCESS_MESSAGES } from '@constants/application-list-entry/success-messages';
 import { SuccessBanner } from '@core-types/banner/banner.types';
 import { ResultGetDto } from '@openapi';
-import {
-  ApplicationListEntryResultsFacade,
-  BulkResultChange,
-} from '@services/applications-list-entry/application-list-entry-results.facade';
+import { ApplicationListEntryResultsFacade } from '@services/applications-list-entry/application-list-entry-results.facade';
 import { PendingResultRow } from '@shared-types/result-code/result-code-row';
 import { ResultSectionSubmitPayload } from '@shared-types/result-wording-section/result-section.types';
 import {
@@ -56,7 +53,6 @@ export class ResultSelected implements OnInit {
   private readonly selectedResultCode = signal<string>('');
 
   isSubmitting = signal(false);
-  batchResults!: BulkResultChange[];
 
   successBanner = signal<SuccessBanner | null>(null);
 
@@ -79,8 +75,6 @@ export class ResultSelected implements OnInit {
   });
 
   onCreateErrorClick = onCreateErrorClickFn;
-
-  idToSequenceNumberMap!: Record<string, string | undefined>;
 
   columns = APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS;
 
@@ -147,55 +141,42 @@ export class ResultSelected implements OnInit {
   }
 
   onSubmitResults(payload: ResultSectionSubmitPayload): void {
+    if (this.isSubmitting()) {
+      return;
+    }
+
     const item = payload.pendingToCreate?.[0] ?? payload.existingToUpdate?.[0];
 
     if (item) {
       this.selectedResultCode.set(item.resultCode);
     }
 
-    this.idToSequenceNumberMap = Object.fromEntries(
-      this.rows.map((row) => [row.id, row.sequenceNumber]),
-    );
-
     if (!this.listId || !this.rows?.length) {
       return;
     }
+
     this.isSubmitting.set(true);
-    this.batchResults = [];
+    this.errorSummaryItems.set([]);
+    this.successBanner.set(null);
+
     this.resultsFacade.submitResultChangesForEntries(
       this.listId,
       this.rows.map((row) => row.id),
       payload,
-      (results) => {
+      () => {
         this.isSubmitting.set(false);
-        this.batchResults = results;
+        this.errorSummaryItems.set([]);
 
-        const errorItems: ErrorItem[] = results
-          .filter((r) => !r.success)
-          .map((r) => {
-            return {
-              text: `Sequence number ${this.idToSequenceNumberMap[r.entryId]} failed to update`,
-            } as ErrorItem;
-          });
-
-        this.errorSummaryItems.set(errorItems);
-        if (errorItems.length > 0) {
-          focusErrorSummary(this.platformId);
-        }
-
-        this.successBanner.set(
-          errorItems.length === 0
-            ? {
-                heading: 'Result codes applied successfully',
-                body: `Result code '${this.selectedResultCode()}' applied successfully to application list entries`,
-              }
-            : null,
-        );
+        this.successBanner.set({
+          heading: 'Result codes applied successfully',
+          body: `Result code '${this.selectedResultCode()}' applied successfully to application list entries`,
+        });
 
         focusSuccessBanner(this.platformId);
       },
       (err) => {
         this.isSubmitting.set(false);
+        this.successBanner.set(null);
         this.applyMappedError(err);
         focusErrorSummary(this.platformId);
       },

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.html
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.html
@@ -54,7 +54,7 @@
     type="button"
     class="govuk-button"
     (click)="onSaveResult()"
-    [disabled]="!canSubmitResults()"
+    [disabled]="submitting() || !canSubmitResults()"
   >
     {{ buttonText() }}
   </button>

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.ts
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.ts
@@ -71,6 +71,7 @@ export class ResultWordingSectionComponent {
   captionSize = input<'s' | 'm' | 'l'>('s');
   buttonText = input<string>('Apply result');
   markSubmittedResultsApplied = input(false);
+  submitting = input(false);
 
   removeExisting = output<string>();
   pendingChange = output<PendingResultRow[]>();
@@ -84,6 +85,7 @@ export class ResultWordingSectionComponent {
   private readonly pending = signal<PendingResultRow[]>([]);
   private readonly pendingVersion = signal(0);
   private readonly appliedVersion = signal(0);
+  private lastSubmittedPendingVersion = 0;
   private lastProcessedClearPendingToken = 0;
   readonly wordingSubmitAttempt = signal(0);
   private readonly currentWordingErrors = signal<ErrorItem[]>([]);
@@ -116,10 +118,14 @@ export class ResultWordingSectionComponent {
       this.lastProcessedClearPendingToken = token;
 
       const shouldClearPending = untracked(
-        () => this.pendingVersion() === this.appliedVersion(),
+        () =>
+          this.pendingVersion() === this.appliedVersion() ||
+          (this.lastSubmittedPendingVersion > 0 &&
+            this.pendingVersion() === this.lastSubmittedPendingVersion),
       );
 
       if (shouldClearPending) {
+        this.lastSubmittedPendingVersion = 0;
         this.pending.set([]);
         this.pendingChange.emit(this.pending());
         this.resultCodeSearch = '';
@@ -546,7 +552,12 @@ export class ResultWordingSectionComponent {
     }
 
     if (payload.pendingToCreate.length > 0) {
-      this.appliedVersion.set(this.pendingVersion());
+      if (this.markSubmittedResultsApplied()) {
+        this.appliedVersion.set(this.pendingVersion());
+      } else {
+        this.lastSubmittedPendingVersion = this.pendingVersion();
+      }
+
       this.resultCodeSearch = '';
     }
 

--- a/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
+++ b/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
@@ -1,6 +1,6 @@
 import { DestroyRef, Injectable, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Observable, catchError, forkJoin, map, of } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
 
 import {
   ApplicationListEntryResultsApi,
@@ -12,22 +12,6 @@ import {
 import { PendingResultRow } from '@shared-types/result-code/result-code-row';
 import type { ResultSectionSubmitPayload } from '@shared-types/result-wording-section/result-section.types';
 import { getAllResultCodes, getEntryResults$ } from '@util/result-code-helpers';
-
-export type BulkResultChange =
-  | {
-      action: 'create' | 'update';
-      entryId: string;
-      resultId?: string;
-      success: true;
-      response: ResultGetDto;
-    }
-  | {
-      action: 'create' | 'update';
-      entryId: string;
-      resultId?: string;
-      success: false;
-      error: unknown;
-    };
 
 export type BulkResultRemoval =
   | {
@@ -90,7 +74,7 @@ export class ApplicationListEntryResultsFacade {
     listId: string,
     entryIds: string[],
     payload: ResultSectionSubmitPayload,
-    onSuccess?: (results: BulkResultChange[]) => void,
+    onSuccess?: () => void,
     onError?: (err: unknown) => void,
   ): void {
     if (!listId || !payload) {
@@ -104,7 +88,7 @@ export class ApplicationListEntryResultsFacade {
         .map((result) => [result.id, result]),
     );
 
-    const updateRequests: Observable<BulkResultChange>[] = [];
+    const updateRequests: Observable<ResultGetDto>[] = [];
     (payload.existingToUpdate ?? [])
       .filter((item) => !!item.resultId && !!item.resultCode)
       .forEach((item) => {
@@ -123,77 +107,50 @@ export class ApplicationListEntryResultsFacade {
             }
 
             updateRequests.push(
-              this.entryResultsApi
-                .updateApplicationListEntryResult({
-                  listId,
-                  entryId: result.entryId,
-                  resultId: result.id,
-                  resultUpdateDto: {
-                    resultCode: item.resultCode.trim(),
-                    wordingFields: item.wordingFields ?? [],
-                  },
-                })
-                .pipe(
-                  map(
-                    (response): BulkResultChange => ({
-                      action: 'update',
-                      entryId: result.entryId,
-                      resultId: result.id,
-                      success: true,
-                      response,
-                    }),
-                  ),
-                  catchError((error: unknown) =>
-                    of<BulkResultChange>({
-                      action: 'update',
-                      entryId: result.entryId,
-                      resultId: result.id,
-                      success: false,
-                      error,
-                    }),
-                  ),
-                ),
+              this.entryResultsApi.updateApplicationListEntryResult({
+                listId,
+                entryId: result.entryId,
+                resultId: result.id,
+                resultUpdateDto: {
+                  resultCode: item.resultCode.trim(),
+                  wordingFields: item.wordingFields ?? [],
+                },
+              }),
             );
           });
       });
 
-    const createRequests: Observable<BulkResultChange>[] = [];
+    const selectedEntryIds = [
+      ...new Set((entryIds ?? []).filter((entryId) => !!entryId)),
+    ];
+    const createdResultCodes = [
+      ...new Set(
+        (payload.pendingToCreate ?? [])
+          .map((item) => this.normCode(item.resultCode))
+          .filter((code) => !!code),
+      ),
+    ];
+
+    const createRequests: Observable<unknown>[] = [];
     (payload.pendingToCreate ?? [])
       .filter((item) => !!item.resultCode)
       .forEach((item) => {
-        (entryIds ?? [])
-          .filter((entryId) => !!entryId)
-          .forEach((entryId) => {
-            createRequests.push(
-              this.entryResultsApi
-                .createApplicationListEntryResult({
-                  listId,
-                  entryId,
-                  resultCreateDto: {
-                    resultCode: item.resultCode.trim(),
-                    wordingFields: item.wordingFields ?? [],
-                  },
-                })
-                .pipe(
-                  map(
-                    (response): BulkResultChange => ({
-                      action: 'create',
-                      entryId,
-                      success: true,
-                      response,
-                    }),
-                  ),
-                  catchError((error: unknown) =>
-                    of<BulkResultChange>({
-                      action: 'create',
-                      entryId,
-                      success: false,
-                      error,
-                    }),
-                  ),
-                ),
-            );
-          });
+        if (selectedEntryIds.length === 0) {
+          return;
+        }
+
+        createRequests.push(
+          this.entryResultsApi.bulkResultApplicationListEntries({
+            listId,
+            bulkResultDto: {
+              entryIds: selectedEntryIds as unknown as Set<string>,
+              result: {
+                resultCode: item.resultCode.trim(),
+                wordingFields: item.wordingFields ?? [],
+              },
+            },
+          }),
+        );
       });
 
     const allRequests = [...updateRequests, ...createRequests];
@@ -202,29 +159,68 @@ export class ApplicationListEntryResultsFacade {
     }
 
     forkJoin(allRequests)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (results) => {
-          const successfulResponses = results
-            .filter((result) => result.success)
-            .map((result) => result.response);
-
-          this.mergeCreatedEntryResults(successfulResponses);
-
-          const hasCreateFailures = results.some(
-            (result) => result.action === 'create' && !result.success,
+      .pipe(
+        switchMap((results) => {
+          this.mergeCreatedEntryResults(
+            results.filter((result): result is ResultGetDto =>
+              this.isResultGetDto(result),
+            ),
           );
-          const hasCreateRequests = createRequests.length > 0;
 
-          if (hasCreateRequests && !hasCreateFailures) {
+          if (createRequests.length === 0) {
+            return of(false);
+          }
+
+          return this.getCreatedEntryResultsForEntries$(
+            listId,
+            selectedEntryIds,
+            createdResultCodes,
+          ).pipe(
+            map((createdResults) => {
+              this.mergeCreatedEntryResults(createdResults);
+              return true;
+            }),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: (hasCreateRequests) => {
+          if (hasCreateRequests) {
             this.clearPendingToken.update((n) => n + 1);
             this.pendingRows.set([]);
           }
 
-          onSuccess?.(results);
+          onSuccess?.();
         },
         error: (err) => onError?.(err),
       });
+  }
+
+  private getCreatedEntryResultsForEntries$(
+    listId: string,
+    entryIds: string[],
+    resultCodes: string[],
+  ): Observable<ResultGetDto[]> {
+    if (!listId || entryIds.length === 0 || resultCodes.length === 0) {
+      return of([]);
+    }
+
+    const resultCodeSet = new Set(resultCodes);
+
+    return forkJoin(
+      entryIds.map((entryId) =>
+        getEntryResults$(this.entryResultsApi, { listId, entryId }),
+      ),
+    ).pipe(
+      map((resultsByEntry) =>
+        resultsByEntry
+          .flat()
+          .filter((result) =>
+            resultCodeSet.has(this.normCode(result.resultCode)),
+          ),
+      ),
+    );
   }
 
   removeCreatedEntryResults(
@@ -578,5 +574,15 @@ export class ApplicationListEntryResultsFacade {
 
   private normalizedWordingTemplate(result: ResultGetDto): string {
     return (result.wording?.template ?? '').trim();
+  }
+
+  private isResultGetDto(value: unknown): value is ResultGetDto {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'id' in value &&
+      'entryId' in value &&
+      'resultCode' in value
+    );
   }
 }

--- a/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
+++ b/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
@@ -26,6 +26,16 @@ export type BulkResultRemoval =
       error: unknown;
     };
 
+type BulkResultUpdate =
+  | {
+      result: ResultGetDto;
+      success: true;
+    }
+  | {
+      error: unknown;
+      success: false;
+    };
+
 @Injectable()
 export class ApplicationListEntryResultsFacade {
   private readonly destroyRef = inject(DestroyRef);
@@ -88,7 +98,7 @@ export class ApplicationListEntryResultsFacade {
         .map((result) => [result.id, result]),
     );
 
-    const updateRequests: Observable<ResultGetDto>[] = [];
+    const updateRequests: Observable<BulkResultUpdate>[] = [];
     (payload.existingToUpdate ?? [])
       .filter((item) => !!item.resultId && !!item.resultCode)
       .forEach((item) => {
@@ -107,15 +117,30 @@ export class ApplicationListEntryResultsFacade {
             }
 
             updateRequests.push(
-              this.entryResultsApi.updateApplicationListEntryResult({
-                listId,
-                entryId: result.entryId,
-                resultId: result.id,
-                resultUpdateDto: {
-                  resultCode: item.resultCode.trim(),
-                  wordingFields: item.wordingFields ?? [],
-                },
-              }),
+              this.entryResultsApi
+                .updateApplicationListEntryResult({
+                  listId,
+                  entryId: result.entryId,
+                  resultId: result.id,
+                  resultUpdateDto: {
+                    resultCode: item.resultCode.trim(),
+                    wordingFields: item.wordingFields ?? [],
+                  },
+                })
+                .pipe(
+                  map(
+                    (updatedResult): BulkResultUpdate => ({
+                      result: updatedResult,
+                      success: true,
+                    }),
+                  ),
+                  catchError((error: unknown) =>
+                    of({
+                      error,
+                      success: false,
+                    } as BulkResultUpdate),
+                  ),
+                ),
             );
           });
       });
@@ -145,7 +170,7 @@ export class ApplicationListEntryResultsFacade {
         );
       });
 
-    const allRequests: Observable<ResultGetDto | ResultGetDto[]>[] = [
+    const allRequests: Observable<BulkResultUpdate | ResultGetDto[]>[] = [
       ...updateRequests,
       ...createRequests,
     ];
@@ -161,9 +186,19 @@ export class ApplicationListEntryResultsFacade {
             results.flatMap((result) => this.toResultGetDtos(result)),
           );
 
+          const failedUpdates = results.filter(
+            (result): result is Extract<BulkResultUpdate, { success: false }> =>
+              this.isBulkResultUpdate(result) && !result.success,
+          );
+
           if (createRequests.length > 0) {
             this.clearPendingToken.update((n) => n + 1);
             this.pendingRows.set([]);
+          }
+
+          if (failedUpdates.length > 0) {
+            onError?.(failedUpdates[0].error);
+            return;
           }
 
           onSuccess?.();
@@ -536,6 +571,10 @@ export class ApplicationListEntryResultsFacade {
   }
 
   private toResultGetDtos(value: unknown): ResultGetDto[] {
+    if (this.isBulkResultUpdate(value)) {
+      return value.success ? [value.result] : [];
+    }
+
     if (Array.isArray(value)) {
       return value.filter((item): item is ResultGetDto =>
         this.isResultGetDto(item),
@@ -543,5 +582,19 @@ export class ApplicationListEntryResultsFacade {
     }
 
     return this.isResultGetDto(value) ? [value] : [];
+  }
+
+  private isBulkResultUpdate(value: unknown): value is BulkResultUpdate {
+    if (typeof value !== 'object' || value === null || !('success' in value)) {
+      return false;
+    }
+
+    const update = value as Partial<BulkResultUpdate>;
+
+    if (update.success === true) {
+      return this.isResultGetDto(update.result);
+    }
+
+    return update.success === false && 'error' in value;
   }
 }

--- a/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
+++ b/src/app/shared/services/applications-list-entry/application-list-entry-results.facade.ts
@@ -1,6 +1,6 @@
 import { DestroyRef, Injectable, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of } from 'rxjs';
 
 import {
   ApplicationListEntryResultsApi,
@@ -123,15 +123,7 @@ export class ApplicationListEntryResultsFacade {
     const selectedEntryIds = [
       ...new Set((entryIds ?? []).filter((entryId) => !!entryId)),
     ];
-    const createdResultCodes = [
-      ...new Set(
-        (payload.pendingToCreate ?? [])
-          .map((item) => this.normCode(item.resultCode))
-          .filter((code) => !!code),
-      ),
-    ];
-
-    const createRequests: Observable<unknown>[] = [];
+    const createRequests: Observable<ResultGetDto[]>[] = [];
     (payload.pendingToCreate ?? [])
       .filter((item) => !!item.resultCode)
       .forEach((item) => {
@@ -153,40 +145,23 @@ export class ApplicationListEntryResultsFacade {
         );
       });
 
-    const allRequests = [...updateRequests, ...createRequests];
+    const allRequests: Observable<ResultGetDto | ResultGetDto[]>[] = [
+      ...updateRequests,
+      ...createRequests,
+    ];
     if (allRequests.length === 0) {
       return;
     }
 
     forkJoin(allRequests)
-      .pipe(
-        switchMap((results) => {
-          this.mergeCreatedEntryResults(
-            results.filter((result): result is ResultGetDto =>
-              this.isResultGetDto(result),
-            ),
-          );
-
-          if (createRequests.length === 0) {
-            return of(false);
-          }
-
-          return this.getCreatedEntryResultsForEntries$(
-            listId,
-            selectedEntryIds,
-            createdResultCodes,
-          ).pipe(
-            map((createdResults) => {
-              this.mergeCreatedEntryResults(createdResults);
-              return true;
-            }),
-          );
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (hasCreateRequests) => {
-          if (hasCreateRequests) {
+        next: (results) => {
+          this.mergeCreatedEntryResults(
+            results.flatMap((result) => this.toResultGetDtos(result)),
+          );
+
+          if (createRequests.length > 0) {
             this.clearPendingToken.update((n) => n + 1);
             this.pendingRows.set([]);
           }
@@ -195,32 +170,6 @@ export class ApplicationListEntryResultsFacade {
         },
         error: (err) => onError?.(err),
       });
-  }
-
-  private getCreatedEntryResultsForEntries$(
-    listId: string,
-    entryIds: string[],
-    resultCodes: string[],
-  ): Observable<ResultGetDto[]> {
-    if (!listId || entryIds.length === 0 || resultCodes.length === 0) {
-      return of([]);
-    }
-
-    const resultCodeSet = new Set(resultCodes);
-
-    return forkJoin(
-      entryIds.map((entryId) =>
-        getEntryResults$(this.entryResultsApi, { listId, entryId }),
-      ),
-    ).pipe(
-      map((resultsByEntry) =>
-        resultsByEntry
-          .flat()
-          .filter((result) =>
-            resultCodeSet.has(this.normCode(result.resultCode)),
-          ),
-      ),
-    );
   }
 
   removeCreatedEntryResults(
@@ -584,5 +533,15 @@ export class ApplicationListEntryResultsFacade {
       'entryId' in value &&
       'resultCode' in value
     );
+  }
+
+  private toResultGetDtos(value: unknown): ResultGetDto[] {
+    if (Array.isArray(value)) {
+      return value.filter((item): item is ResultGetDto =>
+        this.isResultGetDto(item),
+      );
+    }
+
+    return this.isResultGetDto(value) ? [value] : [];
   }
 }

--- a/test/unit/app/core/services/error-message.service.spec.ts
+++ b/test/unit/app/core/services/error-message.service.spec.ts
@@ -176,6 +176,20 @@ describe('ErrorMessageService', () => {
       expect(svc.errorMessage()?.status).toBe(415);
     });
 
+    it('treats bulk result endpoint failures as subscribed (no navigation)', () => {
+      const id = '123e4567-e89b-12d3-a456-426614174000';
+      const err = makeErr({
+        status: 409,
+        url: `https://local/application-lists/${id}/entries/results`,
+        error: { title: 'Conflict', status: 409 },
+      });
+
+      svc.handleErrorMessage(err);
+
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+      expect(svc.errorMessage()?.status).toBe(409);
+    });
+
     it('treats job polling endpoint failures as subscribed (no navigation)', () => {
       const id = '123e4567-e89b-12d3-a456-426614174000';
       const err = makeErr({

--- a/test/unit/app/pages/result-selected/result-selected.component.spec.ts
+++ b/test/unit/app/pages/result-selected/result-selected.component.spec.ts
@@ -3,7 +3,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import * as bannersUtil from '@components/applications-list-entry-detail/util/banners.util';
 import { ApplicationEntriesResultContext } from '@components/applications-list-entry-detail/util/routing-state-util';
@@ -13,7 +13,6 @@ import { ENTRY_SUCCESS_MESSAGES } from '@constants/application-list-entry/succes
 import { ApplicationListEntryResultsApi, ResultGetDto } from '@openapi';
 import {
   ApplicationListEntryResultsFacade,
-  BulkResultChange,
   BulkResultRemoval,
 } from '@services/applications-list-entry/application-list-entry-results.facade';
 import { PendingResultRow } from '@shared-types/result-code/result-code-row';
@@ -32,24 +31,22 @@ describe('ResultSelectedComponent', () => {
     },
   };
 
-  const makeResultDto = (id: string, seq?: number): ResultGetDto =>
-    ({
-      id,
-      sequenceNumber: seq,
-    }) as unknown as ResultGetDto;
-
   let mockApi: {
+    bulkResultApplicationListEntries: jest.Mock;
     createApplicationListEntryResult: jest.Mock;
     deleteApplicationListEntryResult: jest.Mock;
+    getApplicationListEntryResults: jest.Mock;
     updateApplicationListEntryResult: jest.Mock;
   };
 
   beforeEach(async () => {
     mockApi = {
-      createApplicationListEntryResult: jest
-        .fn()
-        .mockReturnValue(of(makeResultDto('x', 1))),
+      bulkResultApplicationListEntries: jest.fn().mockReturnValue(of(null)),
+      createApplicationListEntryResult: jest.fn().mockReturnValue(of(null)),
       deleteApplicationListEntryResult: jest.fn().mockReturnValue(of(null)),
+      getApplicationListEntryResults: jest
+        .fn()
+        .mockReturnValue(of({ content: [] })),
       updateApplicationListEntryResult: jest.fn().mockReturnValue(of(null)),
     };
 
@@ -218,18 +215,41 @@ describe('ResultSelectedComponent', () => {
     expect(component.isSubmitting()).toBe(false);
   });
 
-  it('onSubmitResults - partial-failure path: mixed results, error summary contains failing sequence, sets failure flag', () => {
-    component.listId = 'list-partial';
+  it('onSubmitResults sends one bulk request and shows success when it succeeds', () => {
+    component.listId = 'list-success';
+    const hydratedResult = {
+      id: 'result-1',
+      entryId: 'entry-1',
+      resultCode: 'ADJ',
+      wording: {
+        template: 'Adjourned',
+        'substitution-key-constraints': [],
+      },
+    } as ResultGetDto;
+    mockApi.getApplicationListEntryResults
+      .mockReturnValueOnce(
+        of({
+          content: [
+            hydratedResult,
+            {
+              id: 'result-2',
+              entryId: 'entry-1',
+              resultCode: 'OTHER',
+            },
+          ],
+        }),
+      )
+      .mockReturnValueOnce(of({ content: [] }));
     component.rows = [
       {
-        id: 'ok',
+        id: 'entry-1',
         sequenceNumber: '10',
         applicant: 'A',
         respondent: 'R',
         title: 'T',
       },
       {
-        id: 'bad',
+        id: 'entry-2',
         sequenceNumber: '20',
         applicant: 'B',
         respondent: 'S',
@@ -237,49 +257,9 @@ describe('ResultSelectedComponent', () => {
       },
     ] as ApplicationEntriesResultContext[];
 
-    const facadeInstance = (
-      component as unknown as {
-        resultsFacade: ApplicationListEntryResultsFacade;
-      }
-    ).resultsFacade;
-    const submitSpy = jest
-      .spyOn(facadeInstance, 'submitResultChangesForEntries')
-      .mockImplementation(
-        (
-          _listId,
-          _entryIds,
-          _payload,
-          onSuccess?: (results: BulkResultChange[]) => void,
-        ): void => {
-          onSuccess?.([
-            {
-              action: 'create',
-              entryId: 'ok',
-              success: true,
-              response: makeResultDto('ok-result', 10),
-            },
-            {
-              action: 'create',
-              entryId: 'bad',
-              success: false,
-              error: new HttpErrorResponse({
-                status: 500,
-                statusText: 'Server Error',
-              }),
-            },
-          ]);
-        },
-      );
-
-    const focusErrorSpy = jest
-      .spyOn(errorClick, 'focusErrorSummary')
-      .mockImplementation(() => {});
     const focusSuccessSpy = jest
       .spyOn(bannersUtil, 'focusSuccessBanner')
       .mockImplementation(() => {});
-
-    const errorSummarySetSpy = jest.spyOn(component.errorSummaryItems, 'set');
-    const successBannerSetSpy = jest.spyOn(component.successBanner, 'set');
 
     component.onSubmitResults({
       pendingToCreate: [
@@ -295,126 +275,141 @@ describe('ResultSelectedComponent', () => {
       existingToUpdate: [],
     } as ResultSectionSubmitPayload);
 
-    expect(submitSpy).toHaveBeenCalledWith(
-      'list-partial',
-      ['ok', 'bad'],
-      expect.any(Object),
-      expect.any(Function),
-      expect.any(Function),
-    );
-    expect(component.idToSequenceNumberMap).toEqual({ ok: '10', bad: '20' });
-
-    const batchResults = component.batchResults;
-    expect(batchResults).toHaveLength(2);
-
-    const okResult = batchResults.find((r) => r.entryId === 'ok');
-    const badResult = batchResults.find((r) => r.entryId === 'bad');
-
-    expect(okResult).toBeDefined();
-    expect(okResult?.success).toBe(true);
-
-    expect(badResult).toBeDefined();
-    expect(badResult?.success).toBe(false);
-
-    if (badResult && 'error' in badResult) {
-      expect(badResult.error).toBeInstanceOf(HttpErrorResponse);
-    } else {
-      fail('Expected failing BatchResult to contain an error property');
-    }
-
-    expect(errorSummarySetSpy).toHaveBeenCalledTimes(1);
-    const errorItemsArg = errorSummarySetSpy.mock.calls[0][0];
-    expect(errorItemsArg).toHaveLength(1);
-    expect(errorItemsArg[0].text).toContain(
-      'Sequence number 20 failed to update',
-    );
-
-    expect(successBannerSetSpy).toHaveBeenCalledWith(null);
+    expect(mockApi.bulkResultApplicationListEntries).toHaveBeenCalledTimes(1);
+    expect(mockApi.bulkResultApplicationListEntries).toHaveBeenCalledWith({
+      listId: 'list-success',
+      bulkResultDto: {
+        entryIds: ['entry-1', 'entry-2'],
+        result: {
+          resultCode: 'ADJ',
+          wordingFields: [],
+        },
+      },
+    });
+    expect(mockApi.createApplicationListEntryResult).not.toHaveBeenCalled();
+    expect(mockApi.getApplicationListEntryResults).toHaveBeenCalledTimes(2);
+    expect(component.createdEntryResults()).toEqual([hydratedResult]);
+    expect(component.errorSummaryItems()).toEqual([]);
+    expect(component.successBanner()).toEqual({
+      heading: 'Result codes applied successfully',
+      body: "Result code 'ADJ' applied successfully to application list entries",
+    });
     expect(component.isSubmitting()).toBe(false);
 
     const injectedPlatformId = TestBed.inject(PLATFORM_ID);
-    expect(focusErrorSpy).toHaveBeenCalledTimes(1);
-    expect(focusErrorSpy).toHaveBeenCalledWith(injectedPlatformId);
-
-    expect(focusErrorSpy).toHaveBeenCalledTimes(1);
     expect(focusSuccessSpy).toHaveBeenCalledTimes(1);
+    expect(focusSuccessSpy).toHaveBeenCalledWith(injectedPlatformId);
 
-    submitSpy.mockRestore();
-    focusErrorSpy.mockRestore();
     focusSuccessSpy.mockRestore();
   });
 
-  it('onSubmitResults - when an existing result for an entry exists it calls update API and treats response as success', () => {
-    component.listId = 'list-update';
+  it('onSubmitResults handles one bulk validation error and keeps pending data available', () => {
+    component.listId = 'list-error';
     component.rows = [
       {
-        id: 'r1',
-        sequenceNumber: '1',
-        applicant: 'Applicant 1',
-        respondent: 'Respondent 1',
-        title: 'Title 1',
+        id: 'entry-1',
+        sequenceNumber: '10',
+        applicant: 'A',
+        respondent: 'R',
+        title: 'T',
       },
     ] as ApplicationEntriesResultContext[];
 
-    const existingToUpdateItem = {
-      kind: 'existing',
-      id: 'real-result-id',
-      resultCode: 'UPD',
-      display: 'UPD - Updated',
-      wordingFields: [{ key: 'k-upd', value: 'v-upd' }],
-      wording: 'w-upd',
-    };
-
-    const payload: ResultSectionSubmitPayload = {
-      pendingToCreate: [],
-      existingToUpdate: [existingToUpdateItem],
-    } as unknown as ResultSectionSubmitPayload;
+    const pendingRow = {
+      kind: 'pending',
+      tempId: 'tmp_ebf79d63-080b-46fa-938a-f5d82874b234',
+      resultCode: 'ADJ',
+      display: 'ADJ - Adjourned',
+      wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+      wording: '-',
+    } as PendingResultRow;
 
     const facadeInstance = (
       component as unknown as {
         resultsFacade: ApplicationListEntryResultsFacade;
       }
     ).resultsFacade;
-    const submitSpy = jest
-      .spyOn(facadeInstance, 'submitResultChangesForEntries')
-      .mockImplementation(
-        (
-          _listId,
-          _entryIds,
-          _payload,
-          onSuccess?: (results: BulkResultChange[]) => void,
-        ): void => {
-          onSuccess?.([
-            {
-              action: 'update',
-              entryId: 'r1',
-              resultId: 'existing-result-123',
-              success: true,
-              response: makeResultDto('existing-result-123', 1),
+    component.onPendingChange([pendingRow]);
+
+    mockApi.bulkResultApplicationListEntries.mockReturnValueOnce(
+      throwError(
+        () =>
+          new HttpErrorResponse({
+            status: 400,
+            statusText: 'Bad Request',
+            error: {
+              title: 'Validation failed',
+              errors: {
+                resultCode: ['Result code is not valid for this list'],
+              },
             },
-          ]);
-        },
-      );
-
-    component.onSubmitResults(payload);
-
-    expect(submitSpy).toHaveBeenCalledWith(
-      'list-update',
-      ['r1'],
-      payload,
-      expect.any(Function),
-      expect.any(Function),
+          }),
+      ),
     );
 
-    expect(component.successBanner()).toEqual({
-      heading: 'Result codes applied successfully',
-      body: "Result code 'UPD' applied successfully to application list entries",
-    });
+    const focusErrorSpy = jest
+      .spyOn(errorClick, 'focusErrorSummary')
+      .mockImplementation(() => {});
 
-    expect(component.batchResults).toHaveLength(1);
-    expect(component.batchResults[0].entryId).toBe('r1');
-    expect(component.batchResults[0].success).toBe(true);
+    component.onSubmitResults({
+      pendingToCreate: [pendingRow],
+      existingToUpdate: [],
+    } as ResultSectionSubmitPayload);
 
+    expect(mockApi.bulkResultApplicationListEntries).toHaveBeenCalledTimes(1);
+    expect(mockApi.createApplicationListEntryResult).not.toHaveBeenCalled();
+    expect(mockApi.getApplicationListEntryResults).not.toHaveBeenCalled();
+    expect(component.successBanner()).toBeNull();
+    expect(component.errorHint).toBe('Validation failed');
+    expect(component.errorSummaryItems()).toEqual([
+      { text: 'Result code is not valid for this list' },
+    ]);
+    expect(component.isSubmitting()).toBe(false);
+    expect(facadeInstance.pendingRows()).toEqual([pendingRow]);
+
+    expect(focusErrorSpy).toHaveBeenCalledWith(TestBed.inject(PLATFORM_ID));
+
+    focusErrorSpy.mockRestore();
+  });
+
+  it('onSubmitResults ignores duplicate submissions while a bulk request is in flight', () => {
+    component.listId = 'list-submitting';
+    component.rows = [
+      {
+        id: 'entry-1',
+        sequenceNumber: '10',
+        applicant: 'A',
+        respondent: 'R',
+        title: 'T',
+      },
+    ] as ApplicationEntriesResultContext[];
+    component.isSubmitting.set(true);
+
+    const facadeInstance = (
+      component as unknown as {
+        resultsFacade: ApplicationListEntryResultsFacade;
+      }
+    ).resultsFacade;
+    const submitSpy = jest.spyOn(
+      facadeInstance,
+      'submitResultChangesForEntries',
+    );
+
+    component.onSubmitResults({
+      pendingToCreate: [
+        {
+          kind: 'pending',
+          tempId: 'tmp_ebf79d63-080b-46fa-938a-f5d82874b234',
+          resultCode: 'ADJ',
+          display: 'ADJ - Adjourned',
+          wordingFields: [],
+          wording: '-',
+        },
+      ],
+      existingToUpdate: [],
+    } as ResultSectionSubmitPayload);
+
+    expect(submitSpy).not.toHaveBeenCalled();
     submitSpy.mockRestore();
   });
 

--- a/test/unit/app/pages/result-selected/result-selected.component.spec.ts
+++ b/test/unit/app/pages/result-selected/result-selected.component.spec.ts
@@ -41,7 +41,7 @@ describe('ResultSelectedComponent', () => {
 
   beforeEach(async () => {
     mockApi = {
-      bulkResultApplicationListEntries: jest.fn().mockReturnValue(of(null)),
+      bulkResultApplicationListEntries: jest.fn().mockReturnValue(of([])),
       createApplicationListEntryResult: jest.fn().mockReturnValue(of(null)),
       deleteApplicationListEntryResult: jest.fn().mockReturnValue(of(null)),
       getApplicationListEntryResults: jest
@@ -217,7 +217,7 @@ describe('ResultSelectedComponent', () => {
 
   it('onSubmitResults sends one bulk request and shows success when it succeeds', () => {
     component.listId = 'list-success';
-    const hydratedResult = {
+    const createdResult = {
       id: 'result-1',
       entryId: 'entry-1',
       resultCode: 'ADJ',
@@ -226,20 +226,9 @@ describe('ResultSelectedComponent', () => {
         'substitution-key-constraints': [],
       },
     } as ResultGetDto;
-    mockApi.getApplicationListEntryResults
-      .mockReturnValueOnce(
-        of({
-          content: [
-            hydratedResult,
-            {
-              id: 'result-2',
-              entryId: 'entry-1',
-              resultCode: 'OTHER',
-            },
-          ],
-        }),
-      )
-      .mockReturnValueOnce(of({ content: [] }));
+    mockApi.bulkResultApplicationListEntries.mockReturnValueOnce(
+      of([createdResult]),
+    );
     component.rows = [
       {
         id: 'entry-1',
@@ -287,8 +276,8 @@ describe('ResultSelectedComponent', () => {
       },
     });
     expect(mockApi.createApplicationListEntryResult).not.toHaveBeenCalled();
-    expect(mockApi.getApplicationListEntryResults).toHaveBeenCalledTimes(2);
-    expect(component.createdEntryResults()).toEqual([hydratedResult]);
+    expect(mockApi.getApplicationListEntryResults).not.toHaveBeenCalled();
+    expect(component.createdEntryResults()).toEqual([createdResult]);
     expect(component.errorSummaryItems()).toEqual([]);
     expect(component.successBanner()).toEqual({
       heading: 'Result codes applied successfully',

--- a/test/unit/app/shared/components/result-wording-section/result-wording-section.component.spec.ts
+++ b/test/unit/app/shared/components/result-wording-section/result-wording-section.component.spec.ts
@@ -574,13 +574,12 @@ describe('ResultWordingSectionComponent', () => {
     ).toBe(true);
   });
 
-  it('clearPendingToken effect resets search when pendingVersion === appliedVersion', () => {
+  it('clearPendingToken effect resets search after a submitted pending row succeeds', () => {
     const pendingEmitSpy = jest.spyOn(component.pendingChange, 'emit');
 
-    // First complete one apply cycle so pendingVersion === appliedVersion.
     component.selectResultCode(codes[0]);
     component.onSaveResult();
-    expect(component.canSubmitResults()).toBe(false);
+    expect(component.canSubmitResults()).toBe(true);
 
     component.resultCodeSearch = 'something';
 

--- a/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
+++ b/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
@@ -35,8 +35,10 @@ function makeDetail(
 describe('ApplicationListEntryResultsFacade', () => {
   let facade: ApplicationListEntryResultsFacade;
   let entryResultsApi: {
+    bulkResultApplicationListEntries: jest.Mock;
     createApplicationListEntryResult: jest.Mock;
     deleteApplicationListEntryResult: jest.Mock;
+    getApplicationListEntryResults: jest.Mock;
     updateApplicationListEntryResult: jest.Mock;
   };
   let resultCodesApi: {
@@ -46,8 +48,12 @@ describe('ApplicationListEntryResultsFacade', () => {
 
   beforeEach(() => {
     entryResultsApi = {
+      bulkResultApplicationListEntries: jest.fn(() => of(null) as unknown),
       createApplicationListEntryResult: jest.fn(() => of(null) as unknown),
       deleteApplicationListEntryResult: jest.fn(() => of(null) as unknown),
+      getApplicationListEntryResults: jest.fn(
+        () => of({ content: [] }) as unknown,
+      ),
       updateApplicationListEntryResult: jest.fn(() => of(null) as unknown),
     };
     resultCodesApi = {
@@ -71,6 +77,10 @@ describe('ApplicationListEntryResultsFacade', () => {
     });
 
     facade = TestBed.inject(ApplicationListEntryResultsFacade);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('loadEntryResults', () => {
@@ -201,15 +211,32 @@ describe('ApplicationListEntryResultsFacade', () => {
   });
 
   describe('submitResultChangesForEntries', () => {
-    it('creates pending results for each selected entry and clears pending when all succeed', () => {
+    it('creates pending results with one bulk request, hydrates saved results, and clears pending when it succeeds', () => {
       const onSuccess = jest.fn();
-      entryResultsApi.createApplicationListEntryResult
-        .mockReturnValueOnce(of(makeResult({ id: 'R-10', entryId: 'E-1' })))
-        .mockReturnValueOnce(of(makeResult({ id: 'R-11', entryId: 'E-2' })));
+      const createdForEntry1 = makeResult({
+        id: 'R-10',
+        entryId: 'E-1',
+        resultCode: 'rc2',
+      });
+      const unrelatedForEntry1 = makeResult({
+        id: 'R-99',
+        entryId: 'E-1',
+        resultCode: 'OTHER',
+      });
+      const createdForEntry2 = makeResult({
+        id: 'R-11',
+        entryId: 'E-2',
+        resultCode: 'RC2',
+      });
+      entryResultsApi.getApplicationListEntryResults
+        .mockReturnValueOnce(
+          of({ content: [createdForEntry1, unrelatedForEntry1] }) as unknown,
+        )
+        .mockReturnValueOnce(of({ content: [createdForEntry2] }) as unknown);
 
       facade.submitResultChangesForEntries(
         'L-1',
-        ['E-1', 'E-2'],
+        ['E-1', 'E-2', 'E-1'],
         {
           pendingToCreate: [
             {
@@ -223,32 +250,100 @@ describe('ApplicationListEntryResultsFacade', () => {
       );
 
       expect(
-        entryResultsApi.createApplicationListEntryResult,
-      ).toHaveBeenNthCalledWith(1, {
+        entryResultsApi.bulkResultApplicationListEntries,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        entryResultsApi.bulkResultApplicationListEntries,
+      ).toHaveBeenCalledWith({
         listId: 'L-1',
-        entryId: 'E-1',
-        resultCreateDto: {
-          resultCode: 'rc2',
-          wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+        bulkResultDto: {
+          entryIds: ['E-1', 'E-2'],
+          result: {
+            resultCode: 'rc2',
+            wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+          },
         },
       });
       expect(
         entryResultsApi.createApplicationListEntryResult,
+      ).not.toHaveBeenCalled();
+      expect(
+        entryResultsApi.getApplicationListEntryResults,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        entryResultsApi.getApplicationListEntryResults,
+      ).toHaveBeenNthCalledWith(1, {
+        listId: 'L-1',
+        entryId: 'E-1',
+        pageNumber: 0,
+        pageSize: 100,
+      });
+      expect(
+        entryResultsApi.getApplicationListEntryResults,
       ).toHaveBeenNthCalledWith(2, {
         listId: 'L-1',
         entryId: 'E-2',
-        resultCreateDto: {
-          resultCode: 'rc2',
-          wordingFields: [{ key: 'Date', value: '2026-03-04' }],
-        },
+        pageNumber: 0,
+        pageSize: 100,
       });
       expect(facade.newlyCreatedEntryResults()).toEqual([
-        makeResult({ id: 'R-10', entryId: 'E-1' }),
-        makeResult({ id: 'R-11', entryId: 'E-2' }),
+        createdForEntry1,
+        createdForEntry2,
       ]);
       expect(facade.clearPendingToken()).toBe(1);
       expect(facade.pendingRows()).toEqual([]);
       expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it('keeps pending rows and calls onError when the bulk request fails', () => {
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+      const error = new Error('bulk failed');
+
+      facade.setPending([
+        {
+          resultCode: 'RC2',
+          wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+        } as PendingResultRow,
+      ]);
+      entryResultsApi.bulkResultApplicationListEntries.mockReturnValueOnce(
+        throwError(() => error),
+      );
+
+      facade.submitResultChangesForEntries(
+        'L-1',
+        ['E-1', 'E-2'],
+        {
+          pendingToCreate: [
+            {
+              resultCode: 'RC2',
+              wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+            } as PendingResultRow,
+          ],
+          existingToUpdate: [],
+        },
+        onSuccess,
+        onError,
+      );
+
+      expect(
+        entryResultsApi.bulkResultApplicationListEntries,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        entryResultsApi.createApplicationListEntryResult,
+      ).not.toHaveBeenCalled();
+      expect(
+        entryResultsApi.getApplicationListEntryResults,
+      ).not.toHaveBeenCalled();
+      expect(facade.clearPendingToken()).toBe(0);
+      expect(facade.pendingRows()).toEqual([
+        {
+          resultCode: 'RC2',
+          wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+        },
+      ]);
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(error);
     });
 
     it('updates tracked created results by resultId', () => {

--- a/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
+++ b/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
@@ -468,6 +468,60 @@ describe('ApplicationListEntryResultsFacade', () => {
       });
       expect(onSuccess).toHaveBeenCalled();
     });
+
+    it('merges successful looped updates and reports failed updates', () => {
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+      const error = new Error('update failed');
+      const originalResult1 = makeResult({
+        id: 'R-1',
+        entryId: 'E-1',
+        resultCode: 'RC1',
+      });
+      const originalResult2 = makeResult({
+        id: 'R-2',
+        entryId: 'E-2',
+        resultCode: 'RC1',
+      });
+      const updatedResult1 = makeResult({
+        id: 'R-1',
+        entryId: 'E-1',
+        resultCode: 'RC1',
+        wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+      });
+
+      facade.addCreatedEntryResults([originalResult1, originalResult2]);
+      entryResultsApi.updateApplicationListEntryResult
+        .mockReturnValueOnce(of(updatedResult1))
+        .mockReturnValueOnce(throwError(() => error));
+
+      facade.submitResultChangesForEntries(
+        'L-1',
+        ['E-1', 'E-2'],
+        {
+          pendingToCreate: [],
+          existingToUpdate: [
+            {
+              resultId: 'R-1',
+              resultCode: 'RC1',
+              wordingFields: [{ key: 'Date', value: '2026-03-04' }],
+            },
+          ],
+        },
+        onSuccess,
+        onError,
+      );
+
+      expect(
+        entryResultsApi.updateApplicationListEntryResult,
+      ).toHaveBeenCalledTimes(2);
+      expect(facade.newlyCreatedEntryResults()).toEqual([
+        updatedResult1,
+        originalResult2,
+      ]);
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(error);
+    });
   });
 
   describe('removeCreatedEntryResults', () => {

--- a/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
+++ b/test/unit/app/shared/services/application-list-entry-results.facade.spec.ts
@@ -48,7 +48,7 @@ describe('ApplicationListEntryResultsFacade', () => {
 
   beforeEach(() => {
     entryResultsApi = {
-      bulkResultApplicationListEntries: jest.fn(() => of(null) as unknown),
+      bulkResultApplicationListEntries: jest.fn(() => of([]) as unknown),
       createApplicationListEntryResult: jest.fn(() => of(null) as unknown),
       deleteApplicationListEntryResult: jest.fn(() => of(null) as unknown),
       getApplicationListEntryResults: jest.fn(
@@ -211,28 +211,21 @@ describe('ApplicationListEntryResultsFacade', () => {
   });
 
   describe('submitResultChangesForEntries', () => {
-    it('creates pending results with one bulk request, hydrates saved results, and clears pending when it succeeds', () => {
+    it('creates pending results with one bulk request, stores returned results, and clears pending when it succeeds', () => {
       const onSuccess = jest.fn();
       const createdForEntry1 = makeResult({
         id: 'R-10',
         entryId: 'E-1',
         resultCode: 'rc2',
       });
-      const unrelatedForEntry1 = makeResult({
-        id: 'R-99',
-        entryId: 'E-1',
-        resultCode: 'OTHER',
-      });
       const createdForEntry2 = makeResult({
         id: 'R-11',
         entryId: 'E-2',
         resultCode: 'RC2',
       });
-      entryResultsApi.getApplicationListEntryResults
-        .mockReturnValueOnce(
-          of({ content: [createdForEntry1, unrelatedForEntry1] }) as unknown,
-        )
-        .mockReturnValueOnce(of({ content: [createdForEntry2] }) as unknown);
+      entryResultsApi.bulkResultApplicationListEntries.mockReturnValueOnce(
+        of([createdForEntry1, createdForEntry2]) as unknown,
+      );
 
       facade.submitResultChangesForEntries(
         'L-1',
@@ -269,23 +262,7 @@ describe('ApplicationListEntryResultsFacade', () => {
       ).not.toHaveBeenCalled();
       expect(
         entryResultsApi.getApplicationListEntryResults,
-      ).toHaveBeenCalledTimes(2);
-      expect(
-        entryResultsApi.getApplicationListEntryResults,
-      ).toHaveBeenNthCalledWith(1, {
-        listId: 'L-1',
-        entryId: 'E-1',
-        pageNumber: 0,
-        pageSize: 100,
-      });
-      expect(
-        entryResultsApi.getApplicationListEntryResults,
-      ).toHaveBeenNthCalledWith(2, {
-        listId: 'L-1',
-        entryId: 'E-2',
-        pageNumber: 0,
-        pageSize: 100,
-      });
+      ).not.toHaveBeenCalled();
       expect(facade.newlyCreatedEntryResults()).toEqual([
         createdForEntry1,
         createdForEntry2,


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1293

### Change description

- Replaced per-entry result create calls with a single `POST /application-lists/{listId}/entries/results` request.
- Consumes the returned `ResultGetDto[]` from the bulk save to show newly applied result cards immediately.
- Removed the success-path GET fan-out that was temporarily hydrating saved results per entry.
- Keeps entered pending result data available when the bulk request fails.
- Preserves the existing result code search/selection UI and edit/remove behaviour.
- Updated unit tests to verify single bulk submission, no per-entry create calls, no readback loop, and success/error handling.


### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
