### PR TITLE
Fix Codex PR status failure handling

### DIFF
--- a/.github/workflows/codex_jira_dispatch.yml
+++ b/.github/workflows/codex_jira_dispatch.yml
@@ -1384,7 +1384,7 @@ jobs:
             exit 0
           fi
           set +e
-          {
+          (
             ./.github/scripts/codex-wait-pr-status.sh
             status=$?
             if [[ "$status" -eq 0 ]]; then
@@ -1392,7 +1392,7 @@ jobs:
               status=$?
             fi
             exit "$status"
-          } >"$RUNNER_TEMP/codex-pr-status.log" 2>&1
+          ) >"$RUNNER_TEMP/codex-pr-status.log" 2>&1
           status=$?
           cat "$RUNNER_TEMP/codex-pr-status.log"
           echo "failure_artifact=$STATUS_FAILURE_ARTIFACT" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
### Change description\n\nFixes the post-publication status wrapper so a failing Jenkins or Sonar check is captured as , uploaded as a diagnostic artifact, and routed into the existing Codex repair job.\n\nThe external commands now run in a subshell. Their exit status is returned to the trusted wrapper without terminating that wrapper before it writes the job outputs.\n\n### Testing done\n\n- Parsed the workflow as YAML.\n- Ran actionlint 1.7.12; only the repository's custom self-hosted runner label needed to be ignored.\n- Reproduced the failed-command path under Bash and verified that it records  while the wrapper exits successfully.\n\n### Security Vulnerability Assessment ###\n\n**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?\n- [ ] Yes\n- [x] No\n\n### Checklist\n\n- [x] commit messages are meaningful and follow good commit message guidelines\n- [x] README and other documentation has been updated / added (if needed)\n- [x] tests have been updated / new tests has been added (if needed)\n- [ ] Does this PR introduce a breaking change\n