### PR TITLE
Fix vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "glob": "^13.0.1",
     "govuk-frontend": "^5.12.0",
     "helmet": "^7.0.0",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^3.0.7",
     "jspdf": "^4.2.0",
     "jspdf-autotable": "^5.0.2",
     "lodash": "^4.18.1",
@@ -211,7 +211,7 @@
     "@opentelemetry/core": "2.8.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "form-data": "4.0.6",
     "protobufjs": "8.6.3",
     "tar": "7.5.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7837,7 +7837,7 @@ __metadata:
     globals: "npm:^16.3.0"
     govuk-frontend: "npm:^5.12.0"
     helmet: "npm:^7.0.0"
-    http-proxy-middleware: "npm:^3.0.5"
+    http-proxy-middleware: "npm:^3.0.7"
     husky: "npm:^9.1.7"
     jest: "npm:^30.0.5"
     jest-axe: "npm:^10.0.0"
@@ -10118,15 +10118,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.4.10":
-  version: 3.4.10
-  resolution: "dompurify@npm:3.4.10"
+"dompurify@npm:3.4.11":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10/e051c70e7a0729d8cc04d40d7863dc8977495140857e81dc668fb548b7a43c7f80cfc973e3c9c0a6cd18b8eaa94ea7de9603daa02d38c8b15a9b32cc25a6f440
+  checksum: 10/d0473e1a22ed9cc23d86ef426717bce866913d1a725512a9478985bd917b272e0faba5f1d6ad8b2e37f3f4219206c4385162d7c984cfedcd23396e1e6ae0bc5e
   languageName: node
   linkType: hard
 
@@ -12525,9 +12525,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "http-proxy-middleware@npm:3.0.5"
+"http-proxy-middleware@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "http-proxy-middleware@npm:3.0.7"
   dependencies:
     "@types/http-proxy": "npm:^1.17.15"
     debug: "npm:^4.3.6"
@@ -12535,7 +12535,7 @@ __metadata:
     is-glob: "npm:^4.0.3"
     is-plain-object: "npm:^5.0.0"
     micromatch: "npm:^4.0.8"
-  checksum: 10/83c1956be6451a5f4a2f3c7b3d84085dbd47e1efb5bb684c1ed668a6606c18c7c07be823b0dbba1326955b64cf88de2672492940b0b48d140215fbdb06105c9a
+  checksum: 10/a44135de721e55517b0fca596855e1e4da92b5fdad247425b4253a345fface37b2a800fcfe37dc28863e9021d8c56cf9cb33ebd20d63c9eca6918a46b39082d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Vuln fixes:

├─ http-proxy-middleware: 3.0.5

09:49:53  │  ├─ ID: 1121165

09:49:53  │  ├─ Issue: http-proxy-middleware `router` host+path substring matching allows Host-header-driven backend routing bypass

09:49:53  │  ├─ URL: https://github.com/advisories/GHSA-64mm-vxmg-q3vj

09:49:53  │  ├─ Severity: moderate

09:49:53  │  ├─ Vulnerable Versions: >= 0.16.0, < 3.0.6

09:49:53  │  ├─ Patched Versions: 3.0.6

09:49:53  │  ├─ Via: appreg-frontend@workspace:.

09:49:53  │  └─ Recommendation: Upgrade to 3.0.6

09:49:53  │  └─ CVSS Score: Not Available

09:49:53  │  └─ CVSS Vector: Not Available

09:49:53  

09:49:53  ├─ http-proxy-middleware: 3.0.5

09:49:53  │  ├─ ID: 1121163

09:49:53  │  ├─ Issue: http-proxy-middleware: multipart/form-data field injection via unescaped CRLF in `fixRequestBody`

09:49:53  │  ├─ URL: https://github.com/advisories/GHSA-gcq2-9pq2-cxqm

09:49:53  │  ├─ Severity: high

09:49:53  │  ├─ Vulnerable Versions: >= 3.0.4, < 3.0.7

09:49:53  │  ├─ Patched Versions: 3.0.7

09:49:53  │  ├─ Via: appreg-frontend@workspace:.

09:49:53  │  └─ Recommendation: Upgrade to 3.0.7

09:49:53  │  └─ CVSS Score: 7.5

09:49:53  │  └─ CVSS Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:H/A:N

09:49:53  

09:49:53  ├─ dompurify: 3.4.10

09:49:53  │  ├─ ID: 1121192

09:49:53  │  ├─ Issue: DOMPurify: Permanent `ALLOWED_ATTR` pollution via `setConfig()` bypassing the hook clone-guard (incomplete fix of the 3.4.7 hook-pollution patch)

09:49:53  │  ├─ URL: https://github.com/advisories/GHSA-cmwh-pvxp-8882

09:49:53  │  ├─ Severity: moderate

09:49:53  │  ├─ Vulnerable Versions: <= 3.4.10

09:49:53  │  ├─ Patched Versions: 3.4.11

09:49:53  │  ├─ Via: jspdf@npm:4.2.1

09:49:53  │  └─ Recommendation: Upgrade to 3.4.11

09:49:53  │  └─ CVSS Score: Not Available

09:49:53  │  └─ CVSS Vector: Not Available