### PR TITLE
Add Sonar verification to Codex repair loop

### DIFF
--- a/.github/scripts/codex-jira-verify.sh
+++ b/.github/scripts/codex-jira-verify.sh
@@ -188,6 +188,40 @@ format_verified_patch() {
   git_sanitized diff --cached --binary >"${patch_path}"
 }
 
+run_frontend_sonar_analysis() {
+  if [[ "${RUN_SONAR:-true}" != "true" ]]; then
+    echo "Skipping Sonar analysis because RUN_SONAR is not true."
+    return
+  fi
+
+  if [[ -z "${SONAR_TOKEN:-}" ]]; then
+    echo "::error::SONAR_TOKEN is required for Codex verification Sonar analysis." >&2
+    exit 1
+  fi
+
+  local sonar_host_url="${SONAR_HOST_URL:-https://sonarcloud.io}"
+  local sonar_organization="${SONAR_ORGANIZATION:-hmcts}"
+  local sonar_branch_name="${SONAR_BRANCH_NAME:-${branch_name}}"
+  local sonar_args=(
+    -Dproject.settings=sonar-project.properties
+    "-Dsonar.host.url=${sonar_host_url}"
+    "-Dsonar.branch.name=${sonar_branch_name}"
+  )
+
+  if [[ -n "${sonar_organization}" ]]; then
+    sonar_args+=("-Dsonar.organization=${sonar_organization}")
+  fi
+
+  ensure_frontend_formatter
+  echo "Generating frontend coverage for Sonar analysis."
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs test:coverage --runInBand
+
+  echo "Running Sonar analysis for Codex branch ${sonar_branch_name}."
+  run_sanitized env "SONAR_TOKEN=${SONAR_TOKEN}" \
+    node .yarn/releases/yarn-4.10.3.cjs \
+    dlx -p sonarqube-scanner sonar-scanner "${sonar_args[@]}"
+}
+
 mkdir -p "${artifact_dir}" "${sanitized_home}" "${sanitized_tmp}"
 
 branch_name="$(metadata_value branch_name)"
@@ -223,6 +257,8 @@ else
   verify_trusted_file "${trusted_pipeline_path}" "${trusted_pipeline_sha}" "pipeline wrapper"
   run_sanitized "${trusted_pipeline_path}" "${local_pipeline_mode}" --base "${default_branch}" --no-fetch
 fi
+
+run_frontend_sonar_analysis
 
 {
   echo "branch_name=${branch_name}"

--- a/.github/scripts/codex-pr-review-verify.sh
+++ b/.github/scripts/codex-pr-review-verify.sh
@@ -188,6 +188,41 @@ format_verified_patch() {
   git_sanitized diff --cached --binary >"${patch_path}"
 }
 
+run_frontend_sonar_analysis() {
+  if [[ "${RUN_SONAR:-true}" != "true" ]]; then
+    echo "Skipping Sonar analysis because RUN_SONAR is not true."
+    return
+  fi
+
+  if [[ -z "${SONAR_TOKEN:-}" ]]; then
+    echo "::error::SONAR_TOKEN is required for Codex review verification Sonar analysis." >&2
+    exit 1
+  fi
+
+  local sonar_host_url="${SONAR_HOST_URL:-https://sonarcloud.io}"
+  local sonar_organization="${SONAR_ORGANIZATION:-hmcts}"
+  local sonar_args=(
+    -Dproject.settings=sonar-project.properties
+    "-Dsonar.host.url=${sonar_host_url}"
+    "-Dsonar.pullrequest.key=${pr_number}"
+    "-Dsonar.pullrequest.branch=${head_ref}"
+    "-Dsonar.pullrequest.base=${base_ref:-master}"
+  )
+
+  if [[ -n "${sonar_organization}" ]]; then
+    sonar_args+=("-Dsonar.organization=${sonar_organization}")
+  fi
+
+  ensure_frontend_formatter
+  echo "Generating frontend coverage for Sonar analysis."
+  run_sanitized node .yarn/releases/yarn-4.10.3.cjs test:coverage --runInBand
+
+  echo "Running Sonar analysis for Codex review PR #${pr_number}."
+  run_sanitized env "SONAR_TOKEN=${SONAR_TOKEN}" \
+    node .yarn/releases/yarn-4.10.3.cjs \
+    dlx -p sonarqube-scanner sonar-scanner "${sonar_args[@]}"
+}
+
 mkdir -p "${artifact_dir}" "${sanitized_home}" "${sanitized_tmp}"
 
 has_changes="$(metadata_value has_changes)"
@@ -240,6 +275,8 @@ else
   verify_trusted_file "${trusted_pipeline_path}" "${trusted_pipeline_sha}" "pipeline wrapper"
   run_sanitized "${trusted_pipeline_path}" "${local_pipeline_mode}" --base "${base_ref:-master}" --no-fetch
 fi
+
+run_frontend_sonar_analysis
 
 {
   echo "has_changes=true"

--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -80,7 +80,7 @@ jobs:
     needs: codex-generate
     if: needs.codex-generate.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -94,6 +94,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-jira-output
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-0
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-0
@@ -110,6 +114,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex output
         uses: actions/download-artifact@v4
@@ -227,7 +237,7 @@ jobs:
     needs: [codex-generate, repair-codex-output-1]
     if: needs.repair-codex-output-1.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -241,6 +251,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-1
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-1
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-1
@@ -257,6 +271,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex output
         uses: actions/download-artifact@v4
@@ -374,7 +394,7 @@ jobs:
     needs: [codex-generate, repair-codex-output-2]
     if: needs.repair-codex-output-2.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -388,6 +408,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-2
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-2
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-2
@@ -404,6 +428,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex output
         uses: actions/download-artifact@v4
@@ -521,7 +551,7 @@ jobs:
     needs: [codex-generate, repair-codex-output-3]
     if: needs.repair-codex-output-3.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -535,6 +565,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-jira-output-repair-3
       CODEX_VERIFIED_ARTIFACT: codex-jira-verified-3
       CODEX_FAILURE_ARTIFACT: codex-jira-verification-failure-3
@@ -551,6 +585,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex output
         uses: actions/download-artifact@v4

--- a/.github/workflows/codex_pr_review_feedback.yml
+++ b/.github/workflows/codex_pr_review_feedback.yml
@@ -182,7 +182,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       passed: ${{ steps.verify.outputs.passed }}
       output_artifact: codex-review-output
@@ -194,6 +194,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-review-output
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-0
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-0
@@ -210,6 +214,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex review output
         uses: actions/download-artifact@v4
@@ -326,7 +336,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       passed: ${{ steps.verify.outputs.passed }}
       output_artifact: codex-review-output-repair-1
@@ -338,6 +348,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-1
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-1
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-1
@@ -354,6 +368,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex review output
         uses: actions/download-artifact@v4
@@ -470,7 +490,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       passed: ${{ steps.verify.outputs.passed }}
       output_artifact: codex-review-output-repair-2
@@ -482,6 +502,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-2
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-2
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-2
@@ -498,6 +522,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex review output
         uses: actions/download-artifact@v4
@@ -614,7 +644,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       passed: ${{ steps.verify.outputs.passed }}
       output_artifact: codex-review-output-repair-3
@@ -626,6 +656,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       LOCAL_PIPELINE_MODE: fast
       FRONTEND_FAST_COMMAND: yarn lint
+      RUN_SONAR: 'true'
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+      SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
       CODEX_OUTPUT_ARTIFACT: codex-review-output-repair-3
       CODEX_VERIFIED_ARTIFACT: codex-review-verified-3
       CODEX_FAILURE_ARTIFACT: codex-review-verification-failure-3
@@ -642,6 +676,12 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
 
       - name: Download Codex review output
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Jira link

N/A - Codex pilot workflow hardening.

### Change description

Adds Sonar analysis to the trusted Codex verification path before a Codex patch is published.

The Jira dispatch and PR review feedback verification jobs now expose the existing `SONAR_TOKEN` secret only in the no-write verification job, run Sonar after the local verification wrapper, and feed any Sonar failure into the existing Codex repair loop.

For Jira-triggered runs, Sonar is submitted against the generated Codex branch name because the PR does not exist yet. For PR review-feedback runs, Sonar is submitted with pull request metadata.

The frontend verification scripts generate Jest coverage for Sonar and run `sonar-scanner` through Yarn `dlx` against the existing `sonar-project.properties`; no package or lockfile changes are needed for the scanner.

### Testing done

- `bash -n .github/scripts/codex-jira-verify.sh .github/scripts/codex-pr-review-verify.sh`
- Workflow YAML parsed with Ruby `YAML.load_file`
- `node .yarn/releases/yarn-4.10.3.cjs prettier --check .github/workflows/codex_jira_dispatch.yml .github/workflows/codex_pr_review_feedback.yml`
- `node .yarn/releases/yarn-4.10.3.cjs dlx -p sonarqube-scanner sonar-scanner --help`
- `git diff --check`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
