### PR TITLE
ARCPOC-1422 SA/App code 404 handling in ALE, and lodgement date in app code search

### DIFF
--- a/src/app/core/services/error-message.service.ts
+++ b/src/app/core/services/error-message.service.ts
@@ -12,11 +12,24 @@ type EndpointRule = { endpoint: string | RegExp; responses: number[] };
 
 // Contains endpoints where errors are handled in their component
 const regexIdPlaceholder = '[0-9a-fA-F-]{36}';
+const referenceDataCodePlaceholder = '[^/]+';
 
 const subscribedEndpoints: EndpointRule[] = [
   { endpoint: '/application-lists', responses: [400, 403, 404, 406, 500, 504] },
   { endpoint: '/application-codes', responses: [400, 403, 406, 500, 504] },
 
+  {
+    endpoint: new RegExp(
+      `^/application-codes/${referenceDataCodePlaceholder}$`,
+    ),
+    responses: [404],
+  },
+  {
+    endpoint: new RegExp(
+      `^/standard-applicants/${referenceDataCodePlaceholder}$`,
+    ),
+    responses: [404],
+  },
   {
     endpoint: new RegExp(`^/application-codes/${regexIdPlaceholder}$`),
     responses: [400, 403, 413, 415, 500, 504],

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.html
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.html
@@ -64,10 +64,7 @@
     />
   } @else {
     @if (
-      codesRows.length === 0 &&
-      hasSearched() &&
-      form.valid &&
-      (form.value.code || form.value.title)
+      codesRows.length === 0 && hasSearched() && form.valid && hasSearchFilter()
     ) {
       <app-alert
         alertType="information"

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.ts
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.ts
@@ -170,8 +170,14 @@ export class ApplicationCodeSearchComponent implements OnInit {
 
     this.hasSearched.set(false);
 
-    const code = this.form.value.code?.trim() ?? '';
-    const title = this.form.value.title?.trim() ?? '';
+    const {
+      code: rawCode,
+      title: rawTitle,
+      lodgementDate: rawLodgementDate,
+    } = this.form.getRawValue();
+    const code = rawCode?.trim() ?? '';
+    const title = rawTitle?.trim() ?? '';
+    const lodgementDate = rawLodgementDate?.trim() ?? '';
 
     this.loading.set(true);
 
@@ -183,6 +189,7 @@ export class ApplicationCodeSearchComponent implements OnInit {
       {
         code: code || undefined,
         title: title || undefined,
+        date: lodgementDate || undefined,
         pageNumber: this.currentPage(),
         pageSize: this.pageSize(),
         sort: [`${apiSortKey},${sort.direction}`],
@@ -258,6 +265,11 @@ export class ApplicationCodeSearchComponent implements OnInit {
 
     const errors = this.getValidationErrors();
     return errors.find((error) => error.id === 'code')?.text ?? null;
+  }
+
+  hasSearchFilter(): boolean {
+    const { code, title, lodgementDate } = this.form.getRawValue();
+    return [code, title, lodgementDate].some((value) => !!value?.trim());
   }
 
   clear(options?: { emitEvent?: boolean }): void {

--- a/test/unit/app/core/services/error-message.service.spec.ts
+++ b/test/unit/app/core/services/error-message.service.spec.ts
@@ -104,6 +104,32 @@ describe('ErrorMessageService', () => {
       expect(svc.errorMessage()?.status).toBe(404);
     });
 
+    it('does not navigate for application code detail 404s with dated lookups', () => {
+      const err = makeErr({
+        status: 404,
+        url: 'https://local/application-codes/APP-100?date=1000-01-01',
+        error: { title: 'Not Found', status: 404 },
+      });
+
+      svc.handleErrorMessage(err);
+
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+      expect(svc.errorMessage()?.status).toBe(404);
+    });
+
+    it('does not navigate for standard applicant detail 404s with dated lookups', () => {
+      const err = makeErr({
+        status: 404,
+        url: 'https://local/standard-applicants/SA-123?date=1000-01-01',
+        error: { title: 'Not Found', status: 404 },
+      });
+
+      svc.handleErrorMessage(err);
+
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+      expect(svc.errorMessage()?.status).toBe(404);
+    });
+
     it('navigates to /forbidden for non-subscribed 403', () => {
       const err = makeErr({
         status: 403,

--- a/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
+++ b/test/unit/app/shared/components/application-codes-search/application-codes-search.component.spec.ts
@@ -77,7 +77,11 @@ describe('ApplicationCodeSearchComponent', () => {
       .spyOn(helpers, 'fetchCodeRows$')
       .mockReturnValue(of(mockRows));
 
-    component.form.patchValue({ code: ' MS99004 ', title: ' Statutory ' });
+    component.form.patchValue({
+      lodgementDate: '2024-01-01',
+      code: ' MS99004 ',
+      title: ' Statutory ',
+    });
 
     component.search();
 
@@ -88,6 +92,7 @@ describe('ApplicationCodeSearchComponent', () => {
       {
         code: 'MS99004',
         title: 'Statutory',
+        date: '2024-01-01',
         pageNumber: 0,
         pageSize: 10,
         sort: ['code,asc'],
@@ -106,6 +111,7 @@ describe('ApplicationCodeSearchComponent', () => {
 
     component.currentPage.set(3);
     component.pageSize.set(25);
+    component.form.patchValue({ lodgementDate: '2024-02-01' });
 
     component.search();
 
@@ -114,6 +120,7 @@ describe('ApplicationCodeSearchComponent', () => {
       {
         code: undefined,
         title: undefined,
+        date: '2024-02-01',
         pageNumber: 3,
         pageSize: 25,
         sort: ['code,asc'],
@@ -130,7 +137,11 @@ describe('ApplicationCodeSearchComponent', () => {
       }),
     );
 
-    component.form.patchValue({ code: null, title: null });
+    component.form.patchValue({
+      lodgementDate: '2024-03-01',
+      code: null,
+      title: null,
+    });
 
     component.search();
 
@@ -139,6 +150,7 @@ describe('ApplicationCodeSearchComponent', () => {
       {
         code: undefined,
         title: undefined,
+        date: '2024-03-01',
         pageNumber: 0,
         pageSize: 10,
         sort: ['code,asc'],
@@ -146,6 +158,28 @@ describe('ApplicationCodeSearchComponent', () => {
       true,
     );
     expect(component.codesRows).toEqual([]);
+  });
+
+  it('shows no-results message after a date-only search returns no rows', () => {
+    jest.spyOn(helpers, 'fetchCodeRows$').mockReturnValue(
+      of({
+        rows: [],
+        totalPages: 0,
+      }),
+    );
+
+    component.form.patchValue({
+      lodgementDate: '1000-01-01',
+      code: null,
+      title: null,
+    });
+
+    component.search();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'No application codes found',
+    );
   });
 
   it('search() should handle API error', () => {
@@ -200,6 +234,16 @@ describe('ApplicationCodeSearchComponent', () => {
 
     expect(component.codeError()).toBeNull();
     expect(errorsSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats lodgement date as a search filter for no-results display', () => {
+    component.form.patchValue({
+      lodgementDate: '1000-01-01',
+      code: null,
+      title: null,
+    });
+
+    expect(component.hasSearchFilter()).toBe(true);
   });
 
   it('onAddCode() should emit selectCodeAndLodgementDate when valid', () => {
@@ -333,7 +377,10 @@ describe('ApplicationCodeSearchComponent', () => {
       .mockReturnValue(of(mockRows));
 
     component.currentPage.set(4);
-    component.form.patchValue({ code: 'MS99004' });
+    component.form.patchValue({
+      lodgementDate: '2024-04-01',
+      code: 'MS99004',
+    });
 
     component.onSortChange({ key: 'title', direction: 'desc' });
 
@@ -344,6 +391,7 @@ describe('ApplicationCodeSearchComponent', () => {
       {
         code: 'MS99004',
         title: undefined,
+        date: '2024-04-01',
         pageNumber: 0,
         pageSize: 10,
         sort: ['title,desc'],
@@ -363,6 +411,26 @@ describe('ApplicationCodeSearchComponent', () => {
       apiMock,
       expect.objectContaining({
         sort: ['feeDue,asc'],
+      }),
+      true,
+    );
+  });
+
+  it('uses the lodgement date when searching in disabled mode', () => {
+    const fetchSpy = jest
+      .spyOn(helpers, 'fetchCodeRows$')
+      .mockReturnValue(of(mockRows));
+
+    componentRef.setInput('lodgementDateDisabled', true);
+    fixture.detectChanges();
+    component.form.controls.lodgementDate.setValue('2026-04-13');
+
+    component.search();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      apiMock,
+      expect.objectContaining({
+        date: '2026-04-13',
       }),
       true,
     );


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1422

### Change description

This PR updates application code search to include the ALE lodgement date when calling `GET /application-codes`, matching the new backend/OpenAPI support for date-effective filtering.

It also improves the no-results state so a date-only search, such as a historic lodgement date with no valid application codes, shows the existing “No application codes found” message instead of leaving the results area blank.

**Changes**

- Treats /application-codes/{code}?date=... 404s as component-handled.
- Treats /standard-applicants/{code}?date=... 404s as component-handled.
- Passes `lodgementDate` as the `date` query parameter for application code searches.
- Uses `getRawValue()` so disabled lodgement dates on ALE update are still included.
- Treats lodgement date as an application-code search filter for no-results display.
- Adds unit coverage for date-aware search, disabled-date update mode, and date-only no-results messaging.


### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
