### PR TITLE
Fix application list entry API payloads

### DIFF
--- a/cypress/e2e/features/apiTests/Testdata.feature
+++ b/cypress/e2e/features/apiTests/Testdata.feature
@@ -216,8 +216,8 @@ Feature: API - Test Data Setup - 40 ALEs
             | applicant.person.contactDetails.mobile        | 07940{RANDOM}                   |
             | applicant.person.contactDetails.email         | applicant.e7.{RANDOM}@test.com  |
             | respondent.person.name.title                  | Mrs                             |
-            | respondent.person.name.surname                | Lewis {RANDOM}                  |
-            | respondent.person.name.firstForename          | Charlotte                       |
+            | respondent.person.name.lastName               | Lewis {RANDOM}                  |
+            | respondent.person.name.firstName              | Charlotte                       |
             | respondent.person.contactDetails.addressLine1 | {RANDOM} Abbey Road             |
             | respondent.person.contactDetails.addressLine2 | London                          |
             | respondent.person.contactDetails.postcode     | NW8 9AY                         |

--- a/cypress/e2e/features/apiTests/applicationListEntry.feature
+++ b/cypress/e2e/features/apiTests/applicationListEntry.feature
@@ -16,11 +16,10 @@ Feature: API - Application List Entry
           "applicant": {
               "person": {
                   "name": {
-                      "title": "Mr, Mrs",
-                      "surname": "Smith{RANDOM}",
-                      "firstForename": "John",
-                      "secondForename": "A",
-                      "thirdForename": "B"
+                      "title": "Mr",
+                      "firstName": "John",
+                      "middleName": "A B",
+                      "lastName": "Smith{RANDOM}"
                   },
                   "contactDetails": {
                       "addressLine1": "{RANDOM} High Street",
@@ -47,7 +46,15 @@ Feature: API - Application List Entry
           "caseReference": "CASE-001",
           "accountNumber": "APP-{RANDOM}",
           "notes": "Application discussion ref {RANDOM}",
-          "lodgementDate": "todayiso"
+          "lodgementDate": "todayiso",
+          "officials": [
+              {
+                  "title": "Mr",
+                  "surname": "Smith{RANDOM}",
+                  "forename": "John",
+                  "type": "MAGISTRATE"
+              }
+          ]
       }
       """
     Then User Verify Response Status Code Should Be "201"
@@ -77,11 +84,10 @@ Feature: API - Application List Entry
           "applicant": {
               "person": {
                   "name": {
-                      "title": "Mr, Mrs",
-                      "surname": "Smith{RANDOM}",
-                      "firstForename": "John",
-                      "secondForename": "A",
-                      "thirdForename": "B"
+                      "title": "Mr",
+                      "firstName": "John",
+                      "middleName": "A B",
+                      "lastName": "Smith{RANDOM}"
                   },
                   "contactDetails": {
                       "addressLine1": "{RANDOM} High Street",
@@ -111,7 +117,7 @@ Feature: API - Application List Entry
           "lodgementDate": "todayiso",
           "officials": [
               {
-                  "title": "Mr, Mrs",
+                  "title": "Mr",
                   "surname": "Smith{RANDOM}",
                   "forename": "John",
                   "type": "MAGISTRATE"
@@ -231,7 +237,7 @@ Feature: API - Application List Entry
       | standardApplicantCode                        | null                                |
       | applicationCode                              | AD99002                             |
       | applicant.person.name.title                  | Mr                                  |
-      | applicant.person.name.surname                | Smith {RANDOM}                      |
+      | applicant.person.name.lastName               | Smith {RANDOM}                      |
       | applicant.person.name.firstName              | John                                |
       | applicant.person.name.middleName             | A                                   |
       | applicant.person.contactDetails.addressLine1 | {RANDOM} High Street                |

--- a/cypress/e2e/features/regression/ApplicationsList/ApplicationsListRowActions.feature
+++ b/cypress/e2e/features/regression/ApplicationsList/ApplicationsListRowActions.feature
@@ -48,10 +48,9 @@ Feature: Application List Row Actions
                     "person": {
                         "name": {
                             "title": "Mr",
-                            "surname": "Taylor {RANDOM}",
-                            "firstForename": "Henry",
-                            "secondForename": "James",
-                            "thirdForename": null
+                            "firstName": "Henry",
+                            "middleName": "James",
+                            "lastName": "Taylor {RANDOM}"
                         },
                         "contactDetails": {
                             "addressLine1": "{RANDOM} King Street",
@@ -71,10 +70,9 @@ Feature: Application List Row Actions
                     "person": {
                         "name": {
                             "title": "Ms",
-                            "surname": "Clark {RANDOM}",
-                            "firstForename": "Emily",
-                            "secondForename": "Rose",
-                            "thirdForename": null
+                            "firstName": "Emily",
+                            "middleName": "Rose",
+                            "lastName": "Clark {RANDOM}"
                         },
                         "contactDetails": {
                             "addressLine1": "{RANDOM} Market Road",
@@ -142,10 +140,9 @@ Feature: Application List Row Actions
                     "person": {
                         "name": {
                             "title": "Mr",
-                            "surname": "Smith {RANDOM}",
-                            "firstForename": "John",
-                            "secondForename": "A",
-                            "thirdForename": "B"
+                            "firstName": "John",
+                            "middleName": "A B",
+                            "lastName": "Smith {RANDOM}"
                         },
                         "contactDetails": {
                             "addressLine1": "{RANDOM} High Street",

--- a/cypress/support/utils/ObjectBuilder.ts
+++ b/cypress/support/utils/ObjectBuilder.ts
@@ -5,9 +5,9 @@ export class ObjectBuilder {
   /**
    * Converts a flat object with dot-notation keys into a nested object structure
    * Example:
-   *   { "applicant.person.name.title": "Mr", "applicant.person.name.surname": "Smith" }
+   *   { "applicant.person.name.title": "Mr", "applicant.person.name.lastName": "Smith" }
    * becomes:
-   *   { applicant: { person: { name: { title: "Mr", surname: "Smith" } } } }
+   *   { applicant: { person: { name: { title: "Mr", lastName: "Smith" } } } }
    *
    * Also supports array notation:
    *   { "wordingFields.0.key": "Reference", "wordingFields.0.value": "123" }


### PR DESCRIPTION

### Change description

Updated failing regression tests following API contract changes to applicant name validation.

The staging API now expects applicant names in the format:

```json
{
  "name": {
    "firstName": "John",
    "middleName": "A B",
    "lastName": "Smith"
  }
}
```

The affected regression scenarios were still using legacy fields (`surname`, `firstForename`, `secondForename`, `thirdForename`) in direct API payloads, causing the API to return `400 Bad Request` instead of the expected `201 Created`.

The test data has been updated to use the current API contract.

### Testing done

* Executed affected Cypress regression scenarios locally.
* Verified Application List Entry creation scenarios now return `201 Created`.
* Confirmed previously failing nightly regression tests pass with updated test data.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

* [ ] Yes
* [x] No

### Checklist

* [x] commit messages are meaningful
* [ ] documentation has been updated (if needed)
* [x] tests have been updated/added (if needed)
* [ ] this PR introduces a breaking change
