### PR TITLE
ARCPOC-1539

### DIFF
--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -109,9 +109,13 @@ export function buildStandardApplicationForm(
   // Cross-field validators for fields that depend on other entry values.
   const formValidators = [
     crossFormValidation('mags1FirstName', 'mags1Surname'),
+    crossFormValidation('mags1Surname', 'mags1FirstName'),
     crossFormValidation('mags2FirstName', 'mags2Surname'),
+    crossFormValidation('mags2Surname', 'mags2FirstName'),
     crossFormValidation('mags3FirstName', 'mags3Surname'),
+    crossFormValidation('mags3Surname', 'mags3FirstName'),
     crossFormValidation('officialFirstName', 'officialSurname'),
+    crossFormValidation('officialSurname', 'officialFirstName'),
     accountReferenceRequiredForApplicationCode(),
   ];
 

--- a/src/app/shared/constants/application-list-entry/error-messages.ts
+++ b/src/app/shared/constants/application-list-entry/error-messages.ts
@@ -112,6 +112,7 @@ export const CIVIL_FEE_FIELD_MESSAGES: CivilFeeErrorMap = {
 
 export const OFFICIAL_FIELD_MESSAGES = {
   mags1FirstName: {
+    required: 'Magistrates 1 first name is required',
     maxlength: 'First name must be 100 characters or fewer',
     pattern: 'First name contains invalid characters',
   },
@@ -121,6 +122,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'Last name contains invalid characters',
   },
   mags2FirstName: {
+    required: 'Magistrates 2 first name is required',
     maxlength: 'First name must be 100 characters or fewer',
     pattern: 'First name contains invalid characters',
   },
@@ -130,6 +132,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'Last name contains invalid characters',
   },
   mags3FirstName: {
+    required: 'Magistrates 3 first name is required',
     maxlength: 'First name must be 100 characters or fewer',
     pattern: 'First name contains invalid characters',
   },
@@ -139,6 +142,7 @@ export const OFFICIAL_FIELD_MESSAGES = {
     pattern: 'Last name contains invalid characters',
   },
   officialFirstName: {
+    required: "Official's first name is required",
     maxlength: 'First name must be 100 characters or fewer',
     pattern: 'First name contains invalid characters',
   },

--- a/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
+++ b/test/unit/app/pages/applications-list-detail/util/entry-detail.form.spec.ts
@@ -193,6 +193,35 @@ describe('applications-list entry form builders', () => {
       form.updateValueAndValidity();
       expect(form.controls.officialSurname.errors).toHaveProperty('required');
     });
+
+    it('requires first name when a magistrate or official surname is entered', () => {
+      const form = buildStandardApplicationForm(fb);
+
+      form.controls.mags1Surname.setValue('Smith');
+      form.updateValueAndValidity();
+      expect(form.controls.mags1FirstName.errors).toHaveProperty('required');
+
+      form.controls.mags1Surname.setValue(null);
+      form.controls.mags1FirstName.setErrors(null);
+
+      form.controls.mags2Surname.setValue('Jones');
+      form.updateValueAndValidity();
+      expect(form.controls.mags2FirstName.errors).toHaveProperty('required');
+
+      form.controls.mags2Surname.setValue(null);
+      form.controls.mags2FirstName.setErrors(null);
+
+      form.controls.mags3Surname.setValue('Taylor');
+      form.updateValueAndValidity();
+      expect(form.controls.mags3FirstName.errors).toHaveProperty('required');
+
+      form.controls.mags3Surname.setValue(null);
+      form.controls.mags3FirstName.setErrors(null);
+
+      form.controls.officialSurname.setValue('Brown');
+      form.updateValueAndValidity();
+      expect(form.controls.officialFirstName.errors).toHaveProperty('required');
+    });
   });
 
   describe('getRespondentEntryType', () => {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/ARCPOC-1539

### Change description

Validation for both mandatory fields (first name and last name) should occur consistently at the same stage in the workflow. Ideally, both validations should be performed on the Update Officials page before allowing navigation to the confirmation page.

The backend was updated in ARCPOC-1406 and the UI needed to be brought in line.

### Testing done

- Unit tests
- Integration tests

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change