### PR TITLE
ARCPOC-1515 Allow optional fields to be unset via input

### DIFF
--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -592,7 +592,10 @@ export function buildEntryUpdateDtoForFeeChange<K extends keyof EntryUpdateDto>(
 }
 
 function normalizeApplicantSelection(
-  dto: EntryUpdateDto,
+  dto: {
+    applicant?: Applicant;
+    standardApplicantCode?: string | null;
+  },
   mode: 'standard' | 'applicant',
 ): void {
   if (mode === 'standard') {

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -67,8 +67,44 @@ type MagSlot = {
   surKey: keyof ApplicationsListEntryFormValue;
 };
 
+type EntryUpdateDtoWithClears = Omit<
+  EntryUpdateDto,
+  'caseReference' | 'accountNumber' | 'notes' | 'numberOfRespondents'
+> & {
+  caseReference?: string | null;
+  accountNumber?: string | null;
+  notes?: string | null;
+  numberOfRespondents?: number | null;
+};
+
 const hasText = (v: unknown): v is string =>
   typeof v === 'string' && v.trim().length > 0;
+
+const toNullableTrimmed = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed || null;
+};
+
+const toNullableInteger = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && Number.isInteger(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  return Number(trimmed);
+};
 
 const MAG_SLOTS: readonly MagSlot[] = [
   {
@@ -312,6 +348,7 @@ export function buildEntryUpdateDtoFromForm(
     officials: detail.officials,
   };
 
+  const officialsPatch = buildOfficialsFromFormValue(formValue);
   const patch = {
     ...buildEntryCreateDto(
       formValue,
@@ -320,24 +357,43 @@ export function buildEntryUpdateDtoFromForm(
       respondentPersonValue,
       respondentOrgValue,
     ),
-    ...buildOfficialsFromFormValue(formValue),
+    ...officialsPatch,
   } as Partial<EntryUpdateDto> & { lodgementDate?: string };
 
   delete patch.lodgementDate;
 
-  const dto: EntryUpdateDto = {
+  const dto: EntryUpdateDtoWithClears = {
     ...base,
     ...patch,
   };
 
+  dto.caseReference = toNullableTrimmed(
+    formValue.applicationNotes.caseReference,
+  );
+  dto.accountNumber = toNullableTrimmed(
+    formValue.applicationNotes.accountReference,
+  );
+  dto.notes = toNullableTrimmed(formValue.applicationNotes.notes);
+  dto.numberOfRespondents = toNullableInteger(formValue.numberOfRespondents);
+
+  if (Array.isArray(formValue.wordingFields)) {
+    dto.wordingFields = patch.wordingFields ?? [];
+  }
+
+  if (Array.isArray(formValue.feeStatuses)) {
+    dto.feeStatuses = formValue.feeStatuses;
+  }
+
+  dto.officials = officialsPatch.officials ?? [];
+
   if (formValue.applicantType === 'standard') {
     dto.standardApplicantCode = (formValue.standardApplicantCode ?? '').trim();
     normalizeApplicantSelection(dto, 'standard');
-    return dto;
+    return dto as EntryUpdateDto;
   }
 
   normalizeApplicantSelection(dto, 'applicant');
-  return dto;
+  return dto as EntryUpdateDto;
 }
 
 export function buildContactDetailsFromRaw(v: ContactFormRaw): ContactDetails {

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -43,7 +43,10 @@ import {
   RespondentPersonFormValue,
 } from '@shared-types/applications-list-entry-create/application-list-entry-form';
 import {
+  hasText,
   mapTitleToOptionValue,
+  toNullableInteger,
+  trimToNull,
   trimToString,
   trimToUndefined,
 } from '@util/string-helpers';
@@ -75,35 +78,6 @@ type EntryUpdateDtoWithClears = Omit<
   accountNumber?: string | null;
   notes?: string | null;
   numberOfRespondents?: number | null;
-};
-
-const hasText = (v: unknown): v is string =>
-  typeof v === 'string' && v.trim().length > 0;
-
-const toNullableTrimmed = (value: string | null | undefined): string | null => {
-  const trimmed = value?.trim();
-  return trimmed || null;
-};
-
-const toNullableInteger = (value: unknown): number | null => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-
-  if (typeof value === 'number') {
-    return Number.isFinite(value) && Number.isInteger(value) ? value : null;
-  }
-
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed || !/^\d+$/.test(trimmed)) {
-    return null;
-  }
-
-  return Number(trimmed);
 };
 
 const MAG_SLOTS: readonly MagSlot[] = [
@@ -367,13 +341,9 @@ export function buildEntryUpdateDtoFromForm(
     ...patch,
   };
 
-  dto.caseReference = toNullableTrimmed(
-    formValue.applicationNotes.caseReference,
-  );
-  dto.accountNumber = toNullableTrimmed(
-    formValue.applicationNotes.accountReference,
-  );
-  dto.notes = toNullableTrimmed(formValue.applicationNotes.notes);
+  dto.caseReference = trimToNull(formValue.applicationNotes.caseReference);
+  dto.accountNumber = trimToNull(formValue.applicationNotes.accountReference);
+  dto.notes = trimToNull(formValue.applicationNotes.notes);
   dto.numberOfRespondents = toNullableInteger(formValue.numberOfRespondents);
 
   if (Array.isArray(formValue.wordingFields)) {

--- a/src/app/shared/util/string-helpers.ts
+++ b/src/app/shared/util/string-helpers.ts
@@ -11,6 +11,36 @@ export function trimToUndefined(v: unknown): string | undefined {
   return s === '' ? undefined : s;
 }
 
+export function trimToNull(v: unknown): string | null {
+  const s = trimToString(v);
+  return s === '' ? null : s;
+}
+
+export function hasText(v: unknown): v is string {
+  return trimToUndefined(v) !== undefined;
+}
+
+export function toNullableInteger(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && Number.isInteger(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  return Number(trimmed);
+}
+
 export function isNullableString(x: unknown): x is string | null | undefined {
   return x === undefined || x === null || typeof x === 'string';
 }
@@ -77,11 +107,7 @@ export function getTrimmedStringOrNullFromGroup(
   name: string,
 ): string | null {
   const v: unknown = group.get(name)?.value;
-  if (typeof v !== 'string') {
-    return null;
-  }
-  const s = v.trim();
-  return s || null;
+  return trimToNull(v);
 }
 
 type PartyWithName = Pick<Applicant, 'person' | 'organisation'>;

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -412,6 +412,75 @@ describe('applications-list entry form builders', () => {
       ]);
     });
 
+    it('sends explicit clear values for optional fields removed on update', () => {
+      const dto = buildEntryUpdateDtoFromForm(
+        {
+          ...baseDetail,
+          respondent: {
+            organisation: {
+              name: 'Existing respondent',
+              contactDetails: { addressLine1: '2 Street' },
+            },
+          },
+          numberOfRespondents: 12,
+          feeStatuses: [
+            {
+              paymentStatus: 'PAID',
+              statusDate: '2026-04-01',
+              paymentReference: 'PAY-1',
+            },
+          ],
+          caseReference: 'CASE-1',
+          accountNumber: 'ACC-1',
+          notes: 'Persisted note',
+          officials: [
+            {
+              type: 'CLERK',
+              forename: 'Clara',
+              surname: 'Clerk',
+            },
+          ],
+          wording: {
+            template: 'At {{Court}}',
+            'substitution-key-constraints': [
+              { key: 'Court', value: 'Court A', constraint: { length: 20 } },
+            ],
+          },
+        } as unknown as EntryGetDetailDto,
+        {
+          applicantType: 'person',
+          standardApplicantCode: null,
+          applicationCode: 'APP-100',
+          respondentEntryType: 'person',
+          numberOfRespondents: null,
+          wordingFields: [],
+          feeStatuses: [],
+          applicationNotes: {
+            notes: '   ',
+            caseReference: '',
+            accountReference: null,
+          },
+        } as never,
+        {
+          ...blankPerson,
+          firstName: 'John',
+          surname: 'Smith',
+          addressLine1: '1 Street',
+        } as never,
+        blankOrg as never,
+        blankPerson as never,
+        blankOrg as never,
+      );
+
+      expect(dto.caseReference).toBeNull();
+      expect(dto.accountNumber).toBeNull();
+      expect(dto.notes).toBeNull();
+      expect(dto.numberOfRespondents).toBeNull();
+      expect(dto.wordingFields).toEqual([]);
+      expect(dto.feeStatuses).toEqual([]);
+      expect(dto.officials).toEqual([]);
+    });
+
     it('builds update payloads from an allowlist and excludes read-only detail fields', () => {
       const dto = buildEntryUpdateDtoFromForm(
         {

--- a/test/unit/app/shared/util/string-helpers.spec.ts
+++ b/test/unit/app/shared/util/string-helpers.spec.ts
@@ -4,9 +4,12 @@ import {
   formatPartyName,
   formatPersonName,
   getDateStamp,
+  hasText,
   mapOptionValueToTitle,
   mapTitleToOptionValue,
   returnOrgName,
+  toNullableInteger,
+  trimToNull,
   trimToString,
   trimToUndefined,
 } from '@util/string-helpers';
@@ -76,6 +79,57 @@ describe('trimToUndefined', () => {
   it('returns undefined for functions and symbols', () => {
     expect(trimToUndefined(Symbol('x'))).toBeUndefined();
     expect(trimToUndefined(() => 'hello')).toBeUndefined();
+  });
+});
+
+describe('trimToNull', () => {
+  it('returns the trimmed string when given a non-empty string with spaces', () => {
+    expect(trimToNull('  hello  ')).toBe('hello');
+  });
+
+  it('returns null for empty, whitespace-only, and non-string values', () => {
+    expect(trimToNull('')).toBeNull();
+    expect(trimToNull('   ')).toBeNull();
+    expect(trimToNull(null)).toBeNull();
+    expect(trimToNull(undefined)).toBeNull();
+    expect(trimToNull(123)).toBeNull();
+  });
+});
+
+describe('hasText', () => {
+  it('returns true only for strings with non-whitespace text', () => {
+    expect(hasText('  hello  ')).toBe(true);
+    expect(hasText('')).toBe(false);
+    expect(hasText('   ')).toBe(false);
+    expect(hasText(null)).toBe(false);
+    expect(hasText(123)).toBe(false);
+  });
+});
+
+describe('toNullableInteger', () => {
+  it('returns integer numbers unchanged', () => {
+    expect(toNullableInteger(12)).toBe(12);
+    expect(toNullableInteger(0)).toBe(0);
+    expect(toNullableInteger(-1)).toBe(-1);
+  });
+
+  it('parses strings containing whole numbers', () => {
+    expect(toNullableInteger(' 12 ')).toBe(12);
+    expect(toNullableInteger('0')).toBe(0);
+    expect(toNullableInteger('0012')).toBe(12);
+  });
+
+  it('returns null for blank, non-numeric, and non-integer values', () => {
+    expect(toNullableInteger(null)).toBeNull();
+    expect(toNullableInteger(undefined)).toBeNull();
+    expect(toNullableInteger('')).toBeNull();
+    expect(toNullableInteger('   ')).toBeNull();
+    expect(toNullableInteger('12.5')).toBeNull();
+    expect(toNullableInteger('-1')).toBeNull();
+    expect(toNullableInteger('abc')).toBeNull();
+    expect(toNullableInteger(12.5)).toBeNull();
+    expect(toNullableInteger(Number.NaN)).toBeNull();
+    expect(toNullableInteger({})).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1515

### Change description

- Update entry save payloads now send explicit clear values for removed optional fields.
- Notes fields and respondent count are cleared as null.
- Wording fields, fee statuses, and officials are cleared as empty arrays where applicable.
- Narrowed applicant-selection helper typing so nullable clear payloads compile cleanly.
- Added regression coverage for cleared optional fields on buildEntryUpdateDtoFromForm.

<!-- Describe what changed and why. -->

### Testing done

<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
