### PR TITLE
remove lodgement date for update ale request

### DIFF
--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -303,10 +303,10 @@ export function buildEntryUpdateDtoFromForm(
     caseReference: detail.caseReference,
     accountNumber: detail.accountNumber,
     notes: detail.notes,
+    officials: detail.officials,
   };
 
-  // Reuse existing mapper to build a “patch”
-  const patch: Partial<EntryUpdateDto> = {
+  const patch = {
     ...buildEntryCreateDto(
       formValue,
       applicantPersonValue,
@@ -315,7 +315,9 @@ export function buildEntryUpdateDtoFromForm(
       respondentOrgValue,
     ),
     ...buildOfficialsFromFormValue(formValue),
-  };
+  } as Partial<EntryUpdateDto> & { lodgementDate?: string };
+
+  delete patch.lodgementDate;
 
   const dto: EntryUpdateDto = {
     ...base,
@@ -472,7 +474,6 @@ export function buildEntryUpdateDtoWithChange<K extends keyof EntryUpdateDto>(
   }
 
   const base: EntryUpdateDto = {
-    // full copy of current server state
     standardApplicantCode: detail.standardApplicantCode,
     applicationCode: detail.applicationCode,
     applicant: detail.applicant,
@@ -487,7 +488,7 @@ export function buildEntryUpdateDtoWithChange<K extends keyof EntryUpdateDto>(
     caseReference: detail.caseReference,
     accountNumber: detail.accountNumber,
     notes: detail.notes,
-    ...(detail as { officials?: Official[] }),
+    officials: detail.officials,
   };
 
   const dto: EntryUpdateDto = {

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -382,6 +382,53 @@ describe('applications-list entry form builders', () => {
         { key: 'Date', value: '2026-04-13' },
       ]);
     });
+
+    it('builds update payloads from an allowlist and excludes read-only detail fields', () => {
+      const dto = buildEntryUpdateDtoFromForm(
+        {
+          ...baseDetail,
+          id: 'ENTRY-1',
+          listId: 'LIST-1',
+          lodgementDate: '2025-01-01',
+          wording: {
+            template: 'At {{Court}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+            ],
+          },
+        } as EntryGetDetailDto,
+        {
+          applicantType: 'person',
+          standardApplicantCode: null,
+          applicationCode: 'APP-200',
+          lodgementDate: '2026-01-02',
+          respondentEntryType: 'person',
+          applicationNotes: {
+            notes: null,
+            caseReference: null,
+            accountReference: null,
+          },
+        } as never,
+        {
+          ...blankPerson,
+          firstName: 'John',
+          surname: 'Smith',
+          addressLine1: '1 Street',
+        } as never,
+        blankOrg as never,
+        blankPerson as never,
+        blankOrg as never,
+      );
+
+      const payload = dto as Record<string, unknown>;
+
+      expect(payload).not.toHaveProperty('lodgementDate');
+      expect(payload).not.toHaveProperty('id');
+      expect(payload).not.toHaveProperty('listId');
+      expect(payload).not.toHaveProperty('wording');
+      expect(payload.applicationCode).toBe('APP-200');
+      expect(payload.applicant).toBeDefined();
+    });
   });
 
   describe('respondentPersonToFormPatch', () => {
@@ -447,10 +494,50 @@ describe('applications-list entry form builders', () => {
       expect(dto.applicant?.person?.name?.firstName).toBe('Jane');
       expect('standardApplicantCode' in dto).toBe(false);
     });
+
+    it('does not copy read-only detail fields into partial update payloads', () => {
+      const dto = buildEntryUpdateDtoWithChange(
+        {
+          id: 'ENTRY-1',
+          listId: 'LIST-1',
+          applicationCode: 'APP-100',
+          lodgementDate: '2025-01-01',
+          wording: {
+            template: 'At {{Court}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+            ],
+          },
+          officials: [
+            {
+              type: 'CLERK',
+              forename: 'Clara',
+              surname: 'Clerk',
+            },
+          ],
+        } as unknown as EntryGetDetailDto,
+        'feeStatuses',
+        [],
+      );
+
+      const payload = dto as Record<string, unknown>;
+
+      expect(payload).not.toHaveProperty('lodgementDate');
+      expect(payload).not.toHaveProperty('id');
+      expect(payload).not.toHaveProperty('listId');
+      expect(payload).not.toHaveProperty('wording');
+      expect(payload.officials).toEqual([
+        {
+          type: 'CLERK',
+          forename: 'Clara',
+          surname: 'Clerk',
+        },
+      ]);
+    });
   });
 
   describe('buildEntryUpdateDtoForFeeChange', () => {
-    it('uses current applicationCode and lodgementDate from the form while preserving unrelated persisted fields', () => {
+    it('uses current applicationCode from the form while preserving unrelated persisted fields', () => {
       const dto = buildEntryUpdateDtoForFeeChange(
         {
           applicationCode: 'APP-100',
@@ -479,6 +566,9 @@ describe('applications-list entry form builders', () => {
       expect(dto.applicationCode).toBe('APP-200');
       expect(dto.notes).toBe('persisted note');
       expect(dto.applicant?.person?.name?.firstName).toBe('Jane');
+      expect(dto as Record<string, unknown>).not.toHaveProperty(
+        'lodgementDate',
+      );
     });
 
     it('prefers staged wordingFields from the form when building a fee-only update', () => {

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -1273,11 +1273,10 @@ describe('ApplicationsListEntryDetail', () => {
     const formSvc = TestBed.inject(ApplicationListEntryFormService);
 
     const dto: EntryUpdateDto = {
-      lodgementDate: '2025-11-01',
       applicationCode: 'APP-100',
       standardApplicantCode: 'SA-999',
       applicant: undefined,
-    } as unknown as EntryUpdateDto;
+    };
 
     jest.spyOn(formSvc, 'buildUpdateDto').mockReturnValue(dto);
 
@@ -1308,6 +1307,52 @@ describe('ApplicationsListEntryDetail', () => {
 
     expect(component['appListEntryDetailState']().successBanner?.heading).toBe(
       'Applicant updated',
+    );
+  });
+
+  it('onUpdateApplicant sends an update payload without lodgementDate or detail-only fields', () => {
+    component['entryDetail'] = {
+      id: 'EN-1',
+      listId: 'AL-1',
+      applicationCode: 'APP100',
+      numberOfRespondents: 0,
+      lodgementDate: '2025-11-01',
+      wording: {
+        template: 'At {{Court}}',
+        'substitution-key-constraints': [
+          { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+        ],
+      },
+    } as EntryGetDetailDto;
+
+    component['form'].patchValue({
+      applicantType: 'standard',
+      applicationCode: 'APP100',
+      lodgementDate: '2026-01-01',
+    });
+    component.onStandardApplicantCodeChanged('SA-999');
+    component['form'].controls.standardApplicantCode.setValue('SA-999', {
+      emitEvent: false,
+    });
+
+    mockUpdateApplicationListEntry.mockClear();
+
+    component.onUpdateApplicant();
+
+    expect(mockUpdateApplicationListEntry).toHaveBeenCalledTimes(1);
+
+    const updatePayload = mockUpdateApplicationListEntry.mock.calls[0][0]
+      .entryUpdateDto as Record<string, unknown>;
+
+    expect(updatePayload).not.toHaveProperty('lodgementDate');
+    expect(updatePayload).not.toHaveProperty('id');
+    expect(updatePayload).not.toHaveProperty('listId');
+    expect(updatePayload).not.toHaveProperty('wording');
+    expect(updatePayload).toEqual(
+      expect.objectContaining({
+        applicationCode: 'APP100',
+        standardApplicantCode: 'SA-999',
+      }),
     );
   });
 

--- a/test/unit/app/shared/services/application-list-entry-form.service.spec.ts
+++ b/test/unit/app/shared/services/application-list-entry-form.service.spec.ts
@@ -359,6 +359,7 @@ describe('ApplicationListEntryFormService', () => {
         },
       }),
     );
+    expect(dto as Record<string, unknown>).not.toHaveProperty('lodgementDate');
     expect(dto.applicant).toBeUndefined();
   });
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1424

### Change description
- Updated application list entry update mapping so PUT payloads reuse the existing create mapper but explicitly remove `lodgementDate` before sending.
- Kept `lodgementDate` display/read and create behaviour unchanged.
- Fixed partial update DTO construction for fee/offsite updates so it no longer spreads the full GET detail object into the PUT payload.
- Added regression tests proving update payloads do not include `lodgementDate` or other detail-only fields like `id`, `listId`, and `wording`.
- Verified focused unit coverage for mapper, form service, and entry detail component update flows.


<!-- Describe what changed and why. -->

### Testing done
manual and unit testing
<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
