### PR TITLE
Fix parity workflow output path initialisation

### DIFF
--- a/.github/workflows/appreg_parity_check.yml
+++ b/.github/workflows/appreg_parity_check.yml
@@ -47,7 +47,6 @@ jobs:
       ISSUE_ASSIGNEE: ${{ inputs.assignee }}
       ISSUE_URL: ${{ inputs.issueUrl }}
       WORKFLOW_TYPE: ${{ inputs.workflowType }}
-      OUTPUT_DIR: ${{ runner.temp }}/parity-output
 
     steps:
       - name: Validate workflow type
@@ -56,6 +55,9 @@ jobs:
             echo "Unexpected workflowType: ${WORKFLOW_TYPE}" >&2
             exit 1
           fi
+
+      - name: Initialise workflow paths
+        run: echo "OUTPUT_DIR=${RUNNER_TEMP}/parity-output" >>"${GITHUB_ENV}"
 
       - name: Checkout default branch
         uses: actions/checkout@v5


### PR DESCRIPTION
### Jira link

See [ARCPOC-1419](https://tools.hmcts.net/jira/browse/ARCPOC-1419)

### Change description

Fixes the Apps Reg legacy parity workflow so GitHub can parse and dispatch it from Jira Automation.

The workflow previously used `${{ runner.temp }}` in job-level `env`, which GitHub rejects during `workflow_dispatch` parsing. This moves the parity output directory initialisation into a runtime shell step using `$RUNNER_TEMP` and writes it to `$GITHUB_ENV` for later steps.

### Testing done

- Parsed the workflow YAML locally.
- Ran Prettier against the frontend workflow file.
- Ran `git diff --check`.
- Confirmed the Azure Function logs showed GitHub dispatch was failing with workflow parse error: `Unrecognized named-value: 'runner'`.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
