### PR TITLE
remove dep from package json

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,16 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs
 
+packageExtensions:
+  '@angular-builders/jest@*':
+    peerDependenciesMeta:
+      '@angular/platform-browser-dynamic':
+        optional: true
+  'jest-preset-angular@*':
+    peerDependenciesMeta:
+      '@angular/platform-browser-dynamic':
+        optional: true
+
 npmScopes:
   appreg:
     npmRegistryServer: 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/'

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@angular/core": "^21.2.11",
     "@angular/forms": "^21.2.11",
     "@angular/platform-browser": "^21.2.11",
-    "@angular/platform-browser-dynamic": "^21.2.11",
     "@angular/platform-server": "^21.2.11",
     "@angular/router": "^21.2.11",
     "@angular/ssr": "^21.2.9",

--- a/setup.jest.ts
+++ b/setup.jest.ts
@@ -1,8 +1,41 @@
 import '@angular/compiler';
 import '@angular/common/locales/global/en-GB';
-import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+import 'zone.js';
+import 'zone.js/testing';
 
-setupZoneTestEnv();
+import {
+  COMPILER_OPTIONS,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
+import { TextDecoder, TextEncoder } from 'util';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+  globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
+}
+
+class TestModule {}
+
+NgModule({
+  providers: [provideZoneChangeDetection()],
+})(TestModule);
+
+getTestBed().initTestEnvironment(
+  [BrowserTestingModule, TestModule],
+  platformBrowserTesting([
+    {
+      provide: COMPILER_OPTIONS,
+      useValue: {},
+      multi: true,
+    },
+  ]),
+);
 
 // Mock govuk and moj frontend bundles so tests can run without dom errors
 // Shared in all tests so if we need specific behaviour then a local mock is needed

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,20 +565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/platform-browser-dynamic@npm:^21.2.11":
-  version: 21.2.17
-  resolution: "@angular/platform-browser-dynamic@npm:21.2.17"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/common": 21.2.17
-    "@angular/compiler": 21.2.17
-    "@angular/core": 21.2.17
-    "@angular/platform-browser": 21.2.17
-  checksum: 10/337eb2986bd580f9763129c8416988230f21262e3b755066ab429a873d4144c6935878f017b46b8705dd1ae22907bbf8f07de8f52632848b45da260c58c94f95
-  languageName: node
-  linkType: hard
-
 "@angular/platform-browser@npm:^21.2.11":
   version: 21.2.17
   resolution: "@angular/platform-browser@npm:21.2.17"
@@ -7785,7 +7771,6 @@ __metadata:
     "@angular/core": "npm:^21.2.11"
     "@angular/forms": "npm:^21.2.11"
     "@angular/platform-browser": "npm:^21.2.11"
-    "@angular/platform-browser-dynamic": "npm:^21.2.11"
     "@angular/platform-server": "npm:^21.2.11"
     "@angular/router": "npm:^21.2.11"
     "@angular/ssr": "npm:^21.2.9"


### PR DESCRIPTION
Removed @angular/platform-browser-dynamic as a resolved dependency from package.json and yarn.lock. I also updated setup.jest.ts to use Angular 21’s @angular/platform-browser/testing setup directly, since jest-preset-angular/setup-env/zone still imports the deprecated dynamic testing package.

Added a small Yarn package extension in .yarnrc.yml to mark that stale Jest peer as optional.