### PR TITLE
Improve Codex frontend verification and Sonar flow

### DIFF
--- a/.github/scripts/codex-check-sonar-quality-gate.sh
+++ b/.github/scripts/codex-check-sonar-quality-gate.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+required_env "SONAR_TOKEN"
+required_env "SONAR_PROJECT_KEY"
+
+PR_NUMBER="${PR_NUMBER:-${SONAR_PR_NUMBER:-}}"
+required_env "PR_NUMBER"
+
+sonar_host_url="${SONAR_HOST_URL:-https://sonarcloud.io}"
+sonar_host_url="${sonar_host_url%/}"
+timeout_seconds="${SONAR_QUALITY_GATE_API_TIMEOUT_SECONDS:-120}"
+poll_seconds="${SONAR_QUALITY_GATE_API_POLL_SECONDS:-10}"
+deadline=$((SECONDS + timeout_seconds))
+
+sonar_get() {
+  local path="$1"
+  shift
+
+  curl -fsS -u "${SONAR_TOKEN}:" --get "$@" "${sonar_host_url}${path}"
+}
+
+quality_gate_status() {
+  local json_path="$1"
+
+  SONAR_JSON_PATH="${json_path}" python3 -I - <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(Path(os.environ["SONAR_JSON_PATH"]).read_text(encoding="utf-8"))
+print(payload.get("projectStatus", {}).get("status", ""))
+PY
+}
+
+print_quality_gate() {
+  local json_path="$1"
+
+  SONAR_JSON_PATH="${json_path}" python3 -I - <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(Path(os.environ["SONAR_JSON_PATH"]).read_text(encoding="utf-8"))
+project_status = payload.get("projectStatus", {})
+print(f"SonarCloud quality gate status: {project_status.get('status', 'UNKNOWN')}")
+for condition in project_status.get("conditions", []):
+    metric = condition.get("metricKey", "unknown")
+    status = condition.get("status", "UNKNOWN")
+    actual = condition.get("actualValue", "")
+    comparator = condition.get("comparator", "")
+    threshold = condition.get("errorThreshold", "")
+    detail = f" actual={actual}" if actual else ""
+    if comparator or threshold:
+        detail += f" threshold={comparator} {threshold}".rstrip()
+    print(f"- {metric}: {status}{detail}")
+PY
+}
+
+print_open_issues() {
+  local issues_path="$1"
+
+  SONAR_JSON_PATH="${issues_path}" python3 -I - <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(Path(os.environ["SONAR_JSON_PATH"]).read_text(encoding="utf-8"))
+issues = payload.get("issues", [])
+if not issues:
+    print("- No open issues returned by SonarCloud.")
+for issue in issues:
+    component = issue.get("component", "")
+    path = component.split(":", 1)[-1] if ":" in component else component
+    line = issue.get("line")
+    location = f"{path}:{line}" if line else path
+    severity = issue.get("severity") or issue.get("impactSeverity") or "UNKNOWN"
+    issue_type = issue.get("type", "UNKNOWN")
+    rule = issue.get("rule", "unknown-rule")
+    message = " ".join((issue.get("message") or "").split())
+    print(f"- [{severity} {issue_type}] {location} {rule}: {message}")
+PY
+}
+
+echo "Checking SonarCloud quality gate for PR #${PR_NUMBER} in project ${SONAR_PROJECT_KEY}."
+
+while true; do
+  quality_gate_json_path="$(mktemp)"
+
+  if sonar_get \
+    "/api/qualitygates/project_status" \
+    --data-urlencode "projectKey=${SONAR_PROJECT_KEY}" \
+    --data-urlencode "pullRequest=${PR_NUMBER}" \
+    >"${quality_gate_json_path}"; then
+    status="$(quality_gate_status "${quality_gate_json_path}")"
+    print_quality_gate "${quality_gate_json_path}"
+    rm -f "${quality_gate_json_path}"
+
+    case "${status}" in
+      OK)
+        echo "SonarCloud quality gate passed."
+        exit 0
+        ;;
+      ERROR)
+        echo "::error::SonarCloud quality gate failed for PR #${PR_NUMBER}."
+        issues_json_path="$(mktemp)"
+        if sonar_get \
+          "/api/issues/search" \
+          --data-urlencode "componentKeys=${SONAR_PROJECT_KEY}" \
+          --data-urlencode "pullRequest=${PR_NUMBER}" \
+          --data-urlencode "resolved=false" \
+          --data-urlencode "ps=50" \
+          >"${issues_json_path}"; then
+          echo
+          echo "Open SonarCloud issues for PR #${PR_NUMBER}:"
+          print_open_issues "${issues_json_path}"
+        else
+          echo "Unable to fetch open SonarCloud issues for PR #${PR_NUMBER}." >&2
+        fi
+        rm -f "${issues_json_path}"
+        exit 1
+        ;;
+    esac
+
+    echo "SonarCloud quality gate status '${status:-missing}' is not final yet."
+  else
+    rm -f "${quality_gate_json_path}"
+    echo "SonarCloud quality gate is not available yet."
+  fi
+
+  if ((SECONDS >= deadline)); then
+    echo "::error::Timed out waiting for SonarCloud quality gate for PR #${PR_NUMBER}."
+    exit 1
+  fi
+
+  sleep "${poll_seconds}"
+done

--- a/.github/scripts/codex-wait-pr-status.sh
+++ b/.github/scripts/codex-wait-pr-status.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+required_env "GH_TOKEN"
+required_env "GITHUB_REPOSITORY"
+required_env "PUBLISHED_COMMIT_SHA"
+
+PR_NUMBER="${PR_NUMBER:-${SONAR_PR_NUMBER:-}}"
+required_env "PR_NUMBER"
+
+status_context="${REQUIRED_STATUS_CONTEXT:-continuous-integration/jenkins/pr-head}"
+timeout_seconds="${REQUIRED_STATUS_TIMEOUT_SECONDS:-2700}"
+poll_seconds="${REQUIRED_STATUS_POLL_SECONDS:-30}"
+sonar_host_url="${SONAR_HOST_URL:-https://sonarcloud.io}"
+sonar_project_key="${SONAR_PROJECT_KEY:-}"
+deadline=$((SECONDS + timeout_seconds))
+
+gh_api() {
+  env -i \
+    "HOME=${HOME:-/tmp}" \
+    "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
+    "LANG=${LANG:-C.UTF-8}" \
+    "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
+    "TERM=${TERM:-xterm}" \
+    "GH_TOKEN=${GH_TOKEN}" \
+    gh api "$@"
+}
+
+status_field() {
+  local json_path="$1"
+  local field="$2"
+
+  STATUS_JSON_PATH="${json_path}" STATUS_CONTEXT="${status_context}" STATUS_FIELD="${field}" python3 -I - <<'PY'
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(Path(os.environ["STATUS_JSON_PATH"]).read_text(encoding="utf-8"))
+context = os.environ["STATUS_CONTEXT"]
+field = os.environ["STATUS_FIELD"]
+
+for status in payload.get("statuses", []):
+    if status.get("context") == context:
+        print(status.get(field) or "")
+        break
+PY
+}
+
+sonar_get() {
+  local path="$1"
+  local query="$2"
+
+  if [[ -z "${SONAR_TOKEN:-}" || -z "${sonar_project_key}" ]]; then
+    return 1
+  fi
+
+  curl -fsS -u "${SONAR_TOKEN}:" "${sonar_host_url}${path}?${query}"
+}
+
+print_sonar_diagnostics() {
+  if [[ -z "${SONAR_TOKEN:-}" || -z "${sonar_project_key}" ]]; then
+    echo "Sonar diagnostics skipped because SONAR_TOKEN or SONAR_PROJECT_KEY is not configured."
+    return
+  fi
+
+  echo
+  echo "SonarCloud quality gate for PR #${PR_NUMBER}:"
+  if quality_gate_json="$(sonar_get "/api/qualitygates/project_status" "projectKey=${sonar_project_key}&pullRequest=${PR_NUMBER}")"; then
+    SONAR_JSON="${quality_gate_json}" python3 -I - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SONAR_JSON"])
+project_status = payload.get("projectStatus", {})
+print(f"- Status: {project_status.get('status', 'UNKNOWN')}")
+for condition in project_status.get("conditions", []):
+    metric = condition.get("metricKey", "unknown")
+    status = condition.get("status", "UNKNOWN")
+    actual = condition.get("actualValue", "")
+    threshold = condition.get("errorThreshold", "")
+    comparator = condition.get("comparator", "")
+    detail = f" actual={actual}" if actual else ""
+    if threshold or comparator:
+        detail += f" threshold={comparator} {threshold}".rstrip()
+    print(f"- {metric}: {status}{detail}")
+PY
+  else
+    echo "- Unable to fetch SonarCloud quality gate."
+  fi
+
+  echo
+  echo "Open SonarCloud issues for PR #${PR_NUMBER} (first 20):"
+  if issues_json="$(
+    sonar_get \
+      "/api/issues/search" \
+      "componentKeys=${sonar_project_key}&pullRequest=${PR_NUMBER}&resolved=false&ps=20"
+  )"; then
+    SONAR_JSON="${issues_json}" python3 -I - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SONAR_JSON"])
+issues = payload.get("issues", [])
+if not issues:
+    print("- No open issues returned by SonarCloud.")
+for issue in issues:
+    component = issue.get("component", "")
+    path = component.split(":", 1)[-1] if ":" in component else component
+    line = issue.get("line")
+    location = f"{path}:{line}" if line else path
+    severity = issue.get("severity") or issue.get("impactSeverity") or "UNKNOWN"
+    issue_type = issue.get("type", "UNKNOWN")
+    rule = issue.get("rule", "unknown-rule")
+    message = " ".join((issue.get("message") or "").split())
+    print(f"- [{severity} {issue_type}] {location} {rule}: {message}")
+PY
+  else
+    echo "- Unable to fetch SonarCloud issues."
+  fi
+}
+
+echo "Waiting for required PR status '${status_context}' on ${GITHUB_REPOSITORY}@${PUBLISHED_COMMIT_SHA}."
+echo "PR: #${PR_NUMBER}; timeout: ${timeout_seconds}s; poll interval: ${poll_seconds}s."
+
+while true; do
+  status_json_path="$(mktemp)"
+  gh_api "repos/${GITHUB_REPOSITORY}/commits/${PUBLISHED_COMMIT_SHA}/status" >"${status_json_path}"
+
+  state="$(status_field "${status_json_path}" state)"
+  description="$(status_field "${status_json_path}" description)"
+  target_url="$(status_field "${status_json_path}" target_url)"
+
+  rm -f "${status_json_path}"
+
+  if [[ -z "${state}" ]]; then
+    echo "Required status '${status_context}' has not been created yet."
+  else
+    echo "Required status '${status_context}' is '${state}': ${description}"
+  fi
+
+  case "${state}" in
+    success)
+      echo "Required status passed: ${target_url}"
+      exit 0
+      ;;
+    failure | error)
+      echo "::error::Required status failed: ${status_context}=${state}"
+      echo "Description: ${description}"
+      echo "Target URL: ${target_url}"
+      print_sonar_diagnostics
+      exit 1
+      ;;
+  esac
+
+  if ((SECONDS >= deadline)); then
+    echo "::error::Timed out waiting for required status '${status_context}'."
+    echo "Last state: ${state:-missing}"
+    echo "Last description: ${description}"
+    echo "Last target URL: ${target_url}"
+    print_sonar_diagnostics
+    exit 1
+  fi
+
+  sleep "${poll_seconds}"
+done

--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -739,8 +739,13 @@ jobs:
       SONAR_TOKEN: ${{ secrets.CODEX_SONAR_TOKEN }}
       SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
       SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
+      SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY || 'appreg-frontend' }}
       SONAR_PR_NUMBER: ${{ needs.publish-pr.outputs.pr_number }}
       SONAR_PR_BASE: ${{ github.event.repository.default_branch }}
+      PUBLISHED_COMMIT_SHA: ${{ needs.publish-pr.outputs.commit_sha }}
+      REQUIRED_STATUS_CONTEXT: ${{ vars.CODEX_REQUIRED_STATUS_CONTEXT || 'continuous-integration/jenkins/pr-head' }}
+      REQUIRED_STATUS_TIMEOUT_SECONDS: ${{ vars.CODEX_REQUIRED_STATUS_TIMEOUT_SECONDS || '2700' }}
+      REQUIRED_STATUS_POLL_SECONDS: ${{ vars.CODEX_REQUIRED_STATUS_POLL_SECONDS || '30' }}
       CODEX_OUTPUT_ARTIFACT: ${{ needs.publish-pr.outputs.output_artifact }}
       CODEX_FAILURE_ARTIFACT: codex-jira-pr-verification-failure-0
 
@@ -781,7 +786,15 @@ jobs:
           OUTPUT_DIR: ${{ runner.temp }}/codex-output
         run: |
           set +e
-          ./.github/scripts/codex-jira-verify.sh >"$RUNNER_TEMP/codex-pr-verification.log" 2>&1
+          (
+            ./.github/scripts/codex-jira-verify.sh
+            status=$?
+            if [[ "${status}" -eq 0 ]]; then
+              ./.github/scripts/codex-wait-pr-status.sh
+              status=$?
+            fi
+            exit "${status}"
+          ) >"$RUNNER_TEMP/codex-pr-verification.log" 2>&1
           status=$?
           cat "$RUNNER_TEMP/codex-pr-verification.log"
           if [[ "${status}" -eq 0 ]]; then
@@ -1050,8 +1063,13 @@ jobs:
       SONAR_TOKEN: ${{ secrets.CODEX_SONAR_TOKEN }}
       SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
       SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION || 'hmcts' }}
+      SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY || 'appreg-frontend' }}
       SONAR_PR_NUMBER: ${{ needs.publish-published-pr-repair-1.outputs.pr_number }}
       SONAR_PR_BASE: ${{ github.event.repository.default_branch }}
+      PUBLISHED_COMMIT_SHA: ${{ needs.publish-published-pr-repair-1.outputs.commit_sha }}
+      REQUIRED_STATUS_CONTEXT: ${{ vars.CODEX_REQUIRED_STATUS_CONTEXT || 'continuous-integration/jenkins/pr-head' }}
+      REQUIRED_STATUS_TIMEOUT_SECONDS: ${{ vars.CODEX_REQUIRED_STATUS_TIMEOUT_SECONDS || '2700' }}
+      REQUIRED_STATUS_POLL_SECONDS: ${{ vars.CODEX_REQUIRED_STATUS_POLL_SECONDS || '30' }}
       CODEX_OUTPUT_ARTIFACT: ${{ needs.publish-published-pr-repair-1.outputs.output_artifact }}
 
     steps:
@@ -1085,6 +1103,7 @@ jobs:
           OUTPUT_DIR: ${{ runner.temp }}/codex-output
         run: |
           ./.github/scripts/codex-jira-verify.sh
+          ./.github/scripts/codex-wait-pr-status.sh
           echo "passed=true" >>"$GITHUB_OUTPUT"
 
   codex-published-pr-verification-failed:

--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -790,6 +790,10 @@ jobs:
             ./.github/scripts/codex-jira-verify.sh
             status=$?
             if [[ "${status}" -eq 0 ]]; then
+              ./.github/scripts/codex-check-sonar-quality-gate.sh
+              status=$?
+            fi
+            if [[ "${status}" -eq 0 ]]; then
               ./.github/scripts/codex-wait-pr-status.sh
               status=$?
             fi
@@ -1103,6 +1107,7 @@ jobs:
           OUTPUT_DIR: ${{ runner.temp }}/codex-output
         run: |
           ./.github/scripts/codex-jira-verify.sh
+          ./.github/scripts/codex-check-sonar-quality-gate.sh
           ./.github/scripts/codex-wait-pr-status.sh
           echo "passed=true" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Jira link

Not applicable. Internal Codex pilot workflow hardening.

### Change description

Updates the Codex Jira dispatch flow so post-PR verification waits for the actual Jenkins PR status after a Codex PR is opened or re-published.

Previously the workflow could complete its own Sonar step before Jenkins/SonarCloud reported the real required PR status. This meant a PR could fail the required `continuous-integration/jenkins/pr-head` check after the Codex repair loop had already skipped. The workflow now polls that required GitHub status context and feeds Jenkins/Sonar failure details into the existing Codex repair path.

### Testing done

- Ran shell syntax checks for the new wait script.
- Parsed the updated workflow YAML successfully.
- Ran `git diff --check`.
- Ran `actionlint` against `.github/workflows/codex_jira_dispatch.yml`.
- Ran Prettier against `.github/workflows/codex_jira_dispatch.yml`.
- Smoke-tested the new status poller against an existing frontend PR with a failing Jenkins status to confirm it exits non-zero and reports the Jenkins target URL.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
