### PR TITLE
harden the login flow to deal with intermitent variation

### DIFF
--- a/cypress/support/helper/auth/MicrosoftAuthHelper.ts
+++ b/cypress/support/helper/auth/MicrosoftAuthHelper.ts
@@ -118,10 +118,7 @@ export class MicrosoftAuthHelper {
                   );
                 }
 
-                cy.wrap($btn)
-                  .should('be.visible')
-                  .should('be.enabled')
-                  .click();
+                cy.wrap($btn).should('be.visible').should('be.enabled').click();
               });
             });
         };

--- a/cypress/support/helper/auth/MicrosoftAuthHelper.ts
+++ b/cypress/support/helper/auth/MicrosoftAuthHelper.ts
@@ -63,6 +63,69 @@ export class MicrosoftAuthHelper {
             .click();
         };
 
+        // Helper to handle optional "Stay signed in?" prompt
+        const handleStaySignedInPromptIfPresent = () => {
+          cy.get('body', { timeout: 15000 })
+            .should(($body) => {
+              const bodyText = $body.text();
+
+              const isStaySignedInPrompt =
+                bodyText.includes('Stay signed in') ||
+                bodyText.includes('Keep me signed in');
+
+              const hasNoButton =
+                $body.find('#idBtn_Back').filter((_, el) => {
+                  const value = (
+                    (el as HTMLInputElement).value ||
+                    el.textContent ||
+                    ''
+                  )
+                    .toString()
+                    .trim();
+
+                  return /^no$/i.test(value);
+                }).length > 0;
+
+              expect(
+                isStaySignedInPrompt || hasNoButton,
+                'Stay signed in prompt or No button should appear',
+              ).to.eq(true);
+            })
+            .then(($body) => {
+              const bodyText = $body.text();
+
+              const isStaySignedInPrompt =
+                bodyText.includes('Stay signed in') ||
+                bodyText.includes('Keep me signed in');
+
+              if (!isStaySignedInPrompt) {
+                cy.log(
+                  'Microsoft SSO: Stay signed in prompt not present; skipping #idBtn_Back',
+                );
+                return;
+              }
+
+              cy.log('Microsoft SSO: Stay signed in prompt detected');
+
+              cy.get('#idBtn_Back', { timeout: 10000 }).then(($btn) => {
+                const value = ($btn.val() || $btn.text() || '')
+                  .toString()
+                  .trim();
+
+                if (!/^no$/i.test(value)) {
+                  throw new Error(
+                    `Microsoft SSO: expected #idBtn_Back to be "No", but found "${value}"`,
+                  );
+                }
+
+                cy.wrap($btn)
+                  .should('be.visible')
+                  .should('be.enabled')
+                  .click();
+              });
+            });
+        };
+
         // Enter email
         cy.log('Entering email...');
         typeExact(emailSel, innerEmail, 'email');
@@ -73,15 +136,8 @@ export class MicrosoftAuthHelper {
         typeExact(passSel, innerPassword, 'password');
         clickSubmit();
 
-        // Wait for and handle "Stay signed in?" prompt
-        cy.get('#idBtn_Back', { timeout: 15000 })
-          .should('be.visible')
-          .should('be.enabled')
-          .then(($btn) => {
-            const text = $btn.val() as string;
-            cy.log(`Clicking button: ${text}`);
-            cy.wrap($btn).click();
-          });
+        // Wait for and handle optional "Stay signed in?" prompt
+        handleStaySignedInPromptIfPresent();
       },
     );
 


### PR DESCRIPTION
### Jira link


See [ARCPOC-1523](https://tools.hmcts.net/jira/browse/ARCPOC-1523)

### Change description

Microsoft SSO login intermittently fails because the auth helper clicks `#idBtn_Back` after password entry without confirming the current Microsoft page state

In the failing flow, `#idBtn_Back` is the back arrow next to the username, not the "No" button on the "Stay signed in?" prompt. The helper clicks the back arrow, sends the login flow backwards, and the test remains in a failed Microsoft sign-in state

### Testing done

Re ran failing tests with different users to validate flow, re ran with original failing users to validate.

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
