### PR TITLE
ARCPOC-1564 Omit respondent from payload if no. of respondents exists

### DIFF
--- a/src/app/pages/applications-list-entry-create/util/entry-create-mapper.ts
+++ b/src/app/pages/applications-list-entry-create/util/entry-create-mapper.ts
@@ -22,6 +22,14 @@ import {
   RespondentPersonFormValue,
 } from '@shared-types/applications-list-entry-create/application-list-entry-form';
 
+type EntryCreateDtoWithRespondentClears = Omit<
+  EntryCreateDto,
+  'respondent' | 'numberOfRespondents'
+> & {
+  respondent?: Respondent | null;
+  numberOfRespondents?: number | null;
+};
+
 /**
  * Top-level builder: turns form values into an EntryCreateDto.
  */
@@ -32,14 +40,8 @@ export function buildEntryCreateDto(
   respondentPersonForm: RespondentPersonFormValue,
   respondentOrganisationForm: OrganisationFormValue,
 ): EntryCreateDto {
-  const dto: Partial<EntryCreateDto> = {
+  const dto: Partial<EntryCreateDtoWithRespondentClears> = {
     applicationCode: toOptionalTrimmed(formValue.applicationCode)!,
-    respondent: buildRespondent(
-      formValue,
-      respondentPersonForm,
-      respondentOrganisationForm,
-    ),
-    numberOfRespondents: toOptionalInteger(formValue.numberOfRespondents),
     wordingFields: buildWordingFields(formValue),
     feeStatuses: buildFeeStatuses(formValue),
     hasOffsiteFee: formValue.hasOffsiteFee ?? undefined,
@@ -60,7 +62,35 @@ export function buildEntryCreateDto(
   }
 
   pruneNullish(dto);
+  applyRespondentSelection(
+    dto,
+    formValue,
+    respondentPersonForm,
+    respondentOrganisationForm,
+  );
   return dto as EntryCreateDto;
+}
+
+function applyRespondentSelection(
+  dto: Partial<EntryCreateDtoWithRespondentClears>,
+  formValue: ApplicationsListEntryFormValue,
+  respondentPersonForm: RespondentPersonFormValue,
+  respondentOrganisationForm: OrganisationFormValue,
+): void {
+  if (formValue.respondentEntryType === 'bulk') {
+    dto.respondent = null;
+    dto.numberOfRespondents =
+      toOptionalInteger(formValue.numberOfRespondents) ?? null;
+    return;
+  }
+
+  dto.respondent =
+    buildRespondent(
+      formValue,
+      respondentPersonForm,
+      respondentOrganisationForm,
+    ) ?? null;
+  dto.numberOfRespondents = null;
 }
 
 function buildApplicant(

--- a/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
+++ b/src/app/pages/applications-list-entry-detail/util/entry-detail.form.ts
@@ -72,11 +72,16 @@ type MagSlot = {
 
 type EntryUpdateDtoWithClears = Omit<
   EntryUpdateDto,
-  'caseReference' | 'accountNumber' | 'notes' | 'numberOfRespondents'
+  | 'caseReference'
+  | 'accountNumber'
+  | 'notes'
+  | 'respondent'
+  | 'numberOfRespondents'
 > & {
   caseReference?: string | null;
   accountNumber?: string | null;
   notes?: string | null;
+  respondent?: Respondent | null;
   numberOfRespondents?: number | null;
 };
 
@@ -344,7 +349,14 @@ export function buildEntryUpdateDtoFromForm(
   dto.caseReference = trimToNull(formValue.applicationNotes.caseReference);
   dto.accountNumber = trimToNull(formValue.applicationNotes.accountReference);
   dto.notes = trimToNull(formValue.applicationNotes.notes);
-  dto.numberOfRespondents = toNullableInteger(formValue.numberOfRespondents);
+
+  if (formValue.respondentEntryType === 'bulk') {
+    dto.respondent = null;
+    dto.numberOfRespondents = toNullableInteger(formValue.numberOfRespondents);
+  } else {
+    dto.respondent = dto.respondent ?? null;
+    dto.numberOfRespondents = null;
+  }
 
   if (Array.isArray(formValue.wordingFields)) {
     dto.wordingFields = patch.wordingFields ?? [];

--- a/src/app/shared/components/respondent-section/respondent-section.component.ts
+++ b/src/app/shared/components/respondent-section/respondent-section.component.ts
@@ -88,7 +88,9 @@ export class RespondentSectionComponent {
         !this.bulkAllowed() &&
         this.form().controls.respondentEntryType.value === 'bulk'
       ) {
-        this.form().controls.respondentEntryType.setValue('person');
+        const form = this.form();
+        form.controls.numberOfRespondents.reset();
+        form.controls.respondentEntryType.setValue('person');
       }
     });
 

--- a/src/app/shared/services/applications-list-entry/application-list-entry-form.service.ts
+++ b/src/app/shared/services/applications-list-entry/application-list-entry-form.service.ts
@@ -313,14 +313,21 @@ export class ApplicationListEntryFormService {
     emitEvent: boolean,
   ): void {
     const r = dto.respondent;
+    const hasBulkRespondentCount =
+      Number.isFinite(dto.numberOfRespondents) && dto.numberOfRespondents > 0;
+    const respondentEntryType = hasBulkRespondentCount
+      ? 'bulk'
+      : (getRespondentEntryType(r) ?? 'person');
 
     forms.form.controls.respondent.setValue(r ?? null, { emitEvent });
-    forms.form.controls.respondentEntryType.setValue(
-      getRespondentEntryType(r) ?? 'person',
-      { emitEvent },
-    );
+    forms.form.controls.respondentEntryType.setValue(respondentEntryType, {
+      emitEvent,
+    });
 
-    if (r?.person) {
+    if (hasBulkRespondentCount) {
+      forms.respondentPersonForm.reset(undefined, { emitEvent });
+      forms.respondentOrganisationForm.reset(undefined, { emitEvent });
+    } else if (r?.person) {
       forms.respondentPersonForm.reset(undefined, { emitEvent });
       forms.respondentPersonForm.patchValue(
         respondentPersonToFormPatch(r.person),

--- a/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/applications-list-entry-create.component.spec.ts
@@ -332,7 +332,7 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     expect(component.vm().currentStandardApplicantSummary).toBeNull();
   });
 
-  it('payload: omits applicant/respondent when empty', () => {
+  it('payload: omits applicant and clears respondent fields when empty', () => {
     component.form.patchValue({
       applicationCode: 'A001',
       applicantType: 'org',
@@ -345,7 +345,8 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     const payload = roundTrip(dto as Record<string, unknown>);
     expect(payload['applicationCode']).toBe('A001');
     expect('applicant' in payload).toBe(false);
-    expect('respondent' in payload).toBe(false);
+    expect(payload['respondent']).toBeNull();
+    expect(payload['numberOfRespondents']).toBeNull();
   });
 
   it('payload: includes applicant.organisation with trimmed name; prunes blank nested fields', () => {
@@ -374,7 +375,7 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     expect('email' in contact).toBe(false);
   });
 
-  it('payload: omits respondent when only whitespace strings are provided', () => {
+  it('payload: clears respondent when only whitespace strings are provided', () => {
     component.form.patchValue({
       applicationCode: 'X001',
       respondentEntryType: 'organisation',
@@ -387,7 +388,8 @@ describe('ApplicationsListEntryCreate (payload + helpers)', () => {
     });
 
     const payload = roundTrip(build() as Record<string, unknown>);
-    expect('respondent' in payload).toBe(false);
+    expect(payload['respondent']).toBeNull();
+    expect(payload['numberOfRespondents']).toBeNull();
   });
 
   it('payload: keeps both applicant and respondent when both are meaningfully populated', () => {

--- a/test/unit/app/pages/applications-list-entry-create/util/entry-create-mapper.spec.ts
+++ b/test/unit/app/pages/applications-list-entry-create/util/entry-create-mapper.spec.ts
@@ -97,7 +97,7 @@ function makeBlankRespondentPerson(): RespondentPersonFormValue {
 }
 
 describe('buildEntryCreateDto', () => {
-  it('omits applicant/respondent when they are not meaningfully populated', () => {
+  it('omits applicant and clears empty respondent fields when they are not meaningfully populated', () => {
     const formValue = makeBaseFormValue({
       applicantType: 'org',
       respondentEntryType: 'organisation',
@@ -119,7 +119,8 @@ describe('buildEntryCreateDto', () => {
 
     expect(payload['applicationCode']).toBe('A001');
     expect('applicant' in payload).toBe(false);
-    expect('respondent' in payload).toBe(false);
+    expect(payload['respondent']).toBeNull();
+    expect(payload['numberOfRespondents']).toBeNull();
   });
 
   it('includes applicant.organisation with trimmed name and prunes blank nested contact fields', () => {
@@ -162,7 +163,7 @@ describe('buildEntryCreateDto', () => {
     expect('email' in contact).toBe(false);
   });
 
-  it('omits respondent when only whitespace strings are provided', () => {
+  it('clears respondent when only whitespace strings are provided', () => {
     const formValue = makeBaseFormValue({
       applicationCode: 'X001',
       respondentEntryType: 'organisation',
@@ -187,7 +188,8 @@ describe('buildEntryCreateDto', () => {
     );
     const payload = roundTrip(dto as unknown as Record<string, unknown>);
 
-    expect('respondent' in payload).toBe(false);
+    expect(payload['respondent']).toBeNull();
+    expect(payload['numberOfRespondents']).toBeNull();
   });
 
   it('keeps both applicant and respondent when both are populated', () => {
@@ -233,6 +235,66 @@ describe('buildEntryCreateDto', () => {
 
     expect(applicant['person']).toBeDefined();
     expect(resp['organisation']).toBeDefined();
+    expect(payload['numberOfRespondents']).toBeNull();
+  });
+
+  it('sends only bulk respondent values when bulk mode is selected', () => {
+    const formValue = makeBaseFormValue({
+      respondentEntryType: 'bulk',
+      numberOfRespondents: 2,
+    });
+
+    const respondentPerson: RespondentPersonFormValue = {
+      ...makeBlankRespondentPerson(),
+      firstName: 'Stale',
+      surname: 'Person',
+      addressLine1: 'Stale address',
+    };
+    const respondentOrganisation: OrganisationFormValue = {
+      ...makeBlankOrganisation(),
+      name: 'Stale Org',
+      addressLine1: 'Stale address',
+    };
+
+    const dto = buildEntryCreateDto(
+      formValue,
+      makeBlankPerson(),
+      makeBlankOrganisation(),
+      respondentPerson,
+      respondentOrganisation,
+    );
+
+    const payload = roundTrip(dto as unknown as Record<string, unknown>);
+
+    expect(payload['numberOfRespondents']).toBe(2);
+    expect(payload['respondent']).toBeNull();
+  });
+
+  it('clears numberOfRespondents when respondent details mode is selected', () => {
+    const formValue = makeBaseFormValue({
+      respondentEntryType: 'person',
+      numberOfRespondents: 2,
+    });
+    const respondentPerson: RespondentPersonFormValue = {
+      ...makeBlankRespondentPerson(),
+      firstName: 'Respondent',
+      surname: 'Person',
+      addressLine1: '1 Street',
+    };
+
+    const dto = buildEntryCreateDto(
+      formValue,
+      makeBlankPerson(),
+      makeBlankOrganisation(),
+      respondentPerson,
+      makeBlankOrganisation(),
+    );
+
+    const payload = roundTrip(dto as unknown as Record<string, unknown>);
+    const respondent = payload['respondent'] as Record<string, unknown>;
+
+    expect(respondent['person']).toBeDefined();
+    expect(payload['numberOfRespondents']).toBeNull();
   });
 
   it('builds feeStatuses when any fee field is provided', () => {
@@ -533,6 +595,7 @@ describe('buildEntryCreateDto', () => {
 
   it('maps numberOfRespondents via toOptionalInteger ("12" -> 12)', () => {
     const formValue = makeBaseFormValue({
+      respondentEntryType: 'bulk',
       numberOfRespondents:
         '12' as unknown as ApplicationsListEntryFormValue['numberOfRespondents'],
     });
@@ -549,9 +612,10 @@ describe('buildEntryCreateDto', () => {
     expect(payload['numberOfRespondents']).toBe(12);
   });
 
-  it('omits numberOfRespondents when blank or non-numeric', () => {
+  it('sets numberOfRespondents to null in bulk mode when blank or non-numeric', () => {
     const makePayload = (v: unknown): Record<string, unknown> => {
       const formValue = makeBaseFormValue({
+        respondentEntryType: 'bulk',
         numberOfRespondents:
           v as ApplicationsListEntryFormValue['numberOfRespondents'],
       });
@@ -567,8 +631,8 @@ describe('buildEntryCreateDto', () => {
       return roundTrip(dto as unknown as Record<string, unknown>);
     };
 
-    expect('numberOfRespondents' in makePayload('')).toBe(false);
-    expect('numberOfRespondents' in makePayload('   ')).toBe(false);
-    expect('numberOfRespondents' in makePayload('abc')).toBe(false);
+    expect(makePayload('')['numberOfRespondents']).toBeNull();
+    expect(makePayload('   ')['numberOfRespondents']).toBeNull();
+    expect(makePayload('abc')['numberOfRespondents']).toBeNull();
   });
 });

--- a/test/unit/app/shared/components/respondent-section/respondent-section.component.spec.ts
+++ b/test/unit/app/shared/components/respondent-section/respondent-section.component.spec.ts
@@ -189,17 +189,19 @@ describe('RespondentSectionComponent - bulkAllowed behaviour', () => {
     );
   });
 
-  it('effect resets respondentEntryType from bulk to person when bulk becomes disallowed', () => {
+  it('effect resets respondentEntryType and numberOfRespondents when bulk becomes disallowed', () => {
     fixture.componentRef.setInput('bulkAllowed', true);
     fixture.detectChanges();
 
     component.form().controls.respondentEntryType.setValue('bulk');
+    component.form().controls.numberOfRespondents.setValue(2);
     fixture.detectChanges();
 
     fixture.componentRef.setInput('bulkAllowed', false);
     fixture.detectChanges();
 
     expect(component.form().controls.respondentEntryType.value).toBe('person');
+    expect(component.form().controls.numberOfRespondents.value).toBeNull();
   });
 
   it('clears numberOfRespondents when switching from bulk to non-bulk respondent type', () => {

--- a/test/unit/app/shared/services/application-list-entry-form.service.spec.ts
+++ b/test/unit/app/shared/services/application-list-entry-form.service.spec.ts
@@ -18,7 +18,7 @@ describe('ApplicationListEntryFormService', () => {
     id: 'entry-1',
     listId: 'list-1',
     applicationCode: 'APP-100',
-    numberOfRespondents: 1,
+    numberOfRespondents: 0,
     lodgementDate: '2026-04-20',
     ...overrides,
   });
@@ -118,6 +118,44 @@ describe('ApplicationListEntryFormService', () => {
     );
 
     expect(forms.form.controls.respondentEntryType.value).toBe('person');
+    expect(forms.respondentPersonForm.getRawValue()).toMatchObject({
+      firstName: '',
+      surname: null,
+      dob: null,
+      addressLine1: '',
+    });
+    expect(forms.respondentOrganisationForm.getRawValue()).toMatchObject({
+      name: '',
+      addressLine1: '',
+    });
+    expect(forms.respondentPersonForm.dirty).toBe(false);
+    expect(forms.respondentOrganisationForm.dirty).toBe(false);
+  });
+
+  it('hydrates a positive numberOfRespondents as bulk respondent mode', () => {
+    const forms = service.createForms();
+
+    forms.form.controls.respondentEntryType.setValue('organisation');
+    forms.respondentPersonForm.patchValue({
+      firstName: 'Old',
+      surname: 'Respondent',
+      addressLine1: 'Old Address',
+    });
+    forms.respondentOrganisationForm.patchValue({
+      name: 'Old Org',
+      addressLine1: 'Old Org Address',
+    });
+
+    service.hydrateFromDto(
+      makeDetail({
+        respondent: null as unknown as EntryGetDetailDto['respondent'],
+        numberOfRespondents: 2,
+      }),
+      forms,
+    );
+
+    expect(forms.form.controls.respondentEntryType.value).toBe('bulk');
+    expect(forms.form.controls.numberOfRespondents.value).toBe(2);
     expect(forms.respondentPersonForm.getRawValue()).toMatchObject({
       firstName: '',
       surname: null,
@@ -410,7 +448,7 @@ describe('ApplicationListEntryFormService', () => {
       expect.objectContaining({
         standardApplicantCode: 'STD-99',
         applicationCode: 'APP-200',
-        numberOfRespondents: 2,
+        numberOfRespondents: null,
         caseReference: 'CASE123',
         accountNumber: 'ACCT123',
         notes: 'Updated notes',
@@ -426,6 +464,39 @@ describe('ApplicationListEntryFormService', () => {
     );
     expect(dto as Record<string, unknown>).not.toHaveProperty('lodgementDate');
     expect(dto.applicant).toBeUndefined();
+  });
+
+  it('buildUpdateDto clears respondent details when bulk mode is selected', () => {
+    const forms = service.createForms();
+    const detail = makeDetail({
+      respondent: {
+        person: {
+          name: {
+            firstName: 'Old',
+            lastName: 'Respondent',
+          },
+          contactDetails: {
+            addressLine1: 'Old Respondent Address',
+          },
+        },
+      },
+    });
+
+    forms.form.patchValue({
+      applicantType: 'standard',
+      applicationCode: 'APP-200',
+      numberOfRespondents: 2,
+      respondentEntryType: 'bulk',
+    });
+
+    const dto = service.buildUpdateDto(detail, forms, 'STD-99');
+
+    expect(dto).toEqual(
+      expect.objectContaining({
+        respondent: null,
+        numberOfRespondents: 2,
+      }),
+    );
   });
 
   it('buildCreateDto syncs selected standard applicant code and builds from all form sections', () => {
@@ -459,7 +530,7 @@ describe('ApplicationListEntryFormService', () => {
     expect(dto).toEqual(
       expect.objectContaining({
         applicationCode: 'APP-300',
-        numberOfRespondents: 3,
+        numberOfRespondents: null,
         lodgementDate: '2026-04-22',
         applicant: {
           person: expect.objectContaining({


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ARCPOC-1564

### Change description

- Enforces mutual exclusivity between respondent details and bulk respondent count when creating/updating application list entries.
- Sends `respondent: null` when bulk respondent mode is selected.
- Sends `numberOfRespondents: null` when person/organisation respondent details are selected.
- Hydrates existing entries with a positive `numberOfRespondents` as bulk respondent mode and pre-populates the bulk count.
- Clears stale respondent forms when loading an entry as bulk respondent mode.
- Resets bulk respondent count if bulk mode becomes disallowed.
- Adds/updates unit coverage for create/update payload mapping, edit hydration, and respondent section bulk-mode reset behaviour.

### Testing done
Manual and unit testing


<!--
List automated and/or manual testing performed.
Include enough detail to show changed lines were exercised.
For UI changes, include before/after screenshots where useful.
-->

### Security Vulnerability Assessment

<!--
If Yes below, include:
- CVE ID(s)
- Reason for suppression/ignoring
- Mitigations/compensating controls
-->

**CVE Suppression:** Are there any CVEs present in the codebase (new or pre-existing) that are intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ ] No

### Checklist

- [ ] commit messages are meaningful
- [ ] documentation has been updated (if needed)
- [ ] tests have been updated/added (if needed)
- [ ] this PR introduces a breaking change
