### PR TITLE
ARCPOC-377 Contextual help for components

### DIFF
--- a/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.html
+++ b/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.html
@@ -27,18 +27,37 @@
 
 <app-page-header title="Bulk Upload Applications" />
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text"> Help with bulk upload </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Use bulk upload to add applications to this list from a CSV file.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>The file must match the current bulk upload template.</li>
+      <li>The filename must end in .csv.</li>
+      <li>
+        After you upload the file, the applications list page shows the upload
+        progress.
+      </li>
+      <li>The file is validated before applications are added to the list.</li>
+      <li>
+        If the upload fails, the error message explains what needs to be
+        corrected.
+      </li>
+    </ul>
+  </div>
+</details>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      <strong>Select the bulk applications file you wish to upload.</strong>
+      Select the bulk applications file you wish to upload.
     </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        the file <strong>must</strong> match the current template for bulk
-        uploads.
-      </li>
-      <li>the filename must end in <strong>.csv</strong></li>
-    </ul>
 
     @if (!vm().isUploadInProgress) {
       <div class="govuk-form-group remove-bot-margin govuk-width-container">

--- a/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.html
+++ b/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.html
@@ -27,31 +27,25 @@
 
 <app-page-header title="Bulk Upload Applications" />
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text"> Help with bulk upload </span>
-  </summary>
+<app-help-details summary="Help with bulk upload">
+  <p class="govuk-body">
+    Use bulk upload to add applications to this list from a CSV file.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Use bulk upload to add applications to this list from a CSV file.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>The file must match the current bulk upload template.</li>
-      <li>The filename must end in .csv.</li>
-      <li>
-        After you upload the file, the applications list page shows the upload
-        progress.
-      </li>
-      <li>The file is validated before applications are added to the list.</li>
-      <li>
-        If the upload fails, the error message explains what needs to be
-        corrected.
-      </li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>The file must match the current bulk upload template.</li>
+    <li>The filename must end in .csv.</li>
+    <li>
+      After you upload the file, the applications list page shows the upload
+      progress.
+    </li>
+    <li>The file is validated before applications are added to the list.</li>
+    <li>
+      If the upload fails, the error message explains what needs to be
+      corrected.
+    </li>
+  </ul>
+</app-help-details>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.ts
+++ b/src/app/pages/applications-list-bulk-upload/applications-list-bulk-upload.component.ts
@@ -25,6 +25,7 @@ import {
 
 import { BreadcrumbsComponent } from '@components/breadcrumbs/breadcrumbs.component';
 import { ErrorSummaryComponent } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { LoadingSpinner } from '@components/loading-spinner/loading-spinner';
 import { PageHeaderComponent } from '@components/page-header/page-header.component';
 import {
@@ -43,6 +44,7 @@ import { createSignalState, setupLoadEffect } from '@util/signal-state-helpers';
     PageHeaderComponent,
     ErrorSummaryComponent,
     LoadingSpinner,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications-list-bulk-upload.component.html',
   styleUrl: './applications-list-bulk-upload.component.scss',

--- a/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
@@ -26,44 +26,36 @@
 
 <h1 class="govuk-heading-xl">Update fee details</h1>
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with civil fee details
-    </span>
-  </summary>
+<app-help-details summary="Help with civil fee details">
+  <p class="govuk-body">
+    Civil fee details record whether an application fee is due, paid, remitted
+    or covered by an undertaking.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Civil fee details record whether an application fee is due, paid, remitted
-      or covered by an undertaking.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Due means the fee still needs to be paid or resolved.</li>
-      <li>
-        Paid means the fee has been paid in full. You can add a payment
-        reference if needed.
-      </li>
-      <li>
-        Remitted means the court has waived the fee, for example through Help
-        with Fees.
-      </li>
-      <li>
-        Undertaking means the applicant has formally agreed to pay later. The
-        list cannot be closed until this is updated to Paid.
-      </li>
-      <li>
-        Applications that do not need a fee show No fee required and the fee
-        fields cannot be changed.
-      </li>
-      <li>
-        Select Off-site fee if an additional fee applies because a magistrate
-        attended a location away from court premises.
-      </li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Due means the fee still needs to be paid or resolved.</li>
+    <li>
+      Paid means the fee has been paid in full. You can add a payment reference
+      if needed.
+    </li>
+    <li>
+      Remitted means the court has waived the fee, for example through Help with
+      Fees.
+    </li>
+    <li>
+      Undertaking means the applicant has formally agreed to pay later. The list
+      cannot be closed until this is updated to Paid.
+    </li>
+    <li>
+      Applications that do not need a fee show No fee required and the fee
+      fields cannot be changed.
+    </li>
+    <li>
+      Select Off-site fee if an additional fee applies because a magistrate
+      attended a location away from court premises.
+    </li>
+  </ul>
+</app-help-details>
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"

--- a/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
@@ -26,6 +26,45 @@
 
 <h1 class="govuk-heading-xl">Update fee details</h1>
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with civil fee details
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Civil fee details record whether an application fee is due, paid, remitted
+      or covered by an undertaking.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Due means the fee still needs to be paid or resolved.</li>
+      <li>
+        Paid means the fee has been paid in full. You can add a payment
+        reference if needed.
+      </li>
+      <li>
+        Remitted means the court has waived the fee, for example through Help
+        with Fees.
+      </li>
+      <li>
+        Undertaking means the applicant has formally agreed to pay later. The
+        list cannot be closed until this is updated to Paid.
+      </li>
+      <li>
+        Applications that do not need a fee show No fee required and the fee
+        fields cannot be changed.
+      </li>
+      <li>
+        Select Off-site fee if an additional fee applies because a magistrate
+        attended a location away from court premises.
+      </li>
+    </ul>
+  </div>
+</details>
+
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.html
@@ -26,36 +26,7 @@
 
 <h1 class="govuk-heading-xl">Update fee details</h1>
 
-<app-help-details summary="Help with civil fee details">
-  <p class="govuk-body">
-    Civil fee details record whether an application fee is due, paid, remitted
-    or covered by an undertaking.
-  </p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>Due means the fee still needs to be paid or resolved.</li>
-    <li>
-      Paid means the fee has been paid in full. You can add a payment reference
-      if needed.
-    </li>
-    <li>
-      Remitted means the court has waived the fee, for example through Help with
-      Fees.
-    </li>
-    <li>
-      Undertaking means the applicant has formally agreed to pay later. The list
-      cannot be closed until this is updated to Paid.
-    </li>
-    <li>
-      Applications that do not need a fee show No fee required and the fee
-      fields cannot be changed.
-    </li>
-    <li>
-      Select Off-site fee if an additional fee applies because a magistrate
-      attended a location away from court premises.
-    </li>
-  </ul>
-</app-help-details>
+<app-civil-fee-help />
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"

--- a/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.ts
@@ -28,7 +28,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
-import { HelpDetailsComponent } from '@components/help-details/help-details.component';
+import { CivilFeeHelpComponent } from '@components/help-details/civil-fee-help.component';
 import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
 import { FeeStatus } from '@openapi';
 import {
@@ -62,7 +62,7 @@ type BulkUpdateFeeSnapshot = {
     SortableTableComponent,
     CivilFeeSectionComponent,
     AlertComponent,
-    HelpDetailsComponent,
+    CivilFeeHelpComponent,
   ],
   templateUrl: './applications-list-detail-bulk-update-fees.component.html',
 })

--- a/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail-bulk-update-fees/applications-list-detail-bulk-update-fees.component.ts
@@ -28,6 +28,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { SortableTableComponent } from '@components/sortable-table/sortable-table.component';
 import { FeeStatus } from '@openapi';
 import {
@@ -61,6 +62,7 @@ type BulkUpdateFeeSnapshot = {
     SortableTableComponent,
     CivilFeeSectionComponent,
     AlertComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications-list-detail-bulk-update-fees.component.html',
 })

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -153,6 +153,40 @@
     >
     </app-page-header>
 
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with applications
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Actions are applied to the entries selected in the table.
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            Result selected applies the same result to all selected entries.
+          </li>
+          <li>
+            Move entries moves the selected entries to another application list.
+          </li>
+          <li>
+            Update officials changes the recorded justice of peace or official
+            for selected entries.
+          </li>
+          <li>
+            Update fee details changes fee information for selected entries.
+          </li>
+          <li>
+            Print continuous prints all selected entries together as a court
+            list or register.
+          </li>
+          <li>Print page prints each selected entry starting on a new page.</li>
+        </ul>
+      </div>
+    </details>
     <hr
       class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
     />

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.html
@@ -153,40 +153,32 @@
     >
     </app-page-header>
 
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with applications
-        </span>
-      </summary>
+    <app-help-details summary="Help with applications">
+      <p class="govuk-body">
+        Actions are applied to the entries selected in the table.
+      </p>
 
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Actions are applied to the entries selected in the table.
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            Result selected applies the same result to all selected entries.
-          </li>
-          <li>
-            Move entries moves the selected entries to another application list.
-          </li>
-          <li>
-            Update officials changes the recorded justice of peace or official
-            for selected entries.
-          </li>
-          <li>
-            Update fee details changes fee information for selected entries.
-          </li>
-          <li>
-            Print continuous prints all selected entries together as a court
-            list or register.
-          </li>
-          <li>Print page prints each selected entry starting on a new page.</li>
-        </ul>
-      </div>
-    </details>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          Result selected applies the same result to all selected entries.
+        </li>
+        <li>
+          Move entries moves the selected entries to another application list.
+        </li>
+        <li>
+          Update officials changes the recorded justice of peace or official for
+          selected entries.
+        </li>
+        <li>
+          Update fee details changes fee information for selected entries.
+        </li>
+        <li>
+          Print continuous prints all selected entries together as a court list
+          or register.
+        </li>
+        <li>Print page prints each selected entry starting on a new page.</li>
+      </ul>
+    </app-help-details>
     <hr
       class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
     />

--- a/src/app/pages/applications-list-detail/applications-list-detail.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-detail.component.ts
@@ -53,6 +53,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NotificationBannerComponent } from '@components/notification-banner/notification-banner.component';
 import { PageHeaderComponent } from '@components/page-header/page-header.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
@@ -142,6 +143,7 @@ const APPLICATION_LIST_DETAIL_SORT_MAP: Record<string, string> = {
     MojButtonMenuDirective,
     ApplicationsListDetailSearchComponent,
     AsyncJobProgressComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications-list-detail.component.html',
   styleUrls: ['./applications-list-detail.component.scss'],

--- a/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.html
@@ -1,5 +1,29 @@
 <h2 class="govuk-heading-l">List details</h2>
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with application list details
+    </span>
+  </summary>
 
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      To close a list, change the status to Closed and save your changes.
+    </p>
+
+    <p class="govuk-body">A list can only be closed when:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>every application has at least one result</li>
+      <li>every application with a fee has a status of Paid or Remitted</li>
+      <li>
+        every application has at least one justice of the peace or official
+        recorded
+      </li>
+      <li>the list duration has been completed</li>
+    </ul>
+  </div>
+</details>
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.html
+++ b/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.html
@@ -1,29 +1,21 @@
 <h2 class="govuk-heading-l">List details</h2>
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with application list details
-    </span>
-  </summary>
+<app-help-details summary="Help with application list details">
+  <p class="govuk-body">
+    To close a list, change the status to Closed and save your changes.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      To close a list, change the status to Closed and save your changes.
-    </p>
+  <p class="govuk-body">A list can only be closed when:</p>
 
-    <p class="govuk-body">A list can only be closed when:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>every application has at least one result</li>
-      <li>every application with a fee has a status of Paid or Remitted</li>
-      <li>
-        every application has at least one justice of the peace or official
-        recorded
-      </li>
-      <li>the list duration has been completed</li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>every application has at least one result</li>
+    <li>every application with a fee has a status of Paid or Remitted</li>
+    <li>
+      every application has at least one justice of the peace or official
+      recorded
+    </li>
+    <li>the list duration has been completed</li>
+  </ul>
+</app-help-details>
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.ts
+++ b/src/app/pages/applications-list-detail/applications-list-update/applications-list-update.component.ts
@@ -25,6 +25,7 @@ import {
 import { ApplicationsListFormComponent } from '@components/applications-list-form/applications-list-form.component';
 import { SuggestionsFacade } from '@components/applications-list-form/facade/applications-list-form.facade';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { DETAIL_ERROR_ANCHORS } from '@constants/application-list-detail-update/error-hrefs';
 import {
   CLOSE_MESSAGES,
@@ -40,7 +41,12 @@ import { ApplicationListRow } from '@util/types/application-list/types';
 @Component({
   selector: 'app-applications-list-update',
   standalone: true,
-  imports: [FormsModule, ReactiveFormsModule, ApplicationsListFormComponent],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    ApplicationsListFormComponent,
+    HelpDetailsComponent,
+  ],
   templateUrl: './applications-list-update.component.html',
 })
 export class ApplicationsListUpdateComponent {

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -59,6 +59,21 @@
   </ng-template>
 
   <ng-template #wordingTpl>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with application wording
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Application wording is based on the selected application code and may
+          include fixed text and fields you need to complete.
+        </p>
+      </div>
+    </details>
+
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
         #wordingSection
@@ -89,6 +104,45 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with civil fee details
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Civil fee details record whether an application fee is due, paid,
+          remitted or covered by an undertaking.
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Due means the fee still needs to be paid or resolved.</li>
+          <li>
+            Paid means the fee has been paid in full. You can add a payment
+            reference if needed.
+          </li>
+          <li>
+            Remitted means the court has waived the fee, for example through
+            Help with Fees.
+          </li>
+          <li>
+            Undertaking means the applicant has formally agreed to pay later.
+            The list cannot be closed until this is updated to Paid.
+          </li>
+          <li>
+            Applications that do not need a fee show No fee required and the fee
+            fields cannot be changed.
+          </li>
+          <li>
+            Select Off-site fee if an additional fee applies because a
+            magistrate attended a location away from court premises.
+          </li>
+        </ul>
+      </div>
+    </details>
+
     <app-civil-fee-section
       #civilFeeSection
       [civilFeeColumns]="civilFeeColumns"

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -59,20 +59,12 @@
   </ng-template>
 
   <ng-template #wordingTpl>
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with application wording
-        </span>
-      </summary>
-
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Application wording is based on the selected application code and may
-          include fixed text and fields you need to complete.
-        </p>
-      </div>
-    </details>
+    <app-help-details summary="Help with application wording">
+      <p class="govuk-body">
+        Application wording is based on the selected application code and may
+        include fixed text and fields you need to complete.
+      </p>
+    </app-help-details>
 
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
@@ -104,44 +96,36 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with civil fee details
-        </span>
-      </summary>
+    <app-help-details summary="Help with civil fee details">
+      <p class="govuk-body">
+        Civil fee details record whether an application fee is due, paid,
+        remitted or covered by an undertaking.
+      </p>
 
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Civil fee details record whether an application fee is due, paid,
-          remitted or covered by an undertaking.
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Due means the fee still needs to be paid or resolved.</li>
-          <li>
-            Paid means the fee has been paid in full. You can add a payment
-            reference if needed.
-          </li>
-          <li>
-            Remitted means the court has waived the fee, for example through
-            Help with Fees.
-          </li>
-          <li>
-            Undertaking means the applicant has formally agreed to pay later.
-            The list cannot be closed until this is updated to Paid.
-          </li>
-          <li>
-            Applications that do not need a fee show No fee required and the fee
-            fields cannot be changed.
-          </li>
-          <li>
-            Select Off-site fee if an additional fee applies because a
-            magistrate attended a location away from court premises.
-          </li>
-        </ul>
-      </div>
-    </details>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Due means the fee still needs to be paid or resolved.</li>
+        <li>
+          Paid means the fee has been paid in full. You can add a payment
+          reference if needed.
+        </li>
+        <li>
+          Remitted means the court has waived the fee, for example through Help
+          with Fees.
+        </li>
+        <li>
+          Undertaking means the applicant has formally agreed to pay later. The
+          list cannot be closed until this is updated to Paid.
+        </li>
+        <li>
+          Applications that do not need a fee show No fee required and the fee
+          fields cannot be changed.
+        </li>
+        <li>
+          Select Off-site fee if an additional fee applies because a magistrate
+          attended a location away from court premises.
+        </li>
+      </ul>
+    </app-help-details>
 
     <app-civil-fee-section
       #civilFeeSection

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.html
@@ -59,12 +59,7 @@
   </ng-template>
 
   <ng-template #wordingTpl>
-    <app-help-details summary="Help with application wording">
-      <p class="govuk-body">
-        Application wording is based on the selected application code and may
-        include fixed text and fields you need to complete.
-      </p>
-    </app-help-details>
+    <app-application-wording-help />
 
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
@@ -96,36 +91,7 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
-    <app-help-details summary="Help with civil fee details">
-      <p class="govuk-body">
-        Civil fee details record whether an application fee is due, paid,
-        remitted or covered by an undertaking.
-      </p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Due means the fee still needs to be paid or resolved.</li>
-        <li>
-          Paid means the fee has been paid in full. You can add a payment
-          reference if needed.
-        </li>
-        <li>
-          Remitted means the court has waived the fee, for example through Help
-          with Fees.
-        </li>
-        <li>
-          Undertaking means the applicant has formally agreed to pay later. The
-          list cannot be closed until this is updated to Paid.
-        </li>
-        <li>
-          Applications that do not need a fee show No fee required and the fee
-          fields cannot be changed.
-        </li>
-        <li>
-          Select Off-site fee if an additional fee applies because a magistrate
-          attended a location away from court premises.
-        </li>
-      </ul>
-    </app-help-details>
+    <app-civil-fee-help />
 
     <app-civil-fee-section
       #civilFeeSection

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -57,6 +57,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NotesSectionComponent } from '@components/notes-section/notes-section.component';
 import { RespondentSectionComponent } from '@components/respondent-section/respondent-section.component';
 import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
@@ -121,6 +122,7 @@ const ENTRY_CREATE_ERROR_HREFS = {
     ApplicantSectionComponent,
     CivilFeeSectionComponent,
     RespondentSectionComponent,
+    HelpDetailsComponent,
   ],
   viewProviders: [
     { provide: ControlContainer, useExisting: FormGroupDirective },

--- a/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
+++ b/src/app/pages/applications-list-entry-create/applications-list-entry-create.component.ts
@@ -57,7 +57,8 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
-import { HelpDetailsComponent } from '@components/help-details/help-details.component';
+import { ApplicationWordingHelpComponent } from '@components/help-details/application-wording-help.component';
+import { CivilFeeHelpComponent } from '@components/help-details/civil-fee-help.component';
 import { NotesSectionComponent } from '@components/notes-section/notes-section.component';
 import { RespondentSectionComponent } from '@components/respondent-section/respondent-section.component';
 import { SelectedStandardApplicantSummary } from '@components/standard-applicant-select/standard-applicant-select.component';
@@ -122,7 +123,8 @@ const ENTRY_CREATE_ERROR_HREFS = {
     ApplicantSectionComponent,
     CivilFeeSectionComponent,
     RespondentSectionComponent,
-    HelpDetailsComponent,
+    ApplicationWordingHelpComponent,
+    CivilFeeHelpComponent,
   ],
   viewProviders: [
     { provide: ControlContainer, useExisting: FormGroupDirective },

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -66,6 +66,21 @@
   </ng-template>
 
   <ng-template #wordingTpl>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with application wording
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Application wording is based on the selected application code and may
+          include fixed text and fields you need to complete.
+        </p>
+      </div>
+    </details>
+
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
         #wordingSection
@@ -96,6 +111,45 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with civil fee details
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Civil fee details record whether an application fee is due, paid,
+          remitted or covered by an undertaking.
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Due means the fee still needs to be paid or resolved.</li>
+          <li>
+            Paid means the fee has been paid in full. You can add a payment
+            reference if needed.
+          </li>
+          <li>
+            Remitted means the court has waived the fee, for example through
+            Help with Fees.
+          </li>
+          <li>
+            Undertaking means the applicant has formally agreed to pay later.
+            The list cannot be closed until this is updated to Paid.
+          </li>
+          <li>
+            Applications that do not need a fee show No fee required and the fee
+            fields cannot be changed.
+          </li>
+          <li>
+            Select Off-site fee if an additional fee applies because a
+            magistrate attended a location away from court premises.
+          </li>
+        </ul>
+      </div>
+    </details>
+
     <app-civil-fee-section
       #civilFeeSection
       [civilFeeColumns]="civilFeeColumns"

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -66,20 +66,12 @@
   </ng-template>
 
   <ng-template #wordingTpl>
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with application wording
-        </span>
-      </summary>
-
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Application wording is based on the selected application code and may
-          include fixed text and fields you need to complete.
-        </p>
-      </div>
-    </details>
+    <app-help-details summary="Help with application wording">
+      <p class="govuk-body">
+        Application wording is based on the selected application code and may
+        include fixed text and fields you need to complete.
+      </p>
+    </app-help-details>
 
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
@@ -111,44 +103,36 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with civil fee details
-        </span>
-      </summary>
+    <app-help-details summary="Help with civil fee details">
+      <p class="govuk-body">
+        Civil fee details record whether an application fee is due, paid,
+        remitted or covered by an undertaking.
+      </p>
 
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Civil fee details record whether an application fee is due, paid,
-          remitted or covered by an undertaking.
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Due means the fee still needs to be paid or resolved.</li>
-          <li>
-            Paid means the fee has been paid in full. You can add a payment
-            reference if needed.
-          </li>
-          <li>
-            Remitted means the court has waived the fee, for example through
-            Help with Fees.
-          </li>
-          <li>
-            Undertaking means the applicant has formally agreed to pay later.
-            The list cannot be closed until this is updated to Paid.
-          </li>
-          <li>
-            Applications that do not need a fee show No fee required and the fee
-            fields cannot be changed.
-          </li>
-          <li>
-            Select Off-site fee if an additional fee applies because a
-            magistrate attended a location away from court premises.
-          </li>
-        </ul>
-      </div>
-    </details>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Due means the fee still needs to be paid or resolved.</li>
+        <li>
+          Paid means the fee has been paid in full. You can add a payment
+          reference if needed.
+        </li>
+        <li>
+          Remitted means the court has waived the fee, for example through Help
+          with Fees.
+        </li>
+        <li>
+          Undertaking means the applicant has formally agreed to pay later. The
+          list cannot be closed until this is updated to Paid.
+        </li>
+        <li>
+          Applications that do not need a fee show No fee required and the fee
+          fields cannot be changed.
+        </li>
+        <li>
+          Select Off-site fee if an additional fee applies because a magistrate
+          attended a location away from court premises.
+        </li>
+      </ul>
+    </app-help-details>
 
     <app-civil-fee-section
       #civilFeeSection

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.html
@@ -66,12 +66,7 @@
   </ng-template>
 
   <ng-template #wordingTpl>
-    <app-help-details summary="Help with application wording">
-      <p class="govuk-body">
-        Application wording is based on the selected application code and may
-        include fixed text and fields you need to complete.
-      </p>
-    </app-help-details>
+    <app-application-wording-help />
 
     @if (vm().appCodeDetail; as appCodeDetail) {
       <app-wording-section
@@ -103,36 +98,7 @@
   </ng-template>
 
   <ng-template #civilFeeTpl>
-    <app-help-details summary="Help with civil fee details">
-      <p class="govuk-body">
-        Civil fee details record whether an application fee is due, paid,
-        remitted or covered by an undertaking.
-      </p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Due means the fee still needs to be paid or resolved.</li>
-        <li>
-          Paid means the fee has been paid in full. You can add a payment
-          reference if needed.
-        </li>
-        <li>
-          Remitted means the court has waived the fee, for example through Help
-          with Fees.
-        </li>
-        <li>
-          Undertaking means the applicant has formally agreed to pay later. The
-          list cannot be closed until this is updated to Paid.
-        </li>
-        <li>
-          Applications that do not need a fee show No fee required and the fee
-          fields cannot be changed.
-        </li>
-        <li>
-          Select Off-site fee if an additional fee applies because a magistrate
-          attended a location away from court premises.
-        </li>
-      </ul>
-    </app-help-details>
+    <app-civil-fee-help />
 
     <app-civil-fee-section
       #civilFeeSection

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -69,6 +69,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import {
   ApplicationNotesForm,
   NotesSectionComponent,
@@ -179,6 +180,7 @@ export const ERROR_HREFS = {
     ApplicantSectionComponent,
     WordingSectionComponent,
     OfficialsSectionComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications-list-entry-detail.component.html',
 })

--- a/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
+++ b/src/app/pages/applications-list-entry-detail/applications-list-entry-detail.component.ts
@@ -69,7 +69,8 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
-import { HelpDetailsComponent } from '@components/help-details/help-details.component';
+import { ApplicationWordingHelpComponent } from '@components/help-details/application-wording-help.component';
+import { CivilFeeHelpComponent } from '@components/help-details/civil-fee-help.component';
 import {
   ApplicationNotesForm,
   NotesSectionComponent,
@@ -180,7 +181,8 @@ export const ERROR_HREFS = {
     ApplicantSectionComponent,
     WordingSectionComponent,
     OfficialsSectionComponent,
-    HelpDetailsComponent,
+    ApplicationWordingHelpComponent,
+    CivilFeeHelpComponent,
   ],
   templateUrl: './applications-list-entry-detail.component.html',
 })

--- a/src/app/pages/applications-list/applications-list.component.html
+++ b/src/app/pages/applications-list/applications-list.component.html
@@ -59,33 +59,24 @@
   ]"
 />
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with application lists
-    </span>
-  </summary>
+<app-help-details summary="Help with application lists">
+  <p class="govuk-body">
+    Actions are only available after you select a list from the search results.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Actions are only available after you select a list from the search
-      results.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        If you enter another location, you must also select the relevant or
-        owning CJA.
-      </li>
-      <li>
-        Print continuous prints all applications together as a court list or
-        register.
-      </li>
-      <li>Print page prints each application entry starting on a new page.</li>
-      <li>Delete list removes the selected list and its entries.</li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      If you enter another location, you must also select the relevant or owning
+      CJA.
+    </li>
+    <li>
+      Print continuous prints all applications together as a court list or
+      register.
+    </li>
+    <li>Print page prints each application entry starting on a new page.</li>
+    <li>Delete list removes the selected list and its entries.</li>
+  </ul>
+</app-help-details>
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"

--- a/src/app/pages/applications-list/applications-list.component.html
+++ b/src/app/pages/applications-list/applications-list.component.html
@@ -59,6 +59,34 @@
   ]"
 />
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with application lists
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Actions are only available after you select a list from the search
+      results.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        If you enter another location, you must also select the relevant or
+        owning CJA.
+      </li>
+      <li>
+        Print continuous prints all applications together as a court list or
+        register.
+      </li>
+      <li>Print page prints each application entry starting on a new page.</li>
+      <li>Delete list removes the selected list and its entries.</li>
+    </ul>
+  </div>
+</details>
+
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/applications-list/applications-list.component.ts
+++ b/src/app/pages/applications-list/applications-list.component.ts
@@ -59,6 +59,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NotificationBannerComponent } from '@components/notification-banner/notification-banner.component';
 import { PageHeaderComponent } from '@components/page-header/page-header.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
@@ -111,6 +112,7 @@ type DeleteFlash = { kind: 'success' } | { kind: 'error'; code: number };
     DateTimePipe,
     ApplicationsListFormComponent,
     AsyncJobProgressComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications-list.component.html',
 })

--- a/src/app/pages/applications/applications.component.html
+++ b/src/app/pages/applications/applications.component.html
@@ -25,33 +25,23 @@
 
 <h1 class="govuk-heading-xl">Applications</h1>
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with searching applications
-    </span>
-  </summary>
+<app-help-details summary="Help with searching applications">
+  <p class="govuk-body">
+    Use this page to search for applications when you do not know which
+    application list they are in.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Use this page to search for applications when you do not know which
-      application list they are in.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Select one or more applications to use the Actions menu.</li>
-      <li>Result selected applies a result to selected open applications.</li>
-      <li>
-        Print continuous prints selected applications together as a court list
-        or register.
-      </li>
-      <li>
-        Print page prints each selected application starting on a new page.
-      </li>
-      <li>Closed applications cannot be opened from this page.</li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Select one or more applications to use the Actions menu.</li>
+    <li>Result selected applies a result to selected open applications.</li>
+    <li>
+      Print continuous prints selected applications together as a court list or
+      register.
+    </li>
+    <li>Print page prints each selected application starting on a new page.</li>
+    <li>Closed applications cannot be opened from this page.</li>
+  </ul>
+</app-help-details>
 
 @if (vm().loading) {
   <app-async-job-progress

--- a/src/app/pages/applications/applications.component.html
+++ b/src/app/pages/applications/applications.component.html
@@ -23,6 +23,36 @@
   }
 }
 
+<h1 class="govuk-heading-xl">Applications</h1>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with searching applications
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Use this page to search for applications when you do not know which
+      application list they are in.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Select one or more applications to use the Actions menu.</li>
+      <li>Result selected applies a result to selected open applications.</li>
+      <li>
+        Print continuous prints selected applications together as a court list
+        or register.
+      </li>
+      <li>
+        Print page prints each selected application starting on a new page.
+      </li>
+      <li>Closed applications cannot be opened from this page.</li>
+    </ul>
+  </div>
+</details>
+
 @if (vm().loading) {
   <app-async-job-progress
     heading="PDF in progress"

--- a/src/app/pages/applications/applications.component.ts
+++ b/src/app/pages/applications/applications.component.ts
@@ -35,6 +35,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NotificationBannerComponent } from '@components/notification-banner/notification-banner.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
 import { SelectInputComponent } from '@components/select-input/select-input.component';
@@ -133,6 +134,7 @@ export const ApplicationsColumns = [
     MojButtonMenuDirective,
     DateTimePipe,
     AsyncJobProgressComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './applications.component.html',
   styleUrls: ['./applications.component.scss'],

--- a/src/app/pages/reports/reports.component.html
+++ b/src/app/pages/reports/reports.component.html
@@ -30,30 +30,25 @@
 
 <h1 class="govuk-heading-xl">Reports</h1>
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">Help with reports</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p>Use this page to generate and download CSV reports.</p>
+<app-help-details summary="Help with reports">
+  <p>Use this page to generate and download CSV reports.</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        Select a report type, then enter the filters needed for that report.
-      </li>
-      <li>Date from and date to are required for each report.</li>
-      <li>Leave optional filters blank to include all matching records.</li>
-      <li>
-        If you enter a court, the criminal justice area and other location
-        fields are not needed.
-      </li>
-      <li>
-        Select Download CSV. The report will be generated and downloaded
-        automatically when ready.
-      </li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      Select a report type, then enter the filters needed for that report.
+    </li>
+    <li>Date from and date to are required for each report.</li>
+    <li>Leave optional filters blank to include all matching records.</li>
+    <li>
+      If you enter a court, the criminal justice area and other location fields
+      are not needed.
+    </li>
+    <li>
+      Select Download CSV. The report will be generated and downloaded
+      automatically when ready.
+    </li>
+  </ul>
+</app-help-details>
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"

--- a/src/app/pages/reports/reports.component.html
+++ b/src/app/pages/reports/reports.component.html
@@ -30,6 +30,31 @@
 
 <h1 class="govuk-heading-xl">Reports</h1>
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">Help with reports</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>Use this page to generate and download CSV reports.</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Select a report type, then enter the filters needed for that report.
+      </li>
+      <li>Date from and date to are required for each report.</li>
+      <li>Leave optional filters blank to include all matching records.</li>
+      <li>
+        If you enter a court, the criminal justice area and other location
+        fields are not needed.
+      </li>
+      <li>
+        Select Download CSV. The report will be generated and downloaded
+        automatically when ready.
+      </li>
+    </ul>
+  </div>
+</details>
+
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -39,6 +39,7 @@ import {
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
 import { FeesSectionComponent } from '@components/fees-section/fees-section.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { ListMaintenanceSectionComponent } from '@components/list-maintenance-section/list-maintenance-section.component';
 import { PrivateProsecutorsIndexSectionComponent } from '@components/private-prosecutors-index-section/private-prosecutors-index-section.component';
 import { ReportSelectorComponent } from '@components/report-option/report-selector.component';
@@ -121,6 +122,7 @@ const REPORT_LOCATION_RESET_VALUE = {
     ErrorSummaryComponent,
     SuccessBannerComponent,
     AsyncJobProgressComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './reports.component.html',
 })

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -16,33 +16,25 @@
 
 <h1 class="govuk-heading-xl">Standard applicants</h1>
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with standard applicants
-    </span>
-  </summary>
+<app-help-details summary="Help with standard applicants">
+  <p class="govuk-body">
+    Use this page to search for standard applicant records by code or name.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Use this page to search for standard applicant records by code or name.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Select View to see the details for a standard applicant.</li>
-      <li>
-        Use Export to download standard applicant search results for use in a
-        spreadsheet.
-      </li>
-      <li>
-        Use Print to create a PDF report of standard applicant search results.
-      </li>
-      <li>
-        Standard applicant records cannot be created or amended on this page.
-      </li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Select View to see the details for a standard applicant.</li>
+    <li>
+      Use Export to download standard applicant search results for use in a
+      spreadsheet.
+    </li>
+    <li>
+      Use Print to create a PDF report of standard applicant search results.
+    </li>
+    <li>
+      Standard applicant records cannot be created or amended on this page.
+    </li>
+  </ul>
+</app-help-details>
 
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"

--- a/src/app/pages/standard-applicants/standard-applicants.component.html
+++ b/src/app/pages/standard-applicants/standard-applicants.component.html
@@ -16,6 +16,34 @@
 
 <h1 class="govuk-heading-xl">Standard applicants</h1>
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with standard applicants
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Use this page to search for standard applicant records by code or name.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Select View to see the details for a standard applicant.</li>
+      <li>
+        Use Export to download standard applicant search results for use in a
+        spreadsheet.
+      </li>
+      <li>
+        Use Print to create a PDF report of standard applicant search results.
+      </li>
+      <li>
+        Standard applicant records cannot be created or amended on this page.
+      </li>
+    </ul>
+  </div>
+</details>
+
 <hr
   class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
 />

--- a/src/app/pages/standard-applicants/standard-applicants.component.ts
+++ b/src/app/pages/standard-applicants/standard-applicants.component.ts
@@ -19,6 +19,7 @@ import {
   ErrorItem,
   ErrorSummaryComponent,
 } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NotificationBannerComponent } from '@components/notification-banner/notification-banner.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
 import {
@@ -83,6 +84,7 @@ const initialStandardApplicantsState: StandardApplicantsState = {
     ErrorSummaryComponent,
     MojButtonMenuDirective,
     NotificationBannerComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './standard-applicants.component.html',
   styleUrl: './standard-applicants.component.scss',

--- a/src/app/shared/components/applicant-section/applicant-section.component.html
+++ b/src/app/shared/components/applicant-section/applicant-section.component.html
@@ -1,26 +1,18 @@
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with applicant details
-    </span>
-  </summary>
+<app-help-details summary="Help with applicant details">
+  <p class="govuk-body">
+    Enter applicant details for a single applicant or organisation.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Enter applicant details for a single applicant or organisation.
-    </p>
+  <p class="govuk-body">
+    If you select a standard applicant, you can choose a different standard
+    applicant, but you cannot edit the standard applicant’s details on this
+    page.
+  </p>
 
-    <p class="govuk-body">
-      If you select a standard applicant, you can choose a different standard
-      applicant, but you cannot edit the standard applicant’s details on this
-      page.
-    </p>
-
-    <p class="govuk-body">
-      The selected standard applicant is shown above the search results.
-    </p>
-  </div>
-</details>
+  <p class="govuk-body">
+    The selected standard applicant is shown above the search results.
+  </p>
+</app-help-details>
 
 <div [formGroup]="form()">
   <div class="govuk-grid-row">

--- a/src/app/shared/components/applicant-section/applicant-section.component.html
+++ b/src/app/shared/components/applicant-section/applicant-section.component.html
@@ -1,3 +1,27 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with applicant details
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Enter applicant details for a single applicant or organisation.
+    </p>
+
+    <p class="govuk-body">
+      If you select a standard applicant, you can choose a different standard
+      applicant, but you cannot edit the standard applicant’s details on this
+      page.
+    </p>
+
+    <p class="govuk-body">
+      The selected standard applicant is shown above the search results.
+    </p>
+  </div>
+</details>
+
 <div [formGroup]="form()">
   <div class="govuk-grid-row">
     <app-select-input

--- a/src/app/shared/components/applicant-section/applicant-section.component.ts
+++ b/src/app/shared/components/applicant-section/applicant-section.component.ts
@@ -6,6 +6,7 @@ import {
   PERSON_TITLE_OPTIONS,
 } from '@components/applications-list-entry-detail/util/entry-detail.constants';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { OrganisationSectionComponent } from '@components/organisation-section/organisation-section.component';
 import { PersonSectionComponent } from '@components/person-section/person-section.component';
 import { SelectInputComponent } from '@components/select-input/select-input.component';
@@ -23,6 +24,7 @@ import { ApplicantType } from '@shared-types/applications-list-entry-create/appl
     PersonSectionComponent,
     SelectInputComponent,
     ReactiveFormsModule,
+    HelpDetailsComponent,
   ],
   templateUrl: './applicant-section.component.html',
 })

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.html
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.html
@@ -1,30 +1,22 @@
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with application codes
-    </span>
-  </summary>
+<app-help-details summary="Help with application codes">
+  <p class="govuk-body">
+    Select the application code that matches the nature of the application being
+    recorded.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Select the application code that matches the nature of the application
-      being recorded.
-    </p>
+  <p class="govuk-body">
+    The lodgement date is the date the court office received the application.
+  </p>
 
-    <p class="govuk-body">
-      The lodgement date is the date the court office received the application.
-    </p>
+  <p class="govuk-body">
+    The lodgement date is used to find the correct fee for the date the
+    application was received.
+  </p>
 
-    <p class="govuk-body">
-      The lodgement date is used to find the correct fee for the date the
-      application was received.
-    </p>
-
-    <p class="govuk-body">
-      Once the lodgement date is saved it cannot be changed.
-    </p>
-  </div>
-</details>
+  <p class="govuk-body">
+    Once the lodgement date is saved it cannot be changed.
+  </p>
+</app-help-details>
 
 <fieldset class="govuk-fieldset">
   <form [formGroup]="form">

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.html
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.html
@@ -1,3 +1,31 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with application codes
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Select the application code that matches the nature of the application
+      being recorded.
+    </p>
+
+    <p class="govuk-body">
+      The lodgement date is the date the court office received the application.
+    </p>
+
+    <p class="govuk-body">
+      The lodgement date is used to find the correct fee for the date the
+      application was received.
+    </p>
+
+    <p class="govuk-body">
+      Once the lodgement date is saved it cannot be changed.
+    </p>
+  </div>
+</details>
+
 <fieldset class="govuk-fieldset">
   <form [formGroup]="form">
     <div class="govuk-grid-row">

--- a/src/app/shared/components/application-codes-search/application-codes-search.component.ts
+++ b/src/app/shared/components/application-codes-search/application-codes-search.component.ts
@@ -24,6 +24,7 @@ import { AlertComponent } from '@components/alert/alert.component';
 import { CODES_COLUMNS } from '@components/applications-list-entry-detail/util/entry-detail.constants';
 import { DateInputComponent } from '@components/date-input/date-input.component';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
 import {
   SortableTableComponent,
@@ -52,6 +53,7 @@ const APPLICATION_CODE_SEARCH_ERROR_MESSAGES = {
     SortableTableComponent,
     PaginationComponent,
     AlertComponent,
+    HelpDetailsComponent,
   ],
   templateUrl: './application-codes-search.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/components/help-details/application-wording-help.component.ts
+++ b/src/app/shared/components/help-details/application-wording-help.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+import { HelpDetailsComponent } from './help-details.component';
+
+@Component({
+  selector: 'app-application-wording-help',
+  standalone: true,
+  imports: [HelpDetailsComponent],
+  template: `
+    <app-help-details summary="Help with application wording">
+      <p class="govuk-body">
+        Application wording is based on the selected application code and may
+        include fixed text and fields you need to complete.
+      </p>
+    </app-help-details>
+  `,
+})
+export class ApplicationWordingHelpComponent {}

--- a/src/app/shared/components/help-details/civil-fee-help.component.ts
+++ b/src/app/shared/components/help-details/civil-fee-help.component.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+
+import { HelpDetailsComponent } from './help-details.component';
+
+@Component({
+  selector: 'app-civil-fee-help',
+  standalone: true,
+  imports: [HelpDetailsComponent],
+  template: `
+    <app-help-details summary="Help with civil fee details">
+      <p class="govuk-body">
+        Civil fee details record whether an application fee is due, paid,
+        remitted or covered by an undertaking.
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Due means the fee still needs to be paid or resolved.</li>
+        <li>
+          Paid means the fee has been paid in full. You can add a payment
+          reference if needed.
+        </li>
+        <li>
+          Remitted means the court has waived the fee, for example through Help
+          with Fees.
+        </li>
+        <li>
+          Undertaking means the applicant has formally agreed to pay later. The
+          list cannot be closed until this is updated to Paid.
+        </li>
+        <li>
+          Applications that do not need a fee show No fee required and the fee
+          fields cannot be changed.
+        </li>
+        <li>
+          Select Off-site fee if an additional fee applies because a magistrate
+          attended a location away from court premises.
+        </li>
+      </ul>
+    </app-help-details>
+  `,
+})
+export class CivilFeeHelpComponent {}

--- a/src/app/shared/components/help-details/help-details.component.ts
+++ b/src/app/shared/components/help-details/help-details.component.ts
@@ -1,0 +1,20 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-help-details',
+  standalone: true,
+  template: `
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">{{ summary() }}</span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <ng-content />
+      </div>
+    </details>
+  `,
+})
+export class HelpDetailsComponent {
+  readonly summary = input.required<string>();
+}

--- a/src/app/shared/components/notes-section/notes-section.component.html
+++ b/src/app/shared/components/notes-section/notes-section.component.html
@@ -1,3 +1,25 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Help with application notes
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Use this section to record case references, account references and any
+      additional notes for the application.
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Account reference is required for enforcement application codes prefixed
+        with EF.
+      </li>
+    </ul>
+  </div>
+</details>
+
 <div class="govuk-grid-row" [formGroup]="form()">
   <div class="govuk-grid-column-one-quarter">
     <div

--- a/src/app/shared/components/notes-section/notes-section.component.html
+++ b/src/app/shared/components/notes-section/notes-section.component.html
@@ -1,24 +1,16 @@
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Help with application notes
-    </span>
-  </summary>
+<app-help-details summary="Help with application notes">
+  <p class="govuk-body">
+    Use this section to record case references, account references and any
+    additional notes for the application.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Use this section to record case references, account references and any
-      additional notes for the application.
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        Account reference is required for enforcement application codes prefixed
-        with EF.
-      </li>
-    </ul>
-  </div>
-</details>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      Account reference is required for enforcement application codes prefixed
+      with EF.
+    </li>
+  </ul>
+</app-help-details>
 
 <div class="govuk-grid-row" [formGroup]="form()">
   <div class="govuk-grid-column-one-quarter">

--- a/src/app/shared/components/notes-section/notes-section.component.ts
+++ b/src/app/shared/components/notes-section/notes-section.component.ts
@@ -3,6 +3,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { ErrorItem } from '@components/error-summary/error-summary.component';
 import { GovukTextareaComponent } from '@components/govuk-textarea/govuk-textarea.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import { NOTES_ERROR_MESSAGES } from '@constants/application-list-entry/error-messages';
 
 export type ApplicationNotesForm = FormGroup<{
@@ -12,7 +13,7 @@ export type ApplicationNotesForm = FormGroup<{
 }>;
 @Component({
   selector: 'app-notes-section',
-  imports: [GovukTextareaComponent, ReactiveFormsModule],
+  imports: [GovukTextareaComponent, ReactiveFormsModule, HelpDetailsComponent],
   templateUrl: './notes-section.component.html',
 })
 export class NotesSectionComponent {

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.html
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.html
@@ -1,3 +1,18 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text"> Help with result wording </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      Result wording is based on the selected result code and may include fixed
+      text and fields you need to complete.
+    </p>
+
+    <p class="govuk-body">Fixed wording cannot be edited on this page.</p>
+  </div>
+</details>
+
 @if (showAppliedBanner()) {
   <app-alert
     alertType="success"

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.html
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.html
@@ -1,17 +1,11 @@
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text"> Help with result wording </span>
-  </summary>
+<app-help-details summary="Help with result wording">
+  <p class="govuk-body">
+    Result wording is based on the selected result code and may include fixed
+    text and fields you need to complete.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Result wording is based on the selected result code and may include fixed
-      text and fields you need to complete.
-    </p>
-
-    <p class="govuk-body">Fixed wording cannot be edited on this page.</p>
-  </div>
-</details>
+  <p class="govuk-body">Fixed wording cannot be edited on this page.</p>
+</app-help-details>
 
 @if (showAppliedBanner()) {
   <app-alert

--- a/src/app/shared/components/result-wording-section/result-wording-section.component.ts
+++ b/src/app/shared/components/result-wording-section/result-wording-section.component.ts
@@ -25,6 +25,7 @@ import {
   ApplicationEntriesResultContext,
 } from '@components/applications-list-entry-detail/util/routing-state-util';
 import { ErrorItem } from '@components/error-summary/error-summary.component';
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
 import {
   SortableTableComponent,
   TableColumn,
@@ -58,6 +59,7 @@ import { ResultRow, toExistingRows } from '@util/result-code-helpers';
     SortableTableComponent,
     AlertComponent,
     DateTimePipe,
+    HelpDetailsComponent,
   ],
 })
 export class ResultWordingSectionComponent {

--- a/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
+++ b/test/unit/app/shared/components/applicant-section/applicant-section.component.spec.ts
@@ -137,13 +137,12 @@ describe('ApplicantSectionComponent', () => {
     fixture.detectChanges();
 
     const tag = fixture.debugElement.query(By.css('.govuk-tag'));
-    const body = fixture.debugElement.query(By.css('.govuk-body'));
+    const summaryText = tag?.nativeElement.closest('p')?.textContent ?? '';
 
     expect(tag).toBeTruthy();
     expect(tag.nativeElement.textContent).toContain('Saved');
-    expect(body).toBeTruthy();
-    expect(body.nativeElement.textContent).toContain('SA-123');
-    expect(body.nativeElement.textContent).toContain('Example Org');
+    expect(summaryText).toContain('SA-123');
+    expect(summaryText).toContain('Example Org');
   });
 
   it('renders the current standard applicant tag and text when current values exist', () => {
@@ -155,15 +154,15 @@ describe('ApplicantSectionComponent', () => {
     fixture.detectChanges();
 
     const tags = fixture.debugElement.queryAll(By.css('.govuk-tag'));
-    const body = fixture.debugElement.query(By.css('.govuk-body'));
+    const currentTag = tags.find((tag) =>
+      tag.nativeElement.textContent.includes('Currently selected'),
+    );
+    const summaryText =
+      currentTag?.nativeElement.closest('p')?.textContent ?? '';
 
-    expect(
-      tags.some((tag) =>
-        tag.nativeElement.textContent.includes('Currently selected'),
-      ),
-    ).toBe(true);
-    expect(body.nativeElement.textContent).toContain('SA-999');
-    expect(body.nativeElement.textContent).toContain('Current Org');
+    expect(currentTag).toBeTruthy();
+    expect(summaryText).toContain('SA-999');
+    expect(summaryText).toContain('Current Org');
   });
 
   it('does not render duplicate current and saved tags for the same applicant', () => {

--- a/test/unit/app/shared/components/help-details/help-content.components.spec.ts
+++ b/test/unit/app/shared/components/help-details/help-content.components.spec.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ApplicationWordingHelpComponent } from '@components/help-details/application-wording-help.component';
+import { CivilFeeHelpComponent } from '@components/help-details/civil-fee-help.component';
+
+@Component({
+  imports: [ApplicationWordingHelpComponent, CivilFeeHelpComponent],
+  template: `
+    <app-application-wording-help />
+    <app-civil-fee-help />
+  `,
+})
+class HostComponent {}
+
+describe('help content components', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders application wording help content', () => {
+    const bodyText = fixture.nativeElement.textContent;
+
+    expect(bodyText).toContain('Help with application wording');
+    expect(bodyText).toContain(
+      'Application wording is based on the selected application code',
+    );
+  });
+
+  it('renders civil fee help content', () => {
+    const details = fixture.debugElement.queryAll(By.css('app-help-details'));
+    const bodyText = fixture.nativeElement.textContent;
+
+    expect(details).toHaveLength(2);
+    expect(bodyText).toContain('Help with civil fee details');
+    expect(bodyText).toContain('Undertaking means the applicant');
+  });
+});

--- a/test/unit/app/shared/components/help-details/help-details.component.spec.ts
+++ b/test/unit/app/shared/components/help-details/help-details.component.spec.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { HelpDetailsComponent } from '@components/help-details/help-details.component';
+
+@Component({
+  imports: [HelpDetailsComponent],
+  template: `
+    <app-help-details summary="Help with reports">
+      <p class="govuk-body">Projected help content.</p>
+    </app-help-details>
+  `,
+})
+class HostComponent {}
+
+describe('HelpDetailsComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders the summary text and projected content', () => {
+    const summary = fixture.debugElement.query(
+      By.css('.govuk-details__summary-text'),
+    );
+    const body = fixture.debugElement.query(By.css('.govuk-details__text'));
+
+    expect(summary.nativeElement.textContent).toContain('Help with reports');
+    expect(body.nativeElement.textContent).toContain('Projected help content.');
+  });
+});


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-377

### Change description

- Added GDS details help content across modernised Application Register screens where contextual guidance is useful.
- Condensed legacy help copy into shorter, page-specific guidance focused on less obvious behaviour.
- Added help text for application lists, list entries, applicants, application codes, wording, fees, notes, result wording, bulk upload, application search, standard applicants and reports.
- Kept help content frontend-owned and embedded close to the relevant page/component.
- Identified a follow-up gap around EF application codes requiring an account reference. https://tools.hmcts.net/jira/browse/ARCPOC-1507

### Testing done
Manual testing

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
