### PR TITLE
ARCPOC-1496 remove (s) from column headers

### DIFF
--- a/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationListEntriesBulkResultSelected.feature
+++ b/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationListEntriesBulkResultSelected.feature
@@ -340,7 +340,7 @@ Feature: Applications List  - Bulk Result Selected
         Then User See "Result applications" On The Page
         # Verify all 3 selected rows appear on the result page
         Then User Should See Row In Table "Application(s) to result" With Values:
-            | Sequence number | Applicant(s)           | Respondent(s)                  | Application Title(s)                           |
+            | Sequence number | Applicant              | Respondent                     | Application title                              |
             | 2               | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}           | Issue of liability order summons - council tax |
             | 3               | Sarah Johnson {RANDOM} | Greenfield Consulting {RANDOM} | Collection Order - Financial Penalty Account   |
             | 5               | James Brown {RANDOM}   | Laura Davis {RANDOM}           | Collection Order - Financial Penalty Account   |

--- a/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationListEntriesBulkUpdateOfficials.feature
+++ b/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationListEntriesBulkUpdateOfficials.feature
@@ -102,7 +102,7 @@ Feature: Application List Entries Bulk Update Officials
         When User Clicks "Actions" Then "Update officials" From Caption Menu In Table "Entries"
         Then User Sees Page Heading "Update officials"
         And User Should See Row In Table "Application(s) to update" With Values:
-            | Sequence number | Applicant(s)           | Respondent(s)         | Application Title(s)                           |
+            | Sequence number | Applicant              | Respondent            | Application title                              |
             | 1               | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}  | Issue of liability order summons - council tax |
             | 2               | Sarah Johnson {RANDOM} | Greenfield Consulting | Collection Order - Financial Penalty Account   |
         # Magistrate 1

--- a/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationsListMoveEntries.feature
+++ b/cypress/e2e/features/regression/ApplicationListEntriesActions/ApplicationsListMoveEntries.feature
@@ -126,7 +126,7 @@ Feature: Application List Entries - Move
         When User Clicks "Actions" Then "Move entries" From Caption Menu In Table "Entries"
         Then User See "Move applications" On The Page
         Then User Should See Row In Table "You are moving the following application(s)" With Values:
-            | Applicant(s)           | Respondent(s)                  | Application title                              | Fee required | Resulted |
+            | Applicant              | Respondent                     | Application title                              | Fee required | Resulted |
             | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}           | Issue of liability order summons - council tax | No           |          |
             | Sarah Johnson {RANDOM} | Greenfield Consulting {RANDOM} | Collection Order - Financial Penalty Account   | No           |          |
         When User Searches Application List With:
@@ -138,7 +138,7 @@ Feature: Application List Entries - Move
         # ── Move confirm page ───────────────────────────────────────────────────
         Then User See "Are you sure you want to move these applications to this application list?" On The Page
         Then User Should See Row In Table "You are moving the following application(s)" With Values:
-            | Applicant(s)           | Respondent(s)                  | Application title                              | Fee required | Resulted |
+            | Applicant              | Respondent                     | Application title                              | Fee required | Resulted |
             | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}           | Issue of liability order summons - council tax | No           |          |
             | Sarah Johnson {RANDOM} | Greenfield Consulting {RANDOM} | Collection Order - Financial Penalty Account   | No           |          |
         Then User Should See Row In Table "To this applications list" With Values:
@@ -282,7 +282,7 @@ Feature: Application List Entries - Move
         Then User See "Move applications" On The Page
         # Verify selected entries shown on Move page
         Then User Should See Row In Table "You are moving the following application(s)" With Values:
-            | Applicant(s)           | Respondent(s)                  | Application title                              | Fee required | Resulted |
+            | Applicant              | Respondent                     | Application title                              | Fee required | Resulted |
             | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}           | Issue of liability order summons - council tax | No           |          |
             | Sarah Johnson {RANDOM} | Greenfield Consulting {RANDOM} | Collection Order - Financial Penalty Account   | No           |          |
         # Navigate to Create new list form from Move page
@@ -316,7 +316,7 @@ Feature: Application List Entries - Move
         # ── Move confirm page ────────────────────────────────────────────────────
         Then User See "Are you sure you want to move these applications to this application list?" On The Page
         Then User Should See Row In Table "You are moving the following application(s)" With Values:
-            | Applicant(s)           | Respondent(s)                  | Application title                              | Fee required | Resulted |
+            | Applicant              | Respondent                     | Application title                              | Fee required | Resulted |
             | Henry Taylor {RANDOM}  | Emily Clark {RANDOM}           | Issue of liability order summons - council tax | No           |          |
             | Sarah Johnson {RANDOM} | Greenfield Consulting {RANDOM} | Collection Order - Financial Penalty Account   | No           |          |
         Then User Should See Row In Table "To this applications list" With Values:

--- a/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
+++ b/cypress/e2e/features/regression/ApplicationsListEntry/ALECreate.feature
@@ -202,7 +202,7 @@ Feature: Applications List Entry Create
     Then User Verifies The Textbox "Application details" Contains "This is a test application with special requirements" In The Accordion "Notes"
     # Result Wording Details
     Then User Should See Row In Table "You are resulting the following application(s)" In The Accordion "Result wording" With Values:
-      | Applicant(s)        | Respondent(s)     | Application title(s)       |
+      | Applicant           | Respondent        | Application title          |
       | John Smith {RANDOM} | Jane Doe {RANDOM} | Condemnation of Unfit Food |
     Then User Verifies The Textbox "Result code" In The Accordion "Result wording" Is Empty
     Then User Verifies The Button "Apply result" Is Disabled In The Accordion "Result wording"
@@ -356,7 +356,7 @@ Feature: Applications List Entry Create
     Then User Verifies The Textbox "Application details" Contains "This is a test application with special requirements" In The Accordion "Notes"
     # Result Wording Details
     Then User Should See Row In Table "You are resulting the following application(s)" In The Accordion "Result wording" With Values:
-      | Applicant(s)                                | Respondent(s)                         | Application title(s)                           |
+      | Applicant                                   | Respondent                            | Application title                              |
       | Test Sample Applicant Organisation {RANDOM} | Test Sample Res Organisation {RANDOM} | Issue of liability order summons - council tax |
     Then User Verifies The Button "Apply result" Is Disabled In The Accordion "Result wording"
     # Officials Details
@@ -486,7 +486,7 @@ Feature: Applications List Entry Create
     Then User Verifies The Textbox "Application details" Contains "This is a test application with special requirements" In The Accordion "Notes"
     # Result Wording Details
     Then User Should See Row In Table "You are resulting the following application(s)" In The Accordion "Result wording" With Values:
-      | Applicant(s) | Respondent(s) | Application title(s)                                       |
+      | Applicant    | Respondent    | Application title                                          |
       | Ava Johnson  |               | Request for Certificate of Refusal to State a Case (Civil) |
     Then User Verifies The Textbox "Result code" In The Accordion "Result wording" Is Empty
     Then User Verifies The Button "Apply result" Is Disabled In The Accordion "Result wording"

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.constants.ts
@@ -31,24 +31,24 @@ export const FEE_STATUS_OPTIONS = [
 
 export const APPLICATION_ENTRIES_RESULT_WORDING_COLUMNS = [
   { header: 'Sequence number', field: 'sequenceNumber' },
-  { header: 'Applicant(s)', field: 'applicant' },
-  { header: 'Respondent(s)', field: 'respondent' },
-  { header: 'Application Title(s)', field: 'title' },
+  { header: 'Applicant', field: 'applicant' },
+  { header: 'Respondent', field: 'respondent' },
+  { header: 'Application title', field: 'title' },
 ];
 
 export const APPLICATION_ENTRIES_MOVE_COLUMNS = [
-  { header: 'Applicant(s)', field: 'applicant' },
-  { header: 'Respondent(s)', field: 'respondent' },
+  { header: 'Applicant', field: 'applicant' },
+  { header: 'Respondent', field: 'respondent' },
   { header: 'Application title', field: 'title' },
   { header: 'Fee required', field: 'feeRequired' },
   { header: 'Resulted', field: 'resulted' },
 ];
 
 export const RESULT_WORDING_COLUMNS = [
-  { header: 'Applicant(s)', field: 'applicant' },
-  { header: 'Respondent(s)', field: 'respondent' },
+  { header: 'Applicant', field: 'applicant' },
+  { header: 'Respondent', field: 'respondent' },
   {
-    header: 'Application title(s)',
+    header: 'Application title',
     field: 'title',
     maxWidth: '25rem',
     wrap: true,


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1496


### Change description

- Updated selected-entry/result-wording table headers to remove parenthetical plurals: Applicant(s) → Applicant, Respondent(s) → Respondent.
- Updated Application Title(s) / Application title(s) to Application title for GDS sentence case.
- Updated affected Cypress regression feature assertions to match the new labels.
- Verified no stale exact label matches remain in src, test, or cypress.

### Testing done
Manual testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
