### PR TITLE
Fix existing result codes not showing in success banner

### DIFF
--- a/src/app/pages/result-selected/result-selected.component.ts
+++ b/src/app/pages/result-selected/result-selected.component.ts
@@ -145,7 +145,7 @@ export class ResultSelected implements OnInit {
       return;
     }
 
-    const item = payload.pendingToCreate ?? payload.existingToUpdate;
+    const item = [...payload.pendingToCreate, ...payload.existingToUpdate];
 
     if (item) {
       this.selectedResultCode.set(item.map((element) => element.resultCode));

--- a/test/unit/app/pages/result-selected/result-selected.component.spec.ts
+++ b/test/unit/app/pages/result-selected/result-selected.component.spec.ts
@@ -208,8 +208,8 @@ describe('ResultSelectedComponent', () => {
 
     component.onSubmitResults({
       pendingToCreate: [],
-      pendingToRemove: [],
-    } as unknown as ResultSectionSubmitPayload);
+      existingToUpdate: [],
+    } as ResultSectionSubmitPayload);
 
     expect(submitSpy).not.toHaveBeenCalled();
     expect(component.isSubmitting()).toBe(false);
@@ -270,7 +270,7 @@ describe('ResultSelectedComponent', () => {
         },
       ],
       existingToUpdate: [],
-    } as ResultSectionSubmitPayload);
+    });
 
     expect(mockApi.bulkResultApplicationListEntries).toHaveBeenCalledTimes(2);
     expect(mockApi.bulkResultApplicationListEntries).toHaveBeenCalledWith({


### PR DESCRIPTION
Fix result-selected case where if you save changes on an existing result code, the code doesn't show in the success banner