### PR TITLE
ARCPOC-1462 adjust wording of applicant/respondent validation messages

### DIFF
--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -61,7 +61,11 @@ import { NotesSectionComponent } from '@components/notes-section/notes-section.c
 import { RespondentSectionComponent } from '@components/respondent-section/respondent-section.component';
 import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
 import { WordingSectionComponent } from '@components/wording-section/wording-section.component';
-import { ENTRY_ERROR_MESSAGES } from '@constants/application-list-entry/error-messages';
+import {
+  APPLICANT_ENTRY_ERROR_MESSAGES,
+  ENTRY_ERROR_MESSAGES,
+  RESPONDENT_ENTRY_ERROR_MESSAGES,
+} from '@constants/application-list-entry/error-messages';
 import {
   APPLICANT_ORG_ERROR_HREFS,
   APPLICANT_PERSON_ERROR_HREFS,
@@ -320,7 +324,7 @@ export class ApplicationsListEntryCreate implements OnInit {
 
       this.childErrors.applicant = buildFormErrorSummary(
         this.personForm,
-        ENTRY_ERROR_MESSAGES,
+        APPLICANT_ENTRY_ERROR_MESSAGES,
         { hrefs: APPLICANT_PERSON_ERROR_HREFS },
       );
       return;
@@ -332,7 +336,7 @@ export class ApplicationsListEntryCreate implements OnInit {
 
       this.childErrors.applicant = buildFormErrorSummary(
         this.organisationForm,
-        ENTRY_ERROR_MESSAGES,
+        APPLICANT_ENTRY_ERROR_MESSAGES,
         { hrefs: APPLICANT_ORG_ERROR_HREFS },
       );
       return;
@@ -354,7 +358,7 @@ export class ApplicationsListEntryCreate implements OnInit {
         respondentEntryType: this.form.controls.respondentEntryType.value,
         respondentPersonForm: this.forms.respondentPersonForm,
         respondentOrganisationForm: this.forms.respondentOrganisationForm,
-        errorMessages: ENTRY_ERROR_MESSAGES,
+        errorMessages: RESPONDENT_ENTRY_ERROR_MESSAGES,
         respondentPersonHrefs: RESPONDENT_PERSON_ERROR_HREFS,
         respondentOrganisationHrefs: RESPONDENT_ORG_ERROR_HREFS,
         respondentBulkControl: this.form.controls.numberOfRespondents,

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -26,7 +26,7 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { map } from 'rxjs';
+import { map, merge } from 'rxjs';
 
 import {
   ApplicationsListEntryCreateState,
@@ -191,6 +191,7 @@ export class ApplicationsListEntryCreate implements OnInit {
   ngOnInit(): void {
     this.appListEntryCreateState().id = this.route.snapshot.paramMap.get('id')!;
     this.bindApplicantTypeChanges();
+    this.bindRespondentValidationChanges();
     this.restoreNavigationState();
   }
 
@@ -386,7 +387,10 @@ export class ApplicationsListEntryCreate implements OnInit {
     return isRespondentRequired || respondentFormHasValues;
   }
 
-  private updateErrors(opts: { validateOtherSections: boolean }): void {
+  private updateErrors(opts: {
+    validateOtherSections: boolean;
+    focusSummary?: boolean;
+  }): void {
     // Full or partial validation
     if (opts.validateOtherSections) {
       this.updateApplicantErrors();
@@ -406,6 +410,7 @@ export class ApplicationsListEntryCreate implements OnInit {
 
     if (
       opts.validateOtherSections &&
+      opts.focusSummary !== false &&
       this.appListEntryCreateState().errorFound
     ) {
       focusErrorSummary(this.platformId);
@@ -580,6 +585,26 @@ export class ApplicationsListEntryCreate implements OnInit {
         // reset/rehydrate subforms + keep standardApplicantCode in sync
         this.formSvc.onApplicantTypeChanged(this.forms, t);
         this.formSvc.syncApplicantTypeState(this.forms, t);
+      });
+  }
+
+  private bindRespondentValidationChanges(): void {
+    merge(
+      this.form.controls.respondentEntryType.valueChanges,
+      this.form.controls.numberOfRespondents.valueChanges,
+      this.forms.respondentPersonForm.valueChanges,
+      this.forms.respondentOrganisationForm.valueChanges,
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (!this.appListEntryCreateState().submitted) {
+          return;
+        }
+
+        this.updateErrors({
+          validateOtherSections: true,
+          focusSummary: false,
+        });
       });
   }
 

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -30,7 +30,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { map } from 'rxjs';
+import { map, merge } from 'rxjs';
 
 import {
   ApplicationsListEntryDetailState,
@@ -319,6 +319,7 @@ export class ApplicationsListEntryDetail implements OnInit {
 
     // Watch applicantType changes
     this.bindApplicantTypeChanges();
+    this.bindRespondentValidationChanges();
 
     this.loadEntryAndPatchForm(listId, entryId, pr, state);
 
@@ -648,7 +649,7 @@ export class ApplicationsListEntryDetail implements OnInit {
     this.childErrors.respondent = [];
   }
 
-  private updateAllErrors(): void {
+  private updateAllErrors(opts: { focusSummary?: boolean } = {}): void {
     this.updateApplicantErrors();
     this.updateRespondentErrors();
 
@@ -665,7 +666,7 @@ export class ApplicationsListEntryDetail implements OnInit {
       errorFound,
     });
 
-    if (errorFound) {
+    if (errorFound && opts.focusSummary !== false) {
       focusErrorSummary(this.platformId);
     }
   }
@@ -1071,6 +1072,23 @@ export class ApplicationsListEntryDetail implements OnInit {
         // let the service reset the subforms + standard code
         this.formSvc.onApplicantTypeChanged(this.forms, t);
         this.formSvc.syncApplicantTypeState(this.forms, t);
+      });
+  }
+
+  private bindRespondentValidationChanges(): void {
+    merge(
+      this.form.controls.respondentEntryType.valueChanges,
+      this.form.controls.numberOfRespondents.valueChanges,
+      this.forms.respondentPersonForm.valueChanges,
+      this.forms.respondentOrganisationForm.valueChanges,
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (!this.appListEntryDetailState().formSubmitted) {
+          return;
+        }
+
+        this.updateAllErrors({ focusSummary: false });
       });
   }
 

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -80,7 +80,11 @@ import { TableColumn } from '@components/sortable-table/sortable-table.component
 import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
 import { SuccessBannerComponent } from '@components/success-banner/success-banner.component';
 import { WordingSectionComponent } from '@components/wording-section/wording-section.component';
-import { ENTRY_ERROR_MESSAGES } from '@constants/application-list-entry/error-messages';
+import {
+  APPLICANT_ENTRY_ERROR_MESSAGES,
+  ENTRY_ERROR_MESSAGES,
+  RESPONDENT_ENTRY_ERROR_MESSAGES,
+} from '@constants/application-list-entry/error-messages';
 import {
   APPLICANT_ORG_ERROR_HREFS,
   APPLICANT_PERSON_ERROR_HREFS,
@@ -586,7 +590,7 @@ export class ApplicationsListEntryDetail implements OnInit {
 
       this.childErrors.applicant = buildFormErrorSummary(
         this.personGroup,
-        UPDATE_ENTRY_ERROR_MESSAGES,
+        APPLICANT_ENTRY_ERROR_MESSAGES,
         { hrefs: APPLICANT_PERSON_ERROR_HREFS },
       );
       return;
@@ -598,7 +602,7 @@ export class ApplicationsListEntryDetail implements OnInit {
 
       this.childErrors.applicant = buildFormErrorSummary(
         this.organisationGroup,
-        UPDATE_ENTRY_ERROR_MESSAGES,
+        APPLICANT_ENTRY_ERROR_MESSAGES,
         { hrefs: APPLICANT_ORG_ERROR_HREFS },
       );
       return;
@@ -631,7 +635,7 @@ export class ApplicationsListEntryDetail implements OnInit {
         respondentEntryType: this.form.controls.respondentEntryType.value,
         respondentPersonForm: this.forms.respondentPersonForm,
         respondentOrganisationForm: this.forms.respondentOrganisationForm,
-        errorMessages: UPDATE_ENTRY_ERROR_MESSAGES,
+        errorMessages: RESPONDENT_ENTRY_ERROR_MESSAGES,
         respondentPersonHrefs: RESPONDENT_PERSON_ERROR_HREFS,
         respondentOrganisationHrefs: RESPONDENT_ORG_ERROR_HREFS,
         respondentBulkControl: this.form.controls.numberOfRespondents,

--- a/src/app/shared/constants/application-list-entry/error-messages.ts
+++ b/src/app/shared/constants/application-list-entry/error-messages.ts
@@ -176,6 +176,46 @@ export const ENTRY_ERROR_MESSAGES = {
   ...NUMBER_OF_RESPONDENT_MESSAGES,
 } as const;
 
+export const APPLICANT_ENTRY_ERROR_MESSAGES = {
+  ...ENTRY_ERROR_MESSAGES,
+  firstName: {
+    ...ENTRY_ERROR_MESSAGES.firstName,
+    required: 'Enter applicant first name',
+  },
+  surname: {
+    ...ENTRY_ERROR_MESSAGES.surname,
+    required: 'Enter applicant last name',
+  },
+  addressLine1: {
+    ...ENTRY_ERROR_MESSAGES.addressLine1,
+    required: 'Enter applicant address line 1',
+  },
+  name: {
+    ...ENTRY_ERROR_MESSAGES.name,
+    required: 'Enter applicant organisation name',
+  },
+} as const;
+
+export const RESPONDENT_ENTRY_ERROR_MESSAGES = {
+  ...ENTRY_ERROR_MESSAGES,
+  firstName: {
+    ...ENTRY_ERROR_MESSAGES.firstName,
+    required: 'Enter respondent first name',
+  },
+  surname: {
+    ...ENTRY_ERROR_MESSAGES.surname,
+    required: 'Enter respondent last name',
+  },
+  addressLine1: {
+    ...ENTRY_ERROR_MESSAGES.addressLine1,
+    required: 'Enter respondent address line 1',
+  },
+  name: {
+    ...ENTRY_ERROR_MESSAGES.name,
+    required: 'Enter respondent organisation name',
+  },
+} as const;
+
 export const SEARCH_ERROR_MESSAGES = {
   sequenceNumber: {
     pattern: 'Sequence number must only contain numbers',

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -80,6 +80,42 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     expect(component.vm().summaryErrors.length).toBeGreaterThan(0);
   });
 
+  it('onSubmit: identifies applicant and respondent person required errors in the summary', () => {
+    (
+      component as unknown as {
+        appListEntryCreatePatch: (patch: Record<string, unknown>) => void;
+      }
+    ).appListEntryCreatePatch({
+      appCodeDetail: { requiresRespondent: true },
+    });
+
+    component.form.patchValue({
+      applicationCode: 'A001',
+      lodgementDate: '2026-02-01',
+      applicantType: 'person',
+      respondentEntryType: 'person',
+    });
+
+    component.onSubmit(new Event('submit'));
+
+    expect(createApplicationListEntryMock).not.toHaveBeenCalled();
+    expect(component.vm().errorFound).toBe(true);
+    expect(component.vm().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'firstName',
+          text: 'Enter applicant first name',
+          href: '#applicant-person-first-name',
+        }),
+        expect.objectContaining({
+          id: 'firstName',
+          text: 'Enter respondent first name',
+          href: '#respondent-person-first-name',
+        }),
+      ]),
+    );
+  });
+
   it('onSubmit: validates respondent when partially filled even if not required', () => {
     (
       component as unknown as {

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -166,6 +166,50 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     expect(component.respondentErrorItems).toEqual([]);
   });
 
+  it('updates respondent required messages when respondent becomes populated after submit', () => {
+    (
+      component as unknown as {
+        appListEntryCreatePatch: (patch: Record<string, unknown>) => void;
+      }
+    ).appListEntryCreatePatch({
+      appCodeDetail: { requiresRespondent: false },
+    });
+
+    component.form.patchValue({
+      applicationCode: '   ', // keep submit invalid while respondent is empty
+      respondentEntryType: 'person',
+      numberOfRespondents: null,
+    });
+    component.forms.respondentPersonForm.reset();
+    component.forms.respondentOrganisationForm.reset();
+
+    component.onSubmit(new Event('submit'));
+    expect(component.respondentErrorItems).toEqual([]);
+
+    component.forms.respondentPersonForm.patchValue({ firstName: 'Jane' });
+
+    expect(component.respondentSubmittedAndRequired).toBe(true);
+    expect(component.respondentErrorItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Enter respondent last name',
+          href: '#respondent-person-surname',
+        }),
+        expect.objectContaining({
+          text: 'Enter respondent address line 1',
+          href: '#respondent-person-address-line-1',
+        }),
+      ]),
+    );
+    expect(component.vm().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Enter respondent last name',
+        }),
+      ]),
+    );
+  });
+
   it('includes relayed standard applicant search errors in the parent summary', () => {
     component.form.patchValue({ applicantType: 'standard' });
     (

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -1414,6 +1414,47 @@ describe('ApplicationsListEntryDetail', () => {
     ).toBe(true);
   });
 
+  it('updates respondent required messages when respondent becomes populated after submit', () => {
+    component['forms'].respondentPersonForm.reset();
+    component['forms'].respondentOrganisationForm.reset();
+    component['form'].patchValue({
+      respondentEntryType: 'person',
+      numberOfRespondents: null,
+    });
+    component['appListEntryDetailPatch']({
+      appCodeDetail: {
+        requiresRespondent: false,
+      } as ApplicationCodeGetDetailDto,
+      formSubmitted: true,
+    });
+
+    expect(component.respondentErrorItems).toEqual([]);
+
+    component['forms'].respondentPersonForm.patchValue({
+      firstName: 'Jane',
+    });
+
+    expect(component.respondentErrorItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Enter respondent last name',
+          href: '#respondent-person-surname',
+        }),
+        expect.objectContaining({
+          text: 'Enter respondent address line 1',
+          href: '#respondent-person-address-line-1',
+        }),
+      ]),
+    );
+    expect(component['appListEntryDetailState']().summaryErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 'Enter respondent last name',
+        }),
+      ]),
+    );
+  });
+
   it('toEntryDetailPatch maps wordingFields to values and preserves other fields', () => {
     component['entryDetail'] = {
       wording: {

--- a/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.spec.ts
@@ -1259,10 +1259,10 @@ describe('ApplicationsListEntryDetail', () => {
     expect(applicantErrors.length).toBeGreaterThan(0);
 
     const hasFirstNameError = applicantErrors.some((e) =>
-      /Enter a first name/i.test(e.text),
+      /Enter applicant first name/i.test(e.text),
     );
     const hasSurnameError = applicantErrors.some((e) =>
-      /Enter a last name/i.test(e.text),
+      /Enter applicant last name/i.test(e.text),
     );
 
     expect(hasFirstNameError).toBe(true);
@@ -1409,7 +1409,7 @@ describe('ApplicationsListEntryDetail', () => {
 
     expect(
       component['appListEntryDetailState']().summaryErrors.some((e) =>
-        /organisation name/i.test(e.text),
+        /Enter respondent organisation name/i.test(e.text),
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1462

### Change description
- Added applicant/respondent-specific required validation messages for shared person and organisation fields.
- Updated ALE Create and ALE Update to use contextual applicant/respondent error message maps for child section validation.
- Improved ambiguous summary errors such as `Enter a first name` to messages like `Enter applicant first name` and `Enter respondent first name`.
- Added/updated unit coverage for create and update validation summaries, including duplicate applicant/respondent field names.
- Verified focused Jest specs: `2` suites passed, `110` tests passed.

<!-- Describe what changed and why. -->

### Testing done
Manual and unit testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
