### PR TITLE
Make Codex publish GitHub CLI auth explicit

### DIFF
--- a/.github/scripts/codex-jira-publish.sh
+++ b/.github/scripts/codex-jira-publish.sh
@@ -97,12 +97,16 @@ git_local() {
 gh_authenticated() {
   env -i \
     "HOME=${sanitized_home}" \
+    "XDG_CONFIG_HOME=${sanitized_home}/.config" \
+    "GH_CONFIG_DIR=${sanitized_home}/.config/gh" \
     "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
     "LANG=${LANG:-C.UTF-8}" \
     "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
     "TERM=${TERM:-xterm}" \
     "TMPDIR=${sanitized_tmp}" \
+    "GH_PROMPT_DISABLED=1" \
     "GH_TOKEN=${GH_TOKEN}" \
+    "GITHUB_TOKEN=${GH_TOKEN}" \
     gh "$@"
 }
 

--- a/.github/scripts/codex-merge-conflict-publish.sh
+++ b/.github/scripts/codex-merge-conflict-publish.sh
@@ -99,12 +99,16 @@ git_local() {
 gh_authenticated() {
   env -i \
     "HOME=${sanitized_home}" \
+    "XDG_CONFIG_HOME=${sanitized_home}/.config" \
+    "GH_CONFIG_DIR=${sanitized_home}/.config/gh" \
     "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
     "LANG=${LANG:-C.UTF-8}" \
     "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
     "TERM=${TERM:-xterm}" \
     "TMPDIR=${sanitized_tmp}" \
+    "GH_PROMPT_DISABLED=1" \
     "GH_TOKEN=${GH_TOKEN}" \
+    "GITHUB_TOKEN=${GH_TOKEN}" \
     gh "$@"
 }
 

--- a/.github/scripts/codex-pr-review-publish.sh
+++ b/.github/scripts/codex-pr-review-publish.sh
@@ -95,12 +95,16 @@ git_local() {
 gh_authenticated() {
   env -i \
     "HOME=${sanitized_home}" \
+    "XDG_CONFIG_HOME=${sanitized_home}/.config" \
+    "GH_CONFIG_DIR=${sanitized_home}/.config/gh" \
     "PATH=${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" \
     "LANG=${LANG:-C.UTF-8}" \
     "LC_ALL=${LC_ALL:-${LANG:-C.UTF-8}}" \
     "TERM=${TERM:-xterm}" \
     "TMPDIR=${sanitized_tmp}" \
+    "GH_PROMPT_DISABLED=1" \
     "GH_TOKEN=${GH_TOKEN}" \
+    "GITHUB_TOKEN=${GH_TOKEN}" \
     gh "$@"
 }
 


### PR DESCRIPTION
### Jira link

N/A - Codex pilot workflow maintenance.

### Change description

Make GitHub CLI authentication explicit in the Codex publish scripts used by Jira dispatch, PR review feedback, and merge conflict resolution.

The publish jobs already pass the workflow token to Git for branch pushes. This change also exposes the same token to `gh` as both `GH_TOKEN` and `GITHUB_TOKEN`, disables interactive prompts, and gives `gh` an isolated config directory. This is intended to avoid publish failures where the branch push succeeds but `gh pr list` or `gh pr create` fails with a GraphQL authentication error.

### Testing done

- Ran `bash -n` over the changed publish scripts.
- Ran `git diff --check`.
- Confirmed the branch diff against `origin/master` only contains the intended publish-script auth changes.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful
- [x] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
